### PR TITLE
Use a more specific exception when a response can't be mapped to the schema

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+2.3.0 (2015-XX-XX)
+------------------
+- Raise MatchingResponseNotFound instead of SwaggerMappingError
+  when a response can't be matched to the Swagger schema.
+
 2.2.0 (2015-08-06)
 ------------------
 - Add reason to IncomingResponse

--- a/bravado_core/exception.py
+++ b/bravado_core/exception.py
@@ -15,6 +15,12 @@ class SwaggerMappingError(SwaggerError):
     """
 
 
+class MatchingResponseNotFound(SwaggerMappingError):
+    """Raised when an incoming or outgoing response cannot be matched to a
+    documented response in the swagger spec.
+    """
+
+
 class SwaggerValidationError(SwaggerMappingError):
     """Raised when an error is encountered during validating user defined
     format values in a request or a resposne.

--- a/bravado_core/response.py
+++ b/bravado_core/response.py
@@ -3,7 +3,7 @@ from six import iteritems
 from bravado_core.content_type import APP_JSON
 from bravado_core.unmarshal import unmarshal_schema_object
 from bravado_core.validate import validate_schema_object
-from bravado_core.exception import SwaggerMappingError
+from bravado_core.exception import SwaggerMappingError, MatchingResponseNotFound
 
 # Response bodies considered to be empty
 EMPTY_BODIES = (None, '', '{}', 'null')
@@ -126,8 +126,8 @@ def get_response_spec(status_code, op):
     :type op: :class:`bravado_core.operation.Operation`
     :return: response specification
     :rtype: dict
-    :raises: SwaggerMappingError when the status_code could not be mapped to
-        a response specification.
+    :raises: MatchingResponseNotFound when the status_code could not be mapped
+        to a response specification.
     """
     # We don't need to worry about checking #/responses/ because jsonref has
     # already inlined the $refs
@@ -135,10 +135,10 @@ def get_response_spec(status_code, op):
     default_response_spec = response_specs.get('default', None)
     response_spec = response_specs.get(str(status_code), default_response_spec)
     if response_spec is None:
-        raise SwaggerMappingError(
+        raise MatchingResponseNotFound(
             "Response specification matching http status_code {0} not found "
-            "for {1}. Either add a response specifiction for the status_code "
-            "or use a `default` response.".format(op, status_code))
+            "for operation {1}. Either add a response specification for the "
+            "status_code or use a `default` response.".format(status_code, op))
     return response_spec
 
 

--- a/bravado_core/response.py
+++ b/bravado_core/response.py
@@ -3,7 +3,7 @@ from six import iteritems
 from bravado_core.content_type import APP_JSON
 from bravado_core.unmarshal import unmarshal_schema_object
 from bravado_core.validate import validate_schema_object
-from bravado_core.exception import SwaggerMappingError, MatchingResponseNotFound
+from bravado_core.exception import MatchingResponseNotFound, SwaggerMappingError 
 
 # Response bodies considered to be empty
 EMPTY_BODIES = (None, '', '{}', 'null')

--- a/bravado_core/response.py
+++ b/bravado_core/response.py
@@ -3,7 +3,7 @@ from six import iteritems
 from bravado_core.content_type import APP_JSON
 from bravado_core.unmarshal import unmarshal_schema_object
 from bravado_core.validate import validate_schema_object
-from bravado_core.exception import MatchingResponseNotFound, SwaggerMappingError 
+from bravado_core.exception import MatchingResponseNotFound, SwaggerMappingError
 
 # Response bodies considered to be empty
 EMPTY_BODIES = (None, '', '{}', 'null')

--- a/tests/response/get_response_spec_test.py
+++ b/tests/response/get_response_spec_test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from bravado_core.exception import SwaggerMappingError
+from bravado_core.exception import MatchingResponseNotFound
 from bravado_core.operation import Operation
 from bravado_core.response import get_response_spec
 
@@ -34,6 +34,6 @@ def test_raise_error_when_no_default_and_no_status_code_match(
         empty_swagger_spec, op_spec):
     del op_spec['responses']['default']
     op = Operation(empty_swagger_spec, '/pet/{petId}', 'get', op_spec)
-    with pytest.raises(SwaggerMappingError) as excinfo:
+    with pytest.raises(MatchingResponseNotFound) as excinfo:
         get_response_spec(404, op)
     assert 'not found' in str(excinfo.value)


### PR DESCRIPTION
Needed for https://github.com/Yelp/bravado/issues/153