### PR TITLE
More unicode tests

### DIFF
--- a/tests/marshal/marshal_object_test.py
+++ b/tests/marshal/marshal_object_test.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import pytest
 
 from bravado_core.exception import SwaggerMappingError
@@ -31,7 +32,7 @@ def address_spec():
 def address():
     return {
         'number': 1600,
-        'street_name': 'Pennsylvania',
+        'street_name': u'Ümlaut',
         'street_type': 'Avenue'
     }
 
@@ -139,7 +140,7 @@ def test_missing_properties_not_marshaled(
         empty_swagger_spec, address_spec, address):
     del address['number']
     expected_address = {
-        'street_name': 'Pennsylvania',
+        'street_name': u'Ümlaut',
         'street_type': 'Avenue'
     }
     result = marshal_object(empty_swagger_spec, address_spec, address)
@@ -150,7 +151,7 @@ def test_property_set_to_None_not_marshaled(
         empty_swagger_spec, address_spec, address):
     address['number'] = None
     expected_address = {
-        'street_name': 'Pennsylvania',
+        'street_name': u'Ümlaut',
         'street_type': 'Avenue'
     }
     result = marshal_object(empty_swagger_spec, address_spec, address)
@@ -163,7 +164,7 @@ def test_pass_through_additionalProperties_with_no_spec(
     address['city'] = 'Swaggerville'
     expected_address = {
         'number': 1600,
-        'street_name': 'Pennsylvania',
+        'street_name': u'Ümlaut',
         'street_type': 'Avenue',
         'city': 'Swaggerville',
     }

--- a/tests/marshal/marshal_primitive_test.py
+++ b/tests/marshal/marshal_primitive_test.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import mock
 import pytest
 from bravado_core.exception import SwaggerMappingError
@@ -5,11 +6,19 @@ from bravado_core.exception import SwaggerMappingError
 from bravado_core.marshal import marshal_primitive
 
 
-def test_success():
+def test_integer():
     integer_spec = {
         'type': 'integer'
     }
     assert 10 == marshal_primitive(integer_spec, 10)
+
+
+def test_string():
+    string_spec = {
+        'type': 'string'
+    }
+    assert 'foo' == marshal_primitive(string_spec, 'foo')
+    assert u'Ümlaut' == marshal_primitive(string_spec, u'Ümlaut')
 
 
 @mock.patch('bravado_core.marshal.formatter.to_wire')

--- a/tests/unmarshal/unmarshal_object_test.py
+++ b/tests/unmarshal/unmarshal_object_test.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import pytest
 
 from bravado_core.exception import SwaggerMappingError
@@ -31,7 +32,7 @@ def address_spec():
 def address():
     return {
         'number': 1600,
-        'street_name': 'Pennsylvania',
+        'street_name': u'Ümlaut',
         'street_type': 'Avenue'
     }
 
@@ -39,7 +40,7 @@ def address():
 def test_properties(empty_swagger_spec, address_spec, address):
     expected_address = {
         'number': 1600,
-        'street_name': 'Pennsylvania',
+        'street_name': u'Ümlaut',
         'street_type': 'Avenue'
     }
     result = unmarshal_object(empty_swagger_spec, address_spec, address)
@@ -157,7 +158,7 @@ def test_pass_through_additionalProperties_with_no_spec(
     address['city'] = 'Swaggerville'
     expected_address = {
         'number': 1600,
-        'street_name': 'Pennsylvania',
+        'street_name': u'Ümlaut',
         'street_type': 'Avenue',
         'city': 'Swaggerville',
     }

--- a/tests/unmarshal/unmarshal_primitive_test.py
+++ b/tests/unmarshal/unmarshal_primitive_test.py
@@ -1,14 +1,43 @@
+# -*- coding: utf-8 -*-
 import pytest
 
 from bravado_core.exception import SwaggerMappingError
 from bravado_core.unmarshal import unmarshal_primitive
 
 
-def test_success():
+def test_integer():
     integer_spec = {
         'type': 'integer'
     }
     assert 10 == unmarshal_primitive(integer_spec, 10)
+
+
+def test_string():
+    string_spec = {
+        'type': 'string'
+    }
+    assert 'foo' == unmarshal_primitive(string_spec, 'foo')
+    assert u'Ümlaut' == unmarshal_primitive(string_spec, u'Ümlaut')
+
+
+def test_booean():
+    boolean_spec = {
+        'type': 'boolean'
+    }
+    result = unmarshal_primitive(boolean_spec, True)
+    assert isinstance(result, bool)
+    assert result
+
+    result = unmarshal_primitive(boolean_spec, False)
+    assert isinstance(result, bool)
+    assert not result
+
+
+def test_number():
+    number_spec = {
+        'type': 'number'
+    }
+    assert 3.1 == unmarshal_primitive(number_spec, 3.1)
 
 
 def test_required_success():


### PR DESCRIPTION
While trying to reproduce the unicode in response body failure in #25, I added a bunch of tests.  No change in functionality.