### PR TITLE
Add support for marshalling dict-like objects.

### DIFF
--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -1,5 +1,10 @@
 from bravado_core.exception import SwaggerMappingError
 
+try:
+    from collections import Mapping
+except ImportError:
+    from collections.abc import Mapping
+
 # 'object' and 'array' are omitted since this should really be read as
 # "Swagger types that map to python primitives"
 SWAGGER_PRIMITIVES = (
@@ -45,8 +50,7 @@ def is_dict_like(spec):
     :param spec: swagger object specification in dict form
     :rtype: boolean
     """
-    # TODO: check magic method instead
-    return type(spec) == dict
+    return isinstance(spec, Mapping)
 
 
 def is_list_like(spec):

--- a/tests/marshal/marshal_schema_object_test.py
+++ b/tests/marshal/marshal_schema_object_test.py
@@ -1,4 +1,5 @@
 import copy
+from collections import defaultdict
 
 import pytest
 
@@ -24,6 +25,28 @@ def test_dicts_can_be_used_instead_of_models(petstore_dict):
             {'id': 100, 'name': 'brown'},
         ],
     }
+    expected = copy.deepcopy(pet)
+    result = marshal_schema_object(petstore_spec, pet_spec, pet)
+    assert expected == result
+
+
+def test_defaultdicts_can_be_used_instead_of_models(petstore_dict):
+    petstore_spec = Spec.from_dict(petstore_dict)
+    pet_spec = petstore_spec.spec_dict['definitions']['Pet']
+    pet = defaultdict(None, {
+        'id': 1,
+        'name': 'Fido',
+        'status': 'sold',
+        'photoUrls': ['wagtail.png', 'bark.png'],
+        'category': {
+            'id': 200,
+            'name': 'friendly',
+        },
+        'tags': [
+            {'id': 99, 'name': 'mini'},
+            {'id': 100, 'name': 'brown'},
+        ],
+    })
     expected = copy.deepcopy(pet)
     result = marshal_schema_object(petstore_spec, pet_spec, pet)
     assert expected == result


### PR DESCRIPTION
The `is_dict_like` function in `schema.py` was just checking if the
object's type was a dict.  This causes it to treat any dict subclass as
a model, which fails because dict subclasses are not models.

Updating to check if the item is an instance of `collections.Mapping`
(or `collections.abc.Mapping` on python 3) fixes this.