### PR TITLE
Docs on how to use user-defined formats and configure bravado-core

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+3.0.2 (2015-XX-XX)
+------------------
+- Added Sphinx docs how to use `user-defined formats <http://bravado-core.readthedocs.org/en/latest/formats.html>`_.
+
 3.0.1 (2015-10-09)
 ------------------
 - Automatically tag models in external $refs - Issue #45 - see `Model Discovery <http://bravado-core.readthedocs.org/en/latest/models.html#model-discovery>`_ for more info.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changelog
 ------------------
 - Added docs on how to use `user-defined formats <http://bravado-core.readthedocs.org/en/latest/formats.html>`_.
 - Added docs on how to `configure <http://bravado-core.readthedocs.org/en/latest/config.html>`_ bravado-core.
+- `formats` added as a config option
 
 3.0.1 (2015-10-09)
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,8 @@ Changelog
 
 3.0.2 (2015-XX-XX)
 ------------------
-- Added Sphinx docs how to use `user-defined formats <http://bravado-core.readthedocs.org/en/latest/formats.html>`_.
+- Added docs on how to use `user-defined formats <http://bravado-core.readthedocs.org/en/latest/formats.html>`_.
+- Added docs on how to `configure <http://bravado-core.readthedocs.org/en/latest/config.html>`_ bravado-core.
 
 3.0.1 (2015-10-09)
 ------------------

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -41,7 +41,13 @@ CONFIG_DEFAULTS = {
     #
     # NOTE: outgoing requests on the client side and outgoing responses on the
     #       server side can use either models or dicts.
-    'use_models': True
+    'use_models': True,
+
+    # List of user-defined formats of type
+    # :class:`bravado_core.formatter.SwaggerFormat`. These formats are in
+    # addition to the formats already supported by the Swagger 2.0
+    # Specification.
+    'formats': []
 }
 
 
@@ -115,6 +121,9 @@ class Spec(object):
         return spec
 
     def build(self):
+        for format in self.config['formats']:
+            self.register_format(format)
+
         if self.config['validate_swagger_spec']:
             validator20.validate_spec(self.spec_dict)
 

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -32,6 +32,6 @@ Config key                Type            Default    Description
 *use_models*              boolean         True       | Use python classes to represent models
                                                      | instead of dicts. See :ref:`models`.
 ------------------------- --------------- ---------  ----------------------------------------------------
-*formats*                 list of         True       | List of user-defined formats to support.
+*formats*                 list of         []         | List of user-defined formats to support.
                           SwaggerFormat              | See :ref:`formats`.
 ========================= =============== =========  ====================================================

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -1,0 +1,37 @@
+Configuration
+=============
+
+All configuration is stored in a ``dict``.
+
+.. code-block:: python
+
+    from bravado_core.spec import Spec
+
+    spec_dict = json.loads(open('swagger.json', 'r').read())
+
+    config = {
+        'validate_requests': False,
+        'use_models': False,
+    }
+
+    swagger_spec = Spec.from_dict(spec_dict, config=config)
+
+
+========================= =============== =========  ====================================================
+Config key                Type            Default    Description
+------------------------- --------------- ---------  ----------------------------------------------------
+*validate_swagger_spec*   boolean         True       | Validate the Swagger spec against
+                                                     | the Swagger 2.0 Specification.
+------------------------- --------------- ---------  ----------------------------------------------------
+*validate_requests*       boolean         True       | On the client side, validates outgoing requests.
+                                                     | On the server side, validates incoming requests.
+------------------------- --------------- ---------  ----------------------------------------------------
+*validate_responses*      boolean         True       | On the client side, validates incoming responses.
+                                                     | On the server side, validates outgoing responses.
+------------------------- --------------- ---------  ----------------------------------------------------
+*use_models*              boolean         True       | Use python classes to represent models
+                                                     | instead of dicts. See :ref:`models`.
+------------------------- --------------- ---------  ----------------------------------------------------
+*formats*                 list of         True       | List of user-defined formats to support.
+                          SwaggerFormat              | See :ref:`formats`.
+========================= =============== =========  ====================================================

--- a/docs/source/formats.rst
+++ b/docs/source/formats.rst
@@ -152,7 +152,7 @@ CIDR objects back from the response.
     cidr_param = op.params.get('cidr')
 
     # Create a CIDR object - to_wire() will be called on this during marshalling
-    cidr_object = CIDR('192.168.1.1/24)
+    cidr_object = CIDR('192.168.1.1/24')
     request_dict = {}
 
     # Marshal the cidr_object into the request_dict.

--- a/docs/source/formats.rst
+++ b/docs/source/formats.rst
@@ -1,3 +1,5 @@
+.. _formats:
+
 User-Defined Formats
 ====================
 
@@ -33,11 +35,11 @@ that makes them easy to work with.
             """
             self.cidr = cidr
 
-        def overlaps(other_cidr):
+        def overlaps(self, other_cidr):
             """Return true if other_cidr overlaps with this cidr"""
             ...
 
-        def subnet_mask():
+        def subnet_mask(self):
             """Return the subnet mask of this cidr"""
             ...
 

--- a/docs/source/formats.rst
+++ b/docs/source/formats.rst
@@ -1,0 +1,168 @@
+User-Defined Formats
+====================
+
+Primitive types in Swagger support an optional modifier property ``format`` as
+explained in detail in the `Swagger Specification <https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#data-types>`_.
+With this feature, you can define your own domain specific formats and have
+validation and marshalling to/from python/json handled transparently.
+
+Creating a user-defined format
+------------------------------
+This is best explained with a simple example. Let's create a user-defined
+format for `CIDR notation <https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notation>`_.
+
+In a Swagger spec, the schema-object for a CIDR would resemble:
+
+.. code-block:: json
+
+    {
+        "type": "string",
+        "format": "cidr",
+        "description": "IPv4 CIDR"
+    }
+
+In python, we'd like CIDRs to automatically be converted to a ``CIDR`` object
+that makes them easy to work with.
+
+.. code-block:: python
+
+    class CIDR(object):
+        def __init__(self, cidr):
+            """
+            :param cidr: CIDR in string form.
+            """
+            self.cidr = cidr
+
+        def overlaps(other_cidr):
+            """Return true if other_cidr overlaps with this cidr"""
+            ...
+
+        def subnet_mask():
+            """Return the subnet mask of this cidr"""
+            ...
+
+        ...
+
+We would also like CIDRs to be validated by bravado-core whenever they are
+part of a HTTP request or response.
+
+Create a ``bravado_core.formatter.SwaggerFormat`` to define the CIDR format:
+
+.. code-block:: python
+
+    from bravado_core.formatter import SwaggerFormat
+
+    def validate_cidr(cidr_string):
+        if '/' not in cidr_string:
+            raise SwaggerValidationError('CIDR {0} is invalid'.format(cidr_string))
+
+    cidr_format = SwaggerFormat(
+        # name of the format as used in the Swagger spec
+        format='cidr',
+
+        # Callable to convert a python CIDR object to a string
+        to_wire=lambda cidr_object: cidr_object.cidr,
+
+        # Callable to convert a string to a python CIDR object
+        to_python=lambda cidr_string: CIDR(cidr_string),
+
+        # Callable to validate the cidr in string form
+        validate=validate_cidr
+    )
+
+
+Configuring user-defined formats
+--------------------------------
+Now that we have a ``cidr_format``, just pass it to a ``Spec`` as part of the
+``config`` parameter on ``Spec`` creation.
+
+.. code-block:: python
+
+    from bravado_core.spec import Spec
+
+    spec_dict = json.loads(open('swagger.json', 'r').read())
+    config = {
+        'validate_responses': True,
+        'validate_requests': True,
+        'formats': [cidr_format],
+    }
+    spec = Spec.from_dict(spec_dict, config=config)
+
+All validation and processing of HTTP requests and responses will now use the
+configured format where appropriate.
+
+
+Putting it all together
+-----------------------
+A simple example of passing a CIDR object to a request and getting a list of
+CIDR objects back from the response.
+
+.. code-block:: json
+
+    {
+        "paths": {
+            "/get_overlapping_cidrs": {
+                "get": {
+                    "parameters": [
+                        {
+                            "name": "cidr",
+                            "in": "query",
+                            "type": "string",
+                            "format": "cidr"
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "List of overlapping cidrs",
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string",
+                                    "format": "cidr"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+.. code-block:: python
+
+    from bravado_core.spec import Spec
+    from bravado_core.response import unmarshal_response
+    from bravado_core.param import marshal_param
+
+    # Retrieve the swagger spec from the server and json.load() it
+    spec_dict = ...
+
+    # Create cidr_format add it to the config dict
+    config = ...
+
+    # Create a bravado_core.spec.Spec
+    swagger_spec = Spec.from_dict(spec_dict, config=config)
+
+    # Get the operation to invoke
+    op = swagger_spec.get_op_for_request('GET', '/get_overlapping_cidrs')
+
+    # Get the Param that represents the cidr query parameter
+    cidr_param = op.params.get('cidr')
+
+    # Create a CIDR object - to_wire() will be called on this during marshalling
+    cidr_object = CIDR('192.168.1.1/24)
+    request_dict = {}
+
+    # Marshal the cidr_object into the request_dict.
+    marshal_param(cidr_param, cidr_object, request_dict)
+
+    # Lots of hand-wavey stuff here - use whatever http client you have to
+    # send the request and receive a response
+    response = http_client.send(request_dict)
+
+    # Extract the list of cidrs
+    cidrs = unmarshal_response(response)
+
+    # Verify cidrs are CIDR objects and not strings
+    for cidr in cidrs:
+        assert type(cidr) == CIDR

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -21,6 +21,7 @@ Contents:
    :maxdepth: 1
 
    models
+   formats
    changelog
 
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -20,6 +20,7 @@ Contents:
 .. toctree::
    :maxdepth: 1
 
+   config
    models
    formats
    changelog

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -1,3 +1,5 @@
+.. _models:
+
 Python Models
 =============
 


### PR DESCRIPTION
Subtle change from previous udf branch - formats are registered via the config dict passsed to `Spec.from_dict(spec_dict, config)` instead of calling `spec.register_format(....)` directly.  Much nicer flow from bravado since the config dict is just passed through from `bravado.client.SwaggerClient`.