### PR TITLE
Add config toggles for request validation and swagger spec validation

### DIFF
--- a/bravado_core/param.py
+++ b/bravado_core/param.py
@@ -106,7 +106,9 @@ def marshal_param(param, value, request):
     spec = get_param_type_spec(param)
     location = param.location
     value = marshal_schema_object(param.swagger_spec, spec, value)
-    validate_schema_object(spec, value)
+
+    if param.swagger_spec.config['validate_requests']:
+        validate_schema_object(spec, value)
 
     if spec['type'] == 'array' and location != 'body':
         value = marshal_collection_format(spec, value)
@@ -167,7 +169,9 @@ def unmarshal_param(param, request):
     if param_spec['type'] == 'array' and location != 'body':
         raw_value = unmarshal_collection_format(param_spec, raw_value)
 
-    validate_schema_object(param_spec, raw_value)
+    if param.swagger_spec.config['validate_requests']:
+        validate_schema_object(param_spec, raw_value)
+
     value = unmarshal_schema_object(param.swagger_spec, param_spec, raw_value)
     return value
 

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -17,6 +17,10 @@ CONFIG_DEFAULTS = {
     # On the client side, validate incoming responses
     # On the server side, validate outgoing responses
     'validate_responses': True,
+
+    # On the client side, validate outgoing requests
+    # On the server side, validate incoming requests
+    'validate_requests': True,
 }
 
 
@@ -115,6 +119,9 @@ def build_api_serving_url(spec_dict, origin_url, preferred_scheme=None):
         supported by the API.
     :return: base url which services api requests
     """
+    if origin_url is None:
+        return ''
+
     origin = urlparse.urlparse(origin_url)
 
     def pick_a_scheme(schemes):

--- a/tests/spec/Spec/__init__.py
+++ b/tests/spec/Spec/__init__.py
@@ -1,1 +1,0 @@
-__author__ = 'spatel'

--- a/tests/spec/Spec/__init__.py
+++ b/tests/spec/Spec/__init__.py
@@ -1,0 +1,1 @@
+__author__ = 'spatel'

--- a/tests/spec/Spec/build_test.py
+++ b/tests/spec/Spec/build_test.py
@@ -1,0 +1,20 @@
+from mock import patch
+
+from bravado_core.spec import Spec
+
+
+def assert_validate_call_count(expected_call_count, config, petstore_dict):
+    spec = Spec(petstore_dict, config=config)
+    with patch('bravado_core.spec.validator20.validate_spec') as m_validate:
+        spec.build()
+    assert expected_call_count == m_validate.call_count
+
+
+def test_validate_swagger_spec(petstore_dict):
+    assert_validate_call_count(
+        1, {'validate_swagger_spec': True}, petstore_dict)
+
+
+def test_dont_validate_swagger_spec(petstore_dict):
+    assert_validate_call_count(
+        0, {'validate_swagger_spec': False}, petstore_dict)

--- a/tests/spec/__init__.py
+++ b/tests/spec/__init__.py
@@ -1,1 +1,0 @@
-__author__ = 'spatel'

--- a/tests/spec/build_api_serving_url_test.py
+++ b/tests/spec/build_api_serving_url_test.py
@@ -49,3 +49,7 @@ def test_preferred_scheme_not_available(origin_url):
     with pytest.raises(Exception) as excinfo:
         build_api_serving_url(spec, origin_url, preferred_scheme='ws')
     assert 'not supported' in str(excinfo.value)
+
+
+def test_origin_url_None():
+    assert 'http://localhost/' == build_api_serving_url({})


### PR DESCRIPTION
Pretty self explanatory. Adding to support toggles in pyramid-swagger.