### PR TITLE
Don't create an operation out of path parameters (with unit test)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+3.1.1 (2015-XX-XX)
+------------------
+- Fix the creation of operations that contain shared parameters for a given endpoint.
+
 3.1.0 (2015-10-19)
 ------------------
 - Added http ``headers`` to ``bravado_core.response.IncomingResponse``.

--- a/bravado_core/resource.py
+++ b/bravado_core/resource.py
@@ -49,7 +49,6 @@ def build_resources(swagger_spec):
     paths = swagger_spec.spec_dict['paths']
     for path_name, path_spec in iteritems(paths):
         for http_method, operation_spec in iteritems(path_spec):
-            
             # parameters that are shared across all operations for
             # a given endpoint are also defined at this level - we
             # just need to skip over them.

--- a/bravado_core/resource.py
+++ b/bravado_core/resource.py
@@ -49,6 +49,10 @@ def build_resources(swagger_spec):
     paths = swagger_spec.spec_dict['paths']
     for path_name, path_spec in iteritems(paths):
         for http_method, operation_spec in iteritems(path_spec):
+            
+            # parameters that are shared across all operations for
+            # a given endpoint are also defined at this level - we
+            # just need to skip over them.
             if http_method == 'parameters':
                 continue
 

--- a/tests/resource/build_resources_test.py
+++ b/tests/resource/build_resources_test.py
@@ -1,3 +1,4 @@
+from bravado_core.param import Param
 from bravado_core.resource import build_resources
 from bravado_core.spec import Spec
 
@@ -37,3 +38,20 @@ def test_many_resources_with_the_same_operation_cuz_multiple_tags(paths_spec):
     assert len(tags) == len(resources)
     for tag in tags:
         assert resources[tag].findPetsByStatus
+
+
+def test_resource_with_shared_parameters(paths_spec):
+    # insert a shared parameter into the spec
+    shared_parameter = {
+        'name': 'filter',
+        'in': 'query',
+        'description': 'Filter the pets by attribute',
+        'required': False,
+        'type': 'string',
+    }
+    paths_spec['/pet/findByStatus']['parameters'] = [shared_parameter]
+    spec_dict = {'paths': paths_spec}
+    resources = build_resources(Spec(spec_dict))
+    # verify shared param associated with operation
+    assert isinstance(
+        resources['pet'].findPetsByStatus.params['filter'], Param)


### PR DESCRIPTION
Builds on PR #56 by adding a unit test.