### PR TITLE
Support and validation for user defined Swagger formats

### DIFF
--- a/bravado_core/exception.py
+++ b/bravado_core/exception.py
@@ -1,3 +1,8 @@
+import sys
+
+import six
+
+
 class SwaggerError(Exception):
     """Base exception class which all bravado-core specific exceptions
     inherit from.
@@ -22,3 +27,17 @@ class SwaggerSchemaError(SwaggerError):
     """Raised when an error is encountered during processing of a SwaggerSchema.
     """
     pass
+
+
+def wrap_exception(exception_class):
+    def generic_exception(method):
+        def wrapper(*args, **kwargs):
+            try:
+                method(*args, **kwargs)
+            except Exception as e:
+                six.reraise(
+                    exception_class,
+                    exception_class(str(e)),
+                    sys.exc_info()[2])
+        return wrapper
+    return generic_exception

--- a/bravado_core/exception.py
+++ b/bravado_core/exception.py
@@ -7,7 +7,6 @@ class SwaggerError(Exception):
     """Base exception class which all bravado-core specific exceptions
     inherit from.
     """
-    pass
 
 
 class SwaggerMappingError(SwaggerError):
@@ -15,21 +14,24 @@ class SwaggerMappingError(SwaggerError):
     a response.
     """
 
-    def __init__(self, msg, cause=None):
-        """
-        :param msg: String message for the error.
-        :param cause: Optional exception that caused this one.
-        """
-        super(Exception, self).__init__(msg, cause)
+
+class SwaggerValidationError(SwaggerMappingError):
+    """Raised when an error is encountered during validating user defined
+    format values in a request or a resposne.
+    """
 
 
 class SwaggerSchemaError(SwaggerError):
     """Raised when an error is encountered during processing of a SwaggerSchema.
     """
-    pass
 
 
 def wrap_exception(exception_class):
+    """Helper decorator method to modify the raised exception class to
+    `exception_class` but keeps the message and trace intact.
+
+    :param exception_class: class to wrap raised exception with
+    """
     def generic_exception(method):
         def wrapper(*args, **kwargs):
             try:

--- a/bravado_core/formatter.py
+++ b/bravado_core/formatter.py
@@ -78,13 +78,12 @@ class SwaggerFormat(namedtuple('SwaggerFormat',
 
     :param format: Name for the user format.
     :param to_python: function to unmarshal a value of this format.
-                      Eg. lambda str: base64.b64decode(str)
+                      Eg. lambda val_str: base64.b64decode(val_str)
     :param to_wire: function to marshal a value of this format
-                    Eg. lambda val: base64.b64encode(val)
-    :param validate: function to validate the marshalled value. The method
-                     should raise Exception if the value doesn't conform to the
-                     format. `bravado-core` re-raises the exception with
-                     :class:`bravado_core.exception.SwaggerValidationError`.
+                    Eg. lambda val_py: base64.b64encode(val_py)
+    :param validate: function to validate the marshalled value. Raises
+                     :class:`bravado_core.exception.SwaggerValidationError`
+                     if value does not conform to the format.
     :param description: Short description of the format and conversion logic.
     """
 

--- a/bravado_core/formatter.py
+++ b/bravado_core/formatter.py
@@ -59,9 +59,10 @@ def get_format(format):
 
     :param format: Format name like int, base64, etc.
     :type format: str
+    :rtype: :class:`SwaggerFormat` or None
     """
     formatter = _formatters.get(format)
-    if not formatter:
+    if format and not formatter:
         warnings.warn(
             "%s format is not registered with bravado-core!" % format, Warning)
     return formatter
@@ -76,9 +77,11 @@ class SwaggerFormat(namedtuple('SwaggerFormat',
     which is invoked during bravado-core's validation flow.
 
     :param format: Name for the user format.
-    :param to_python: Lambda method to unmarshal a value of this format
-    :param to_wire: Lambda method to marshal a value of this format
-    :param validate: Lambda method to validate the marshalled value. The method
+    :param to_python: function to unmarshal a value of this format.
+                      Eg. lambda str: base64.b64decode(str)
+    :param to_wire: function to marshal a value of this format
+                    Eg. lambda val: base64.b64encode(val)
+    :param validate: function to validate the marshalled value. The method
                      should raise Exception if the value doesn't conform to the
                      format. `bravado-core` re-raises the exception with
                      :class:`bravado_core.exception.SwaggerValidationError`.

--- a/bravado_core/formatter.py
+++ b/bravado_core/formatter.py
@@ -2,24 +2,16 @@
 Support for the 'format' key in the swagger spec as outlined in
 https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#dataTypeFormat
 """
-import dateutil.parser
+
+import collections
 
 import six
+import dateutil.parser
 
 from bravado_core import schema
 
-
-def register_format(format, to_wire, to_python, description=None):
-    """
-    Register a formatter for a given 'format'.
-
-    :type format: string
-    :param to_wire: single argument callable that converts a value to wire
-        format
-    :param to_python: single argument callable that converts a value to python
-    :param description: useful description
-    """
-    _formatters[format] = (to_wire, to_python, description)
+if six.PY3:
+    long = int
 
 
 def to_wire(spec, value):
@@ -32,9 +24,8 @@ def to_wire(spec, value):
     """
     if value is None or not schema.has_format(spec):
         return value
-
-    to_wire, _, _ = _formatters[schema.get_format(spec)]
-    return to_wire(value)
+    formatter = get_format(schema.get_format(spec))
+    return formatter.to_wire(value) if formatter else value
 
 
 def to_python(spec, value):
@@ -47,46 +38,77 @@ def to_python(spec, value):
     """
     if value is None or not schema.has_format(spec):
         return value
-
-    _, to_python, _ = _formatters[schema.get_format(spec)]
-    return to_python(value)
-
-
-if six.PY3:
-    long = int
+    formatter = get_format(schema.get_format(spec))
+    return formatter.to_python(value) if formatter else value
 
 
-# Default registered formats
+def register_format(swagger_format):
+    """
+    Register a swagger_format to a global _formatters cache.
+
+    :type format: string
+    :param to_wire: single argument callable that converts a value to wire
+        format
+    :param to_python: single argument callable that converts a value to python
+    :param description: useful description
+    """
+    global _formatters
+    _formatters[swagger_format.format] = swagger_format
+
+
+def get_format(format):
+    return _formatters.get(format)
+
+
+# validate should check the correctness of `wire` value
+SwaggerFormat = collections.namedtuple(
+    'SwaggerFormat', 'format to_python to_wire validate description')
+
+
 _formatters = {
-    'date': (
-        lambda d: d.isoformat(),
-        lambda d: dateutil.parser.parse(d).date(),
-        'Converts string:date <=> python datetime.date'),
-    'date-time': (
-        lambda dt: dt.isoformat(),
-        lambda dt: dateutil.parser.parse(dt),
-        'Converts string:date-time <=> python datetime.datetime'),
-    'int64': (
-        lambda i: i if isinstance(i, long) else long(i),
-        lambda i: i if isinstance(i, long) else long(i),
-        'Converts integer:int64 <==> python long'),
-    'int32': (
-        lambda i: i if isinstance(i, int) else int(i),
-        lambda i: i if isinstance(i, int) else int(i),
-        'Converts integer:int32 <==> python int'),
-    # Consider using Decimal (https://docs.python.org/2/library/decimal.html)
-    # as the python representation for number:float and number:double given
-    # the number of benefits is brings to the table.
-    'float': (
-        lambda f: f if isinstance(f, float) else float(f),
-        lambda f: f if isinstance(f, float) else float(f),
-        'Converts number:float <==> python float'),
-    'double': (
-        lambda d: d if isinstance(d, float) else float(d),
-        lambda d: d if isinstance(d, float) else float(d),
-        'Converts number:double <==> python float'),
-    'byte': (
-        lambda b: b if isinstance(b, str) else str(b),
-        lambda b: b if isinstance(b, str) else str(b),
-        'Converts string:byte <==> python str'),
-}
+    'byte': SwaggerFormat(
+        format='byte',
+        to_wire=lambda b: b if isinstance(b, str) else str(b),
+        to_python=(
+            lambda s: s if isinstance(s, str) else str(s)),
+        validate=lambda x: None,  # jsonschema validates string
+        description='Converts [wire]string:byte <=> python byte'),
+    'date': SwaggerFormat(
+        format='date',
+        to_wire=lambda d: d.isoformat(),
+        to_python=lambda d: dateutil.parser.parse(d).date(),
+        validate=lambda x: None,  # jsonschema validates date
+        description='Converts [wire]string:date <=> python datetime.date'),
+    # Python has no double. float is C's double in CPython
+    'double': SwaggerFormat(
+        format='double',
+        to_wire=lambda d: d if isinstance(d, float) else float(d),
+        to_python=lambda d: d if isinstance(d, float) else float(d),
+        validate=lambda x: None,  # jsonschema validates number
+        description='Converts [wire]number:double <=> python float'),
+    'date-time': SwaggerFormat(
+        format='date-time',
+        to_wire=lambda dt: dt.isoformat(),
+        to_python=lambda dt: dateutil.parser.parse(dt),
+        validate=lambda x: None,  # jsonschema validates date-time
+        description=(
+            'Converts string:date-time <=> python datetime.datetime')),
+    'float': SwaggerFormat(
+        format='float',
+        to_wire=lambda f: f if isinstance(f, float) else float(f),
+        to_python=lambda f: f if isinstance(f, float) else float(f),
+        validate=lambda x: None,  # jsonschema validates number
+        description='Converts [wire]number:float <=> python float'),
+    'int32': SwaggerFormat(
+        format='int32',
+        to_wire=lambda i: i if isinstance(i, int) else int(i),
+        to_python=lambda i: i if isinstance(i, int) else int(i),
+        validate=lambda x: None,  # jsonschema validates integer
+        description='Converts [wire]integer:int32 <=> python int'),
+    'int64': SwaggerFormat(
+        format='int64',
+        to_wire=lambda i: i if isinstance(i, long) else long(i),
+        to_python=lambda i: i if isinstance(i, long) else long(i),
+        validate=lambda x: None,  # jsonschema validates integer
+        description='Converts [wire]integer:int64 <=> python long'),
+    }

--- a/bravado_core/validate.py
+++ b/bravado_core/validate.py
@@ -3,15 +3,21 @@ Delegate as much validation as possible out to jsonschema. This module serves
 as the single point of entry for validations should we need to further
 customize the behavior.
 """
-from jsonschema.exceptions import ValidationError
 
-from bravado_core.exception import wrap_exception, SwaggerMappingError
+from bravado_core.exception import (wrap_exception,
+                                    SwaggerMappingError,
+                                    SwaggerValidationError)
 from bravado_core.schema import SWAGGER_PRIMITIVES
 from bravado_core.formatter import get_format
 from bravado_core.swagger20_validator import Swagger20Validator
 
 
 def validate_schema_object(spec, value):
+    """
+    :raises ValidationError: when validation error found by jsonschema.
+    :raises SwaggerMappingError: when `type` of the value is not as per v1.2
+    :raises SwaggerValidationError: when user format's `validate` raises error.
+    """
     obj_type = spec['type']
 
     if obj_type in SWAGGER_PRIMITIVES:
@@ -31,7 +37,7 @@ def validate_schema_object(spec, value):
             obj_type, value))
 
 
-@wrap_exception(ValidationError)
+@wrap_exception(SwaggerValidationError)
 def validate_user_format(spec, value):
     formatter = get_format(spec.get('format'))
     if formatter:

--- a/bravado_core/validate.py
+++ b/bravado_core/validate.py
@@ -15,7 +15,7 @@ from bravado_core.swagger20_validator import Swagger20Validator
 def validate_schema_object(spec, value):
     """
     :raises ValidationError: when validation error found by jsonschema.
-    :raises SwaggerMappingError: when `type` of the value is not as per v1.2
+    :raises SwaggerMappingError: when `type` of value is not as per spec v2.0
     :raises SwaggerValidationError: when user format's `validate` raises error.
     """
     obj_type = spec['type']

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,10 @@
+import base64
 import os
 import simplejson as json
 
 import pytest
 
+import bravado_core.formatter
 from bravado_core.spec import Spec
 
 
@@ -45,3 +47,23 @@ def petstore_dict():
 @pytest.fixture
 def petstore_spec(petstore_dict):
     return Spec.from_dict(petstore_dict)
+
+
+def del_base64():
+    del bravado_core.formatter._formatters['base64']
+
+
+@pytest.fixture
+def base64_format():
+    return bravado_core.formatter.SwaggerFormat(
+        format='base64',
+        to_wire=base64.b64encode,
+        to_python=base64.b64decode,
+        validate=base64.b64decode,
+        description='Base64')
+
+
+@pytest.fixture(scope='function')
+def register_base64_format(base64_format, request):
+    request.addfinalizer(del_base64)
+    bravado_core.formatter.register_format(base64_format)

--- a/tests/exception/wrap_exception_test.py
+++ b/tests/exception/wrap_exception_test.py
@@ -8,6 +8,6 @@ def test_exception_gets_correctly_wrapped():
     def raise_assertion_error():
         raise AssertionError('bla')
 
-    with pytest.raises(IOError) as e:
+    with pytest.raises(IOError) as excinfo:
         raise_assertion_error()
-        assert 'bla' == e.message
+    assert 'bla' == str(excinfo.value)

--- a/tests/exception/wrap_exception_test.py
+++ b/tests/exception/wrap_exception_test.py
@@ -1,0 +1,13 @@
+import pytest
+
+from bravado_core.exception import wrap_exception
+
+
+def test_exception_gets_correctly_wrapped():
+    @wrap_exception(IOError)
+    def raise_assertion_error():
+        raise AssertionError('bla')
+
+    with pytest.raises(IOError) as e:
+        raise_assertion_error()
+        assert 'bla' == e.message

--- a/tests/formatter/get_format_test.py
+++ b/tests/formatter/get_format_test.py
@@ -1,0 +1,10 @@
+
+from bravado_core.formatter import _formatters, get_format
+
+
+def test_returns_format_if_present():
+    assert get_format('int32') == _formatters['int32']
+
+
+def test_returns_none_if_format_not_present():
+    assert get_format('foo') is None

--- a/tests/formatter/get_format_test.py
+++ b/tests/formatter/get_format_test.py
@@ -1,3 +1,4 @@
+from mock import patch
 
 from bravado_core.formatter import _formatters, get_format
 
@@ -6,5 +7,6 @@ def test_returns_format_if_present():
     assert get_format('int32') == _formatters['int32']
 
 
-def test_returns_none_if_format_not_present():
+@patch('bravado_core.formatter.warnings.warn')
+def test_returns_none_if_format_not_present(_):
     assert get_format('foo') is None

--- a/tests/formatter/register_format_test.py
+++ b/tests/formatter/register_format_test.py
@@ -5,7 +5,13 @@ from bravado_core.formatter import register_format, to_wire, to_python
 
 
 def test_success():
-    register_format('base64', base64.b64encode, base64.b64decode, "Base64")
+    base64_format = bravado_core.formatter.SwaggerFormat(
+        format='base64',
+        to_wire=base64.b64encode,
+        to_python=base64.b64decode,
+        validate=lambda x: None,
+        description='Base64')
+    register_format(base64_format)
     try:
         spec = {
             'name': 'username',

--- a/tests/formatter/register_format_test.py
+++ b/tests/formatter/register_format_test.py
@@ -1,24 +1,10 @@
-import base64
-
-import bravado_core.formatter
-from bravado_core.formatter import register_format, to_wire, to_python
+from bravado_core.formatter import to_wire, to_python
 
 
-def test_success():
-    base64_format = bravado_core.formatter.SwaggerFormat(
-        format='base64',
-        to_wire=base64.b64encode,
-        to_python=base64.b64decode,
-        validate=lambda x: None,
-        description='Base64')
-    register_format(base64_format)
-    try:
-        spec = {
-            'name': 'username',
-            'type': 'string',
-            'format': 'base64',
-        }
-        assert b'darwin' == to_python(spec, to_wire(spec, b'darwin'))
-    finally:
-        # I know, icky!
-        del bravado_core.formatter._formatters['base64']
+def test_success(register_base64_format):
+    spec = {
+        'name': 'username',
+        'type': 'string',
+        'format': 'base64',
+    }
+    assert b'darwin' == to_python(spec, to_wire(spec, b'darwin'))

--- a/tests/formatter/to_python_test.py
+++ b/tests/formatter/to_python_test.py
@@ -26,6 +26,11 @@ def test_datetime():
     assert datetime(2015, 3, 22, 13, 19, 54) == result
 
 
+def test_no_registered_format_returns_value_as_is():
+    spec = {'type': 'foo', 'format': 'bar'}
+    assert 'baz' == to_python(spec, 'baz')
+
+
 def test_int64_long():
     spec = {'type': 'integer', 'format': 'int64'}
     if six.PY3:

--- a/tests/formatter/to_python_test.py
+++ b/tests/formatter/to_python_test.py
@@ -1,6 +1,7 @@
 from datetime import date, datetime
 
 import six
+from mock import patch
 
 from bravado_core.formatter import to_python
 
@@ -26,9 +27,16 @@ def test_datetime():
     assert datetime(2015, 3, 22, 13, 19, 54) == result
 
 
-def test_no_registered_format_returns_value_as_is():
+@patch('bravado_core.formatter.warnings.warn')
+def test_no_registered_format_returns_value_as_is(_):
     spec = {'type': 'foo', 'format': 'bar'}
     assert 'baz' == to_python(spec, 'baz')
+
+
+@patch('bravado_core.formatter.warnings.warn')
+def test_no_registered_format_throws_warning(mock_warn):
+    to_python({'type': 'foo', 'format': 'bar'}, 'baz')
+    mock_warn.assert_called_once()
 
 
 def test_int64_long():

--- a/tests/formatter/to_wire_test.py
+++ b/tests/formatter/to_wire_test.py
@@ -24,6 +24,11 @@ def test_datetime():
     assert '2015-03-22T13:19:54' == result
 
 
+def test_no_registered_format_returns_value_as_is():
+    spec = {'type': 'foo', 'format': 'bar'}
+    assert 'baz' == to_wire(spec, 'baz')
+
+
 def test_int64_long():
     spec = {'type': 'integer', 'format': 'int64'}
     if six.PY3:

--- a/tests/formatter/to_wire_test.py
+++ b/tests/formatter/to_wire_test.py
@@ -1,6 +1,7 @@
 from datetime import datetime, date
 
 import six
+from mock import patch
 
 from bravado_core.formatter import to_wire
 
@@ -24,9 +25,16 @@ def test_datetime():
     assert '2015-03-22T13:19:54' == result
 
 
-def test_no_registered_format_returns_value_as_is():
+@patch('bravado_core.formatter.warnings.warn')
+def test_no_registered_format_returns_value_as_is(_):
     spec = {'type': 'foo', 'format': 'bar'}
     assert 'baz' == to_wire(spec, 'baz')
+
+
+@patch('bravado_core.formatter.warnings.warn')
+def test_no_registered_format_throws_warning(mock_warn):
+    to_wire({'type': 'foo', 'format': 'bar'}, 'baz')
+    mock_warn.assert_called_once()
 
 
 def test_int64_long():

--- a/tests/param/cast_request_param_test.py
+++ b/tests/param/cast_request_param_test.py
@@ -1,3 +1,5 @@
+from mock import patch
+
 from bravado_core.param import cast_request_param
 
 
@@ -22,6 +24,7 @@ def test_none_returns_none():
     assert cast_request_param('integer', 'biz_id', None) is None
 
 
-def test_cast_failure_returns_untouched_value():
+@patch('bravado_core.param.log.warn')
+def test_cast_failure_returns_untouched_value(_):
     assert 'i_cant_be_casted_to_an_integer' == cast_request_param(
         'integer', 'biz_id', 'i_cant_be_casted_to_an_integer')

--- a/tests/validate/validate_user_format_test.py
+++ b/tests/validate/validate_user_format_test.py
@@ -1,9 +1,7 @@
-import base64
 import pytest
 
-import bravado_core.formatter
-from bravado_core.formatter import register_format, to_wire
-from bravado_core.validate import validate_user_format, ValidationError
+from bravado_core.formatter import to_wire
+from bravado_core.validate import validate_user_format, SwaggerValidationError
 
 
 @pytest.fixture
@@ -11,31 +9,14 @@ def base64_spec():
     return {'type': 'string', 'format': 'base64'}
 
 
-@pytest.fixture
-def register_base64_format():
-    base64_format = bravado_core.formatter.SwaggerFormat(
-        format='base64',
-        to_wire=base64.b64encode,
-        to_python=base64.b64decode,
-        validate=base64.b64decode,
-        description='Base64')
-    register_format(base64_format)
-
-
 def test_success_validate(base64_spec, register_base64_format):
-    try:
-        validate_user_format(base64_spec, to_wire(base64_spec, b'darwin'))
-    finally:
-        del bravado_core.formatter._formatters['base64']
+    validate_user_format(base64_spec, to_wire(base64_spec, b'darwin'))
 
 
 def test_failure_validate_gets_wrapped(base64_spec, register_base64_format):
-    try:
+    with pytest.raises(SwaggerValidationError) as excinfo:
         validate_user_format(base64_spec, b'darwin')
-    except ValidationError as e:
-        assert 'Incorrect padding' == e.message
-    finally:
-        del bravado_core.formatter._formatters['base64']
+    assert 'Incorrect padding' == str(excinfo.value)
 
 
 def test_unregisterd_format_is_ignored(base64_spec):

--- a/tests/validate/validate_user_format_test.py
+++ b/tests/validate/validate_user_format_test.py
@@ -1,4 +1,5 @@
 import pytest
+from mock import patch
 
 from bravado_core.formatter import to_wire
 from bravado_core.validate import validate_user_format, SwaggerValidationError
@@ -19,5 +20,6 @@ def test_failure_validate_gets_wrapped(base64_spec, register_base64_format):
     assert 'Incorrect padding' == str(excinfo.value)
 
 
-def test_unregisterd_format_is_ignored(base64_spec):
+@patch('bravado_core.formatter.warnings.warn')
+def test_unregisterd_format_is_ignored(_, base64_spec):
     validate_user_format(base64_spec, b'darwin')

--- a/tests/validate/validate_user_format_test.py
+++ b/tests/validate/validate_user_format_test.py
@@ -1,0 +1,42 @@
+import base64
+import pytest
+
+import bravado_core.formatter
+from bravado_core.formatter import register_format, to_wire
+from bravado_core.validate import validate_user_format, ValidationError
+
+
+@pytest.fixture
+def base64_spec():
+    return {'type': 'string', 'format': 'base64'}
+
+
+@pytest.fixture
+def register_base64_format():
+    base64_format = bravado_core.formatter.SwaggerFormat(
+        format='base64',
+        to_wire=base64.b64encode,
+        to_python=base64.b64decode,
+        validate=base64.b64decode,
+        description='Base64')
+    register_format(base64_format)
+
+
+def test_success_validate(base64_spec, register_base64_format):
+    try:
+        validate_user_format(base64_spec, to_wire(base64_spec, b'darwin'))
+    finally:
+        del bravado_core.formatter._formatters['base64']
+
+
+def test_failure_validate_gets_wrapped(base64_spec, register_base64_format):
+    try:
+        validate_user_format(base64_spec, b'darwin')
+    except ValidationError as e:
+        assert 'Incorrect padding' == e.message
+    finally:
+        del bravado_core.formatter._formatters['base64']
+
+
+def test_unregisterd_format_is_ignored(base64_spec):
+    validate_user_format(base64_spec, b'darwin')


### PR DESCRIPTION
- add `SwaggerFormat` namedtuple
- add call to `validate` during primitive check
- Fixes #32 