### PR TITLE
Fix file uploads when marshaling a request; Bump to 1.0.0-rc2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,9 @@
-1.0.0-rc1 (2015-XX-XX)
-------------------
+1.0.0-rc2 (2015-05-27)
+----------------------
+- Fixed file uploads when marshaling a request
+
+1.0.0-rc1 (2015-05-26)
+----------------------
 - Use basePath when matching an operation to a request
 - Refactored exception hierarchy
 - Added use_models config option

--- a/bravado_core/__init__.py
+++ b/bravado_core/__init__.py
@@ -1,1 +1,1 @@
-version = "1.0.0-rc1"
+version = "1.0.0-rc2"

--- a/bravado_core/param.py
+++ b/bravado_core/param.py
@@ -233,7 +233,7 @@ def add_file(param, value, request):
                     param.op.consumes
                 ))
 
-    file_tuple = ('file', (param.name, value))
+    file_tuple = (param.name, (param.name, value))
     request['files'].append(file_tuple)
 
 

--- a/tests/param/add_file_test.py
+++ b/tests/param/add_file_test.py
@@ -18,7 +18,7 @@ def test_single_file(empty_swagger_spec):
     param = Param(empty_swagger_spec, op, param_spec)
     add_file(param, file_contents, request)
     expected_request = {
-        'files': [('file', ('photo', 'I am the contents of a file'))]
+        'files': [('photo', ('photo', 'I am the contents of a file'))]
     }
     assert expected_request == request
 
@@ -45,8 +45,8 @@ def test_multiple_files(empty_swagger_spec):
     add_file(param2, file2_contents, request)
     expected_request = {
         'files': [
-            ('file', ('photo', 'I am the contents of a file1')),
-            ('file', ('headshot', 'I am the contents of a file2')),
+            ('photo', ('photo', 'I am the contents of a file1')),
+            ('headshot', ('headshot', 'I am the contents of a file2')),
         ]
     }
     assert expected_request == request

--- a/tests/param/marshal_param_test.py
+++ b/tests/param/marshal_param_test.py
@@ -124,7 +124,7 @@ def test_formData_file(empty_swagger_spec, param_spec, request_dict):
     marshal_param(param, "i am the contents of a file", request_dict)
     expected = {
         'params': {},
-        'files': [('file', ('petId', "i am the contents of a file"))],
+        'files': [('petId', ('petId', "i am the contents of a file"))],
     }
     assert expected == request_dict
 


### PR DESCRIPTION
This was a fun one to track down...

File uploads with curl on the client side and pyramid-swagger using Swagger 2.0 on the server side worked wonderfully. However, when using the bravado Swagger 2.0 client, I would get HTTP 500s as a response.

Working cURL dump of the form data for the file upload:
```
Content-Type: multipart/form-data; boundary=----------------------------e07d5bf53061
Content-Disposition: form-data; name="photo_file"; filename="test.jpg" Content-Type: image/jpeg JFIF...
```
Broken bravado dump:
```
Content-Type: multipart/form-data; boundary=-----------------------6e1996f15f14b6ab0ada267478ea560\r\n
Content-Disposition: form-data; name="file"; filename="photo_file"\r\n\r\n
\xff\xd8\xff\xe0\x00\x10JFIF...
```

"name" was incorrectly set to "file" instead of the name of the parameter thus causing:
```
Traceback (most recent call last):
  File "/code/virtualenv_run/lib/python2.6/site-packages/pyramid_exclog/__init__.py", line 111, in exclog_tween
    return handler(request)
  File "/code/virtualenv_run/lib/python2.6/site-packages/pyramid_swagger/tween.py", line 137, in validator_tween
    response = handler(request)
  File "/code/virtualenv_run/lib/python2.6/site-packages/pyramid_yelp_conn/session.py", line 88, in session_tween
    if commit_veto(request, response, exc_info):
  File "/code/virtualenv_run/lib/python2.6/site-packages/pyramid_yelp_conn/session.py", line 85, in session_tween
    response = handler(request)
  File "/code/virtualenv_run/lib/python2.6/site-packages/pyramid/router.py", line 163, in handle_request
    response = view_callable(context, request)
  File "/code/virtualenv_run/lib/python2.6/site-packages/pyramid/config/views.py", line 596, in __call__
    return view(context, request)
  File "/code/virtualenv_run/lib/python2.6/site-packages/pyramid/config/views.py", line 329, in attr_view
    return view(context, request)
  File "/code/virtualenv_run/lib/python2.6/site-packages/pyramid/config/views.py", line 305, in predicate_wrapper
    return view(context, request)
  File <redacted>:
    return view(*args)
  File "/code/virtualenv_run/lib/python2.6/site-packages/pyramid/config/views.py", line 355, in rendered_view
    result = view(context, request)
  File "/code/virtualenv_run/lib/python2.6/site-packages/pyramid/config/views.py", line 501, in _requestonly_view
    response = view(request)
  File <redacted>
    photo_file = request.POST['photo_file']
  File "/code/virtualenv_run/lib/python2.6/site-packages/webob/multidict.py", line 99, in __getitem__
    raise KeyError(key)
KeyError: 'photo_file'
```