### PR TITLE
Add guard against adding files to the parameters when no file given

### DIFF
--- a/bravado_core/param.py
+++ b/bravado_core/param.py
@@ -214,6 +214,9 @@ def add_file(param, value, request):
     :param value: The raw content of the file to be uploaded
     :type request: dict
     """
+    if not value:
+        return
+
     if request.get('files') is None:
         # support multiple files by default by setting to an empty array
         request['files'] = []

--- a/tests/param/add_file_test.py
+++ b/tests/param/add_file_test.py
@@ -6,6 +6,20 @@ from bravado_core.operation import Operation
 from bravado_core.param import add_file, Param
 
 
+def test_no_file(empty_swagger_spec):
+    request = {}
+    op = Mock(spec=Operation, consumes=['multipart/form-data'])
+    param_spec = {
+        'type': 'file',
+        'in': 'formData',
+        'name': 'photo'
+    }
+    param = Param(empty_swagger_spec, op, param_spec)
+    add_file(param, None, request)
+    expected_request = {}
+    assert expected_request == request
+
+
 def test_single_file(empty_swagger_spec):
     request = {}
     file_contents = "I am the contents of a file"


### PR DESCRIPTION
Tentative fix for #53