### PR TITLE
[Rough Draft] adding User defined format

### DIFF
--- a/bravado_core/exception.py
+++ b/bravado_core/exception.py
@@ -1,3 +1,7 @@
+import sys
+
+import six
+
 class SwaggerError(Exception):
     """Base exception class which all bravado-core specific exceptions
     inherit from.
@@ -22,3 +26,16 @@ class SwaggerSchemaError(SwaggerError):
     """Raised when an error is encountered during processing of a SwaggerSchema.
     """
     pass
+
+def wrap_exception(exception_class):
+    def generic_exception(method):
+        def wrapper(*args, **kwargs):
+            try:
+                method(*args, **kwargs)
+            except Exception as e:
+                six.reraise(
+                    exception_class,
+                    exception_class(str(e)),
+                    sys.exc_info()[2])
+        return wrapper
+    return generic_exception

--- a/bravado_core/formatter.py
+++ b/bravado_core/formatter.py
@@ -3,6 +3,7 @@ Support for the 'format' key in the swagger spec as outlined in
 https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#dataTypeFormat
 """
 import dateutil.parser
+from collections import namedtuple
 
 import six
 
@@ -20,6 +21,13 @@ def register_format(format, to_wire, to_python, description=None):
     :param description: useful description
     """
     _formatters[format] = (to_wire, to_python, description)
+
+
+def get_formatter(format):
+    """
+    Returns the appriopriate formatting tuples or None
+    """
+    return _formatters.get(format)
 
 
 def to_wire(spec, value):

--- a/bravado_core/validate.py
+++ b/bravado_core/validate.py
@@ -3,7 +3,10 @@ Delegate as much validation as possible out to jsonschema. This module serves
 as the single point of entry for validations should we need to further
 customize the behavior.
 """
-from bravado_core.exception import SwaggerMappingError
+from jsonschema.exceptions import ValidationError
+
+from bravado_core.exception import wrap_exception, SwaggerMappingError
+from bravado_core.formatter import get_formatter
 from bravado_core.schema import SWAGGER_PRIMITIVES
 from bravado_core.swagger20_validator import Swagger20Validator
 
@@ -28,12 +31,25 @@ def validate_schema_object(spec, value):
             obj_type, value))
 
 
+@wrap_exception(ValidationError)
+def validate_user_format(value, format):
+    """value is supposed to be in the 'wire' format during this validation.
+    Hence, it can be validated by running `to_python` on unmarshalled value.
+    To enforce that the exception raised is ValidationError, decorator is used
+    """
+    formatter = get_formatter(format)
+    if formatter:
+        _, to_python, _ = formatter
+        to_python(value)
+
+
 def validate_primitive(spec, value):
     """
     :param spec: spec for a swagger primitive type in dict form
     :type value: int, string, float, long, etc
     """
     Swagger20Validator(spec).validate(value)
+    validate_user_format(value, spec.get('format'))
 
 
 def validate_array(spec, value):


### PR DESCRIPTION
- Fixes #32

- From comments of #32, I did not see an advantage of extra `validator` callback method over the logic of `to_python`. Even if the user provides `validator`, bravado-core cannot constrain that the raised exception will always be `ValidationError` (and secondly where will that be stored `_formatters` structure had to be changed). I think it is better to explicitly wrap it up. The only advantage we are getting with wiring in `validate` here is that a particular exception (ValidationError) is guaranteed in case of failure.

Related changes in `pyramid_swagger` will be [something like these](https://github.com/prat0318/pyramid_swagger/compare/master...add_user_formatter).

Opinions - @analogue @dnephin 