### PR TITLE
Refactor exception hierarchy

### DIFF
--- a/bravado_core/docstring.py
+++ b/bravado_core/docstring.py
@@ -185,6 +185,5 @@ def formatted_type(spec):
         return ref
     elif obj_type:
         return obj_type
-    else:
-        raise SwaggerMappingError(
-            "No proper type could be found from {0}".format(spec))
+    raise SwaggerMappingError(
+        "No proper type could be found from {0}".format(spec))

--- a/bravado_core/exception.py
+++ b/bravado_core/exception.py
@@ -1,5 +1,14 @@
-class SwaggerMappingError(Exception):
-    """Raised when an error is encountered."""
+class SwaggerError(Exception):
+    """Base exception class which all bravado-core specific exceptions
+    inherit from.
+    """
+    pass
+
+
+class SwaggerMappingError(SwaggerError):
+    """Raised when an error is encountered during processing of a request or
+    a response.
+    """
 
     def __init__(self, msg, cause=None):
         """
@@ -7,3 +16,9 @@ class SwaggerMappingError(Exception):
         :param cause: Optional exception that caused this one.
         """
         super(Exception, self).__init__(msg, cause)
+
+
+class SwaggerSchemaError(SwaggerError):
+    """Raised when an error is encountered during processing of a SwaggerSchema.
+    """
+    pass

--- a/bravado_core/marshal.py
+++ b/bravado_core/marshal.py
@@ -22,6 +22,7 @@ def marshal_schema_object(swagger_spec, schema_object_spec, value):
     :type value: int, long, string, unicode, boolean, list, dict, Model type
     :return: marshaled value
     :rtype: int, long, string, unicode, boolean, list, dict
+    :raises: SwaggerMappingError
     """
     obj_type = schema_object_spec['type']
 
@@ -59,7 +60,7 @@ def marshal_primitive(spec, value):
     :type value: int, long, float, boolean, string, unicode, or an object
         based on 'format'
     :rtype: int, long, float, boolean, string, unicode, etc
-    :raises: TypeError
+    :raises: SwaggerMappingError
     """
     default_used = False
 
@@ -68,7 +69,7 @@ def marshal_primitive(spec, value):
         value = schema.get_default(spec)
 
     if value is None and schema.is_required(spec):
-        raise TypeError('Spec {0} is a required value'.format(spec))
+        raise SwaggerMappingError('Spec {0} is a required value'.format(spec))
 
     if not default_used:
         value = formatter.to_wire(spec, value)
@@ -83,10 +84,10 @@ def marshal_array(swagger_spec, array_spec, array_value):
     :type array_spec: dict or jsonref.JsonRef
     :type array_value: list
     :rtype: list
-    :raises: TypeError
+    :raises: SwaggerMappingError
     """
     if not is_list_like(array_value):
-        raise TypeError('Expected list like type for {0}:{1}'.format(
+        raise SwaggerMappingError('Expected list like type for {0}:{1}'.format(
             type(array_value), array_value))
 
     result = []
@@ -107,7 +108,7 @@ def marshal_object(swagger_spec, object_spec, object_value):
     :raises: SwaggerMappingError
     """
     if not is_dict_like(object_value):
-        raise TypeError('Expected dict like type for {0}:{1}'.format(
+        raise SwaggerMappingError('Expected dict like type for {0}:{1}'.format(
             type(object_value), object_value))
 
     result = {}
@@ -134,17 +135,18 @@ def marshal_model(swagger_spec, model_spec, model_value):
     :type model_spec: dict or jsonref.JsonRef
     :type model_value: Model instance
     :rtype: dict
-    :raises: TypeError
+    :raises: SwaggerMappingError
     """
     model_name = model_spec[MODEL_MARKER]
     model_type = swagger_spec.definitions.get(model_name, None)
 
     if model_type is None:
-        raise TypeError('Unknown model {0}'.format(model_name))
+        raise SwaggerMappingError('Unknown model {0}'.format(model_name))
 
     if not isinstance(model_value, model_type):
-        raise TypeError('Expected model of type {0} for {1}:{2}'.format(
-            model_name, type(model_value), model_value))
+        raise SwaggerMappingError(
+            'Expected model of type {0} for {1}:{2}'
+            .format(model_name, type(model_value), model_value))
 
     # just convert the model to a dict and feed into `marshal_object` because
     # models are essentially 'type':'object' when marshaled

--- a/bravado_core/operation.py
+++ b/bravado_core/operation.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
-#
-# Copyright (c) 2015, Yelp, Inc.
-#
 import logging
 
+from bravado_core.exception import SwaggerMappingError
 from bravado_core.param import Param, marshal_param
 from bravado_core.response import unmarshal_response
 
@@ -142,21 +140,22 @@ class Operation(object):
 
         :type request: dict
         :param op_kwargs: the kwargs passed to the operation invocation
-        :raises: TypeError on extra parameters or when a required parameter
-            is not supplied.
+        :raises: SwaggerMappingError on extra parameters or when a required
+            parameter is not supplied.
         """
         current_params = self.params.copy()
         for param_name, param_value in op_kwargs.iteritems():
             param = current_params.pop(param_name, None)
             if param is None:
-                raise TypeError("{0} does not have parameter {1}".format(
-                    self.operation_id, param_name))
+                raise SwaggerMappingError(
+                    "{0} does not have parameter {1}"
+                    .format(self.operation_id, param_name))
             marshal_param(param, param_value, request)
 
         # Check required params and non-required params with a 'default' value
         for remaining_param in current_params.itervalues():
             if remaining_param.required:
-                raise TypeError(
+                raise SwaggerMappingError(
                     '{0} is a required parameter'.format(remaining_param.name))
             if not remaining_param.required and remaining_param.has_default():
                 marshal_param(remaining_param, None, request)

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -4,6 +4,7 @@ import urlparse
 
 import jsonref
 from swagger_spec_validator import validator20
+from bravado_core.exception import SwaggerSchemaError
 
 from bravado_core.model import build_models
 from bravado_core.model import tag_models
@@ -153,6 +154,7 @@ def build_api_serving_url(spec_dict, origin_url=None, preferred_scheme=None):
     :param preferred_scheme: preferred scheme to use if more than one scheme is
         supported by the API.
     :return: base url which services api requests
+    :raises: SwaggerSchemaError
     """
     origin_url = origin_url or 'http://localhost/'
     origin = urlparse.urlparse(origin_url)
@@ -164,7 +166,7 @@ def build_api_serving_url(spec_dict, origin_url=None, preferred_scheme=None):
         if preferred_scheme:
             if preferred_scheme in schemes:
                 return preferred_scheme
-            raise Exception(
+            raise SwaggerSchemaError(
                 "Preferred scheme {0} not supported by API. Available schemes "
                 "include {1}".format(preferred_scheme, schemes))
 
@@ -174,7 +176,7 @@ def build_api_serving_url(spec_dict, origin_url=None, preferred_scheme=None):
         if len(schemes) == 1:
             return schemes[0]
 
-        raise Exception(
+        raise SwaggerSchemaError(
             "Origin scheme {0} not supported by API. Available schemes "
             "include {1}".format(origin.scheme, schemes))
 

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -58,13 +58,14 @@ def unmarshal_primitive(spec, value):
     :type value: int, long, float, boolean, string, unicode, etc
     :rtype: int, long, float, boolean, string, unicode, or an object
         based on 'format'
-    :raises: TypeError
+    :raises: SwaggerMappingError
     """
     if value is None and schema.is_required(spec):
         # TODO: Error message needs more context. Consider adding a stack like
         #       `context` object to each `unmarshal_*` method that acts like
         #       breadcrumbs.
-        raise TypeError('Spec {0} says this is a required value'.format(spec))
+        raise SwaggerMappingError(
+            'Spec {0} says this is a required value'.format(spec))
 
     value = formatter.to_python(spec, value)
     return value
@@ -77,10 +78,10 @@ def unmarshal_array(swagger_spec, array_spec, array_value):
     :type array_spec: dict or jsonref.JsonRef
     :type array_value: list
     :rtype: list
-    :raises: TypeError
+    :raises: SwaggerMappingError
     """
     if not is_list_like(array_value):
-        raise TypeError('Expected list like type for {0}:{1}'.format(
+        raise SwaggerMappingError('Expected list like type for {0}:{1}'.format(
             type(array_value), array_value))
 
     result = []
@@ -97,10 +98,10 @@ def unmarshal_object(swagger_spec, object_spec, object_value):
     :type object_spec: dict or jsonref.JsonRef
     :type object_value: dict
     :rtype: dict
-    :raises: TypeError
+    :raises: SwaggerMappingError
     """
     if not is_dict_like(object_value):
-        raise TypeError('Expected dict like type for {0}:{1}'.format(
+        raise SwaggerMappingError('Expected dict like type for {0}:{1}'.format(
             type(object_value), object_value))
 
     result = {}
@@ -126,18 +127,18 @@ def unmarshal_model(swagger_spec, model_spec, model_value):
     :type model_spec: dict or jsonref.JsonRef
     :type model_value: dict
     :rtype: Model instance
-    :raises: TypeError
+    :raises: SwaggerMappingError
     """
     model_name = model_spec[MODEL_MARKER]
     model_type = swagger_spec.definitions.get(model_name, None)
 
     if model_type is None:
-        raise TypeError(
+        raise SwaggerMappingError(
             'Unknown model {0} when trying to unmarshal {1}'
             .format(model_name, model_value))
 
     if not is_dict_like(model_value):
-        raise TypeError(
+        raise SwaggerMappingError(
             "Expected type to be dict for value {0} to unmarshal to a {1}."
             "Was {1} instead."
             .format(model_value, model_type, type(model_value)))

--- a/tests/marshal/marshal_array_test.py
+++ b/tests/marshal/marshal_array_test.py
@@ -1,6 +1,7 @@
 import copy
 
 import pytest
+from bravado_core.exception import SwaggerMappingError
 
 from bravado_core.marshal import marshal_array
 from bravado_core.spec import Spec
@@ -154,6 +155,6 @@ def test_array_of_models(petstore_dict):
 
 def test_non_list_like_type_throws_error(empty_swagger_spec):
     i_am_not_a_list = dict()
-    with pytest.raises(TypeError) as excinfo:
+    with pytest.raises(SwaggerMappingError) as excinfo:
         marshal_array(empty_swagger_spec, i_am_not_a_list, i_am_not_a_list)
     assert 'Expected list like type' in str(excinfo.value)

--- a/tests/marshal/marshal_model_test.py
+++ b/tests/marshal/marshal_model_test.py
@@ -1,5 +1,6 @@
 import pytest
 
+from bravado_core.exception import SwaggerMappingError
 from bravado_core.marshal import marshal_model
 from bravado_core.spec import Spec
 
@@ -76,9 +77,9 @@ def test_attrs_set_to_None_are_absent_from_result(petstore_dict):
     assert expected == result
 
 
-def test_value_is_not_dict_like_raises_TypeError(petstore_dict):
+def test_value_is_not_dict_like_raises_error(petstore_dict):
     petstore_spec = Spec.from_dict(petstore_dict)
     pet_spec = petstore_spec.spec_dict['definitions']['Pet']
-    with pytest.raises(TypeError) as excinfo:
+    with pytest.raises(SwaggerMappingError) as excinfo:
         marshal_model(petstore_spec, pet_spec, 'i am not a dict')
     assert 'Expected model of type' in str(excinfo.value)

--- a/tests/marshal/marshal_object_test.py
+++ b/tests/marshal/marshal_object_test.py
@@ -1,5 +1,6 @@
 import pytest
 
+from bravado_core.exception import SwaggerMappingError
 from bravado_core.marshal import marshal_object
 from bravado_core.spec import Spec
 
@@ -126,10 +127,10 @@ def test_model(minimal_swagger_dict, address_spec):
     assert expected_address == result
 
 
-def test_object_not_dict_like_raises_TypeError(
+def test_object_not_dict_like_raises_error(
         empty_swagger_spec, address_spec):
     i_am_not_dict_like = 34
-    with pytest.raises(TypeError) as excinfo:
+    with pytest.raises(SwaggerMappingError) as excinfo:
         marshal_object(empty_swagger_spec, address_spec, i_am_not_dict_like)
     assert 'Expected dict' in str(excinfo.value)
 

--- a/tests/marshal/marshal_primitive_test.py
+++ b/tests/marshal/marshal_primitive_test.py
@@ -1,5 +1,6 @@
 import mock
 import pytest
+from bravado_core.exception import SwaggerMappingError
 
 from bravado_core.marshal import marshal_primitive
 
@@ -44,6 +45,6 @@ def test_required_failure():
         'type': 'integer',
         'required': True,
     }
-    with pytest.raises(TypeError) as excinfo:
+    with pytest.raises(SwaggerMappingError) as excinfo:
         marshal_primitive(integer_spec, None)
     assert 'is a required value' in str(excinfo.value)

--- a/tests/operation/construct_params_test.py
+++ b/tests/operation/construct_params_test.py
@@ -1,6 +1,7 @@
 from mock import patch
 import pytest
 
+from bravado_core.exception import SwaggerMappingError
 from bravado_core.operation import Operation
 from bravado_core.spec import Spec
 
@@ -54,7 +55,7 @@ def test_no_params(minimal_swagger_spec, request_dict):
 
 def test_extra_parameter_error(minimal_swagger_spec, request_dict):
     op = Operation.from_spec(minimal_swagger_spec, '/pet/{petId}', 'get', {})
-    with pytest.raises(TypeError) as excinfo:
+    with pytest.raises(SwaggerMappingError) as excinfo:
         op.construct_params(request_dict, op_kwargs={'extra_param': 'bar'})
     assert 'does not have parameter' in str(excinfo.value)
 
@@ -64,7 +65,7 @@ def test_required_parameter_missing(
     request_dict['url'] = '/pet/{petId}'
     op = Operation.from_spec(
         minimal_swagger_spec, '/pet/{petId}', 'get', getPetById_spec)
-    with pytest.raises(TypeError) as excinfo:
+    with pytest.raises(SwaggerMappingError) as excinfo:
         op.construct_params(request_dict, op_kwargs={})
     assert 'required parameter' in str(excinfo.value)
 

--- a/tests/spec/build_api_serving_url_test.py
+++ b/tests/spec/build_api_serving_url_test.py
@@ -1,6 +1,7 @@
 import pytest
 
 from bravado_core.spec import build_api_serving_url
+from bravado_core.exception import SwaggerSchemaError
 
 
 @pytest.fixture
@@ -46,7 +47,7 @@ def test_pick_origin_scheme_when_preferred_scheme_none(origin_url):
 
 def test_preferred_scheme_not_available(origin_url):
     spec = {'schemes': ['https']}
-    with pytest.raises(Exception) as excinfo:
+    with pytest.raises(SwaggerSchemaError) as excinfo:
         build_api_serving_url(spec, origin_url, preferred_scheme='ws')
     assert 'not supported' in str(excinfo.value)
 

--- a/tests/unmarshal/unmarshal_array_test.py
+++ b/tests/unmarshal/unmarshal_array_test.py
@@ -1,29 +1,36 @@
 import copy
 
+import pytest
+
+from bravado_core.exception import SwaggerMappingError
 from bravado_core.unmarshal import unmarshal_array
 from bravado_core.spec import Spec
 
 
-def test_primitive_array(empty_swagger_spec):
-    int_array_spec = {
+@pytest.fixture
+def int_array_spec():
+    return {
         'type': 'array',
         'items': {
             'type': 'integer',
         }
     }
+
+
+def test_primitive_array(empty_swagger_spec, int_array_spec):
     result = unmarshal_array(empty_swagger_spec, int_array_spec, [1, 2, 3])
     assert [1, 2, 3] == result
 
 
-def test_empty_array(empty_swagger_spec):
-    int_array_spec = {
-        'type': 'array',
-        'items': {
-            'type': 'integer',
-        }
-    }
+def test_empty_array(empty_swagger_spec, int_array_spec):
     result = unmarshal_array(empty_swagger_spec, int_array_spec, [])
     assert [] == result
+
+
+def test_type_not_array_raises_error(empty_swagger_spec, int_array_spec):
+    with pytest.raises(SwaggerMappingError) as excinfo:
+        unmarshal_array(empty_swagger_spec, int_array_spec, 'not a list')
+    assert 'Expected list like type' in str(excinfo.value)
 
 
 def test_array_of_array(empty_swagger_spec):

--- a/tests/unmarshal/unmarshal_model_test.py
+++ b/tests/unmarshal/unmarshal_model_test.py
@@ -1,4 +1,5 @@
 import pytest
+from bravado_core.exception import SwaggerMappingError
 
 from bravado_core.unmarshal import unmarshal_model
 from bravado_core.spec import Spec
@@ -98,9 +99,9 @@ def test_Nones_are_reintroduced_for_declared_properties_that_are_not_present(
     assert 'brown' == pet.tags[1].name
 
 
-def test_value_is_not_dict_like_raises_TypeError(petstore_dict):
+def test_value_is_not_dict_like_raises_error(petstore_dict):
     petstore_spec = Spec.from_dict(petstore_dict)
     pet_spec = petstore_spec.spec_dict['definitions']['Pet']
-    with pytest.raises(TypeError) as excinfo:
+    with pytest.raises(SwaggerMappingError) as excinfo:
         unmarshal_model(petstore_spec, pet_spec, 'i am not a dict')
     assert 'Expected type to be dict' in str(excinfo.value)

--- a/tests/unmarshal/unmarshal_object_test.py
+++ b/tests/unmarshal/unmarshal_object_test.py
@@ -1,5 +1,6 @@
 import pytest
 
+from bravado_core.exception import SwaggerMappingError
 from bravado_core.unmarshal import unmarshal_object
 from bravado_core.spec import Spec
 
@@ -131,10 +132,9 @@ def test_model(minimal_swagger_dict, address_spec):
     assert expected_address == address
 
 
-def test_object_not_dict_like_raises_TypeError(
-        empty_swagger_spec, address_spec):
+def test_object_not_dict_like_raises_error(empty_swagger_spec, address_spec):
     i_am_not_dict_like = 34
-    with pytest.raises(TypeError) as excinfo:
+    with pytest.raises(SwaggerMappingError) as excinfo:
         unmarshal_object(empty_swagger_spec, address_spec, i_am_not_dict_like)
     assert 'Expected dict' in str(excinfo.value)
 

--- a/tests/unmarshal/unmarshal_primitive_test.py
+++ b/tests/unmarshal/unmarshal_primitive_test.py
@@ -1,5 +1,6 @@
 import pytest
 
+from bravado_core.exception import SwaggerMappingError
 from bravado_core.unmarshal import unmarshal_primitive
 
 
@@ -23,6 +24,6 @@ def test_required_failure():
         'type': 'integer',
         'required': True,
     }
-    with pytest.raises(TypeError) as excinfo:
+    with pytest.raises(SwaggerMappingError) as excinfo:
         unmarshal_primitive(integer_spec, None)
     assert 'is a required value' in str(excinfo.value)


### PR DESCRIPTION
Fix for #19 

Base exception class is SwaggerError.
- SwaggerMappingError thrown when processing requests/responses
- SwaggerSchemaError thrown when processing the schema

I'll have follow up PRs for bravado and pyramid-swagger based on the change in the exception interface.