### PR TITLE
Dereference elements from a list. Fixes #40.

### DIFF
--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -206,7 +206,9 @@ def replace_jsonref_proxies(obj):
                     fragment[k] = v.__subject__
                 descend(fragment[k])
         elif is_list_like(fragment):
-            for element in fragment:
+            for index, element in enumerate(fragment):
+                if isinstance(element, jsonref.JsonRef):
+                    fragment[index] = element.__subject__
                 descend(element)
 
     descend(obj)

--- a/tests/spec/replace_jsonref_proxies_test.py
+++ b/tests/spec/replace_jsonref_proxies_test.py
@@ -20,10 +20,10 @@ def test_dict():
         }
     }
     json_obj = jsonref.loads(json.dumps(d))
-    assert isinstance(json_obj['foo'], jsonref.JsonRef)
+    assert type(json_obj['foo']) == jsonref.JsonRef
 
     replace_jsonref_proxies(json_obj)
-    assert isinstance(json_obj['foo'], dict)
+    assert type(json_obj['foo']) == dict
 
     assert d['definitions']['user'] == json_obj['foo']
 
@@ -56,12 +56,12 @@ def test_nested_dict():
         }
     }
     json_obj = jsonref.loads(json.dumps(d))
-    assert isinstance(json_obj['foo'], jsonref.JsonRef)
-    assert isinstance(json_obj['foo']['properties']['address'], jsonref.JsonRef)
+    assert type(json_obj['foo']) == jsonref.JsonRef
+    assert type(json_obj['foo']['properties']['address']) == jsonref.JsonRef
 
     replace_jsonref_proxies(json_obj)
-    assert isinstance(json_obj['foo'], dict)
-    assert isinstance(json_obj['foo']['properties']['address'], dict)
+    assert type(json_obj['foo']) == dict
+    assert type(json_obj['foo']['properties']['address']) == dict
 
     assert d['definitions']['address'] == \
         json_obj['foo']['properties']['address']
@@ -85,9 +85,9 @@ def test_list():
         }
     }
     json_obj = jsonref.loads(json.dumps(d))
-    assert isinstance(json_obj['foo'][0], jsonref.JsonRef)
+    assert type(json_obj['foo'][0]) == jsonref.JsonRef
 
     replace_jsonref_proxies(json_obj)
-    assert isinstance(json_obj['foo'][0], dict)
+    assert type(json_obj['foo'][0]) == dict
 
     assert d['definitions']['user'] == json_obj['foo'][0]


### PR DESCRIPTION
- Fixes #40
- Dereference from dict was happening but not from list.
- If `assert not isinstance(json_obj['foo'][0], jsonref.JsonRef)` was added at L93 to `tests/spec/replace_jsonref_proxies_test.py`, it would fail. It passes now.