### PR TITLE
Fix model __repr__ wrt unicode attr values

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+1.0.0-rc2 (2015-XX-XX)
+------------------
+- Fixed repr of a model when it has an attr with a unicode value
+
 1.0.0-rc1 (2015-XX-XX)
 ------------------
 - Use basePath when matching an operation to a request

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -133,7 +133,7 @@ def create_model_repr(model, model_spec):
     :returns: repr string for the model
     """
     s = [
-        "{0}={1}".format(attr_name, getattr(model, attr_name))
+        "{0}={1}".format(attr_name, repr(getattr(model, attr_name)))
         for attr_name in sorted(model_spec['properties'].keys())
     ]
     return "{0}({1})".format(model.__class__.__name__, ', '.join(s))

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -133,7 +133,7 @@ def create_model_repr(model, model_spec):
     :returns: repr string for the model
     """
     s = [
-        "{0}={1}".format(attr_name, repr(getattr(model, attr_name)))
+        "{0}={1!r}".format(attr_name, getattr(model, attr_name))
         for attr_name in sorted(model_spec['properties'].keys())
     ]
     return "{0}({1})".format(model.__class__.__name__, ', '.join(s))

--- a/tests/model/create_model_repr_test.py
+++ b/tests/model/create_model_repr_test.py
@@ -1,6 +1,13 @@
+# -*- coding: utf-8 -*-
 from bravado_core.model import create_model_repr
 
 
 def test_success(user, user_spec):
     expected = "User(email=None, firstName=None, id=None, lastName=None, password=None, phone=None, userStatus=None, username=None)"  # noqa
+    assert expected == create_model_repr(user, user_spec)
+
+
+def test_unicode(user, user_spec):
+    user.firstName = 'Ümlaut'
+    expected = r"User(email=None, firstName='\xc3\x9cmlaut', id=None, lastName=None, password=None, phone=None, userStatus=None, username=None)"  # noqa
     assert expected == create_model_repr(user, user_spec)

--- a/tests/model/create_model_type_test.py
+++ b/tests/model/create_model_type_test.py
@@ -13,7 +13,7 @@ def test_pet_model(pet_spec):
     assert set(dir(pet)) == expected
     assert pet == Pet(id=1, name='Darwin')
     assert pet != Pet(id=2, name='Fido')
-    assert "Pet(category=None, id=1, name=Darwin, photoUrls=None, tags=None)" \
+    assert "Pet(category=None, id=1, name='Darwin', photoUrls=None, tags=None)" \
            == repr(pet)
 
 


### PR DESCRIPTION
Fixes errors like this when printing a model type:

```
Traceback (most recent call last):
  File "test20.py", line 43, in <module>
    print svc.media.getPhotos(business_id=1, photo_ids='1,2,3').result()
  File "/nail/home/spatel/git/bravado-core-analogue/bravado_core/model.py", line 51, in <lambda>
    __repr__=lambda self: create_model_repr(self, model_spec),
  File "/nail/home/spatel/git/bravado-core-analogue/bravado_core/model.py", line 138, in create_model_repr
    for attr_name in sorted(model_spec['properties'].keys())
  File "/nail/home/spatel/git/bravado-core-analogue/bravado_core/model.py", line 51, in <lambda>
    __repr__=lambda self: create_model_repr(self, model_spec),
  File "/nail/home/spatel/git/bravado-core-analogue/bravado_core/model.py", line 138, in create_model_repr
    for attr_name in sorted(model_spec['properties'].keys())
UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-5: ordinal not in range(128)
```