### PR TITLE
Allow null option for properties

### DIFF
--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -38,6 +38,10 @@ def is_param_spec(swagger_spec, schema_object_spec):
     return 'in' in swagger_spec.deref(schema_object_spec)
 
 
+def is_prop_nullable(swagger_spec, schema_object_spec):
+    return swagger_spec.deref(schema_object_spec).get('x-nullable', False)
+
+
 def is_ref(spec):
     return is_dict_like(spec) and '$ref' in spec
 

--- a/tests/schema/is_prop_nullable_test.py
+++ b/tests/schema/is_prop_nullable_test.py
@@ -1,0 +1,48 @@
+from bravado_core.schema import is_prop_nullable
+from bravado_core.spec import Spec
+
+
+def test_true(minimal_swagger_spec):
+    prop_spec = {
+        'type': 'string',
+        'x-nullable': True,
+    }
+    assert is_prop_nullable(minimal_swagger_spec, prop_spec)
+
+
+def test_false(minimal_swagger_spec):
+    prop_spec = {
+        'type': 'string',
+    }
+    assert not is_prop_nullable(minimal_swagger_spec, prop_spec)
+
+
+def test_false_explicit(minimal_swagger_spec):
+    prop_spec = {
+        'type': 'string',
+        'x-nullable': False,
+    }
+    assert not is_prop_nullable(minimal_swagger_spec, prop_spec)
+
+
+def test_ref_true(minimal_swagger_dict):
+    minimal_swagger_dict['definitions'] = {
+        'Pet': {
+            'type': 'object',
+            'x-nullable': True,
+        }
+    }
+    param_spec = {'$ref': '#/definitions/Pet'}
+    swagger_spec = Spec.from_dict(minimal_swagger_dict)
+    assert is_prop_nullable(swagger_spec, param_spec)
+
+
+def test_ref_false(minimal_swagger_dict):
+    minimal_swagger_dict['definitions'] = {
+        'Pet': {
+            'type': 'object',
+        }
+    }
+    param_spec = {'$ref': '#/definitions/Pet'}
+    swagger_spec = Spec.from_dict(minimal_swagger_dict)
+    assert not is_prop_nullable(swagger_spec, param_spec)

--- a/tests/swagger20_validator/type_validator_test.py
+++ b/tests/swagger20_validator/type_validator_test.py
@@ -34,3 +34,25 @@ def test_validate_when_not_a_parameter_schema(m_draft4_type_validator,
             string_schema)
     list(type_validator(minimal_swagger_spec, *args))
     m_draft4_type_validator.assert_called_once_with(*args)
+
+
+@patch('jsonschema._validators.type_draft4')
+def test_skip_when_nullable_property_schema_and_value_is_None(
+        m_draft4_type_validator, minimal_swagger_spec):
+    param_schema = {'name': 'foo', 'x-nullable': True, 'type': 'string'}
+    type_validator(
+        minimal_swagger_spec,
+        validator=None,
+        types=param_schema['type'],
+        instance=None,  # property value
+        schema=param_schema)
+    assert m_draft4_type_validator.call_count == 0
+
+
+@patch('jsonschema._validators.type_draft4')
+def test_validate_when_not_nullable_property_schema_and_value_is_None(
+        m_draft4_type_validator, minimal_swagger_spec):
+    param_schema = {'name': 'foo', 'x-nullable': False, 'type': 'string'}
+    args = (None, param_schema['type'], None, param_schema)
+    type_validator(minimal_swagger_spec, *args)
+    m_draft4_type_validator.assert_called_once_with(*args)

--- a/tests/swagger20_validator/type_validator_test.py
+++ b/tests/swagger20_validator/type_validator_test.py
@@ -39,20 +39,20 @@ def test_validate_when_not_a_parameter_schema(m_draft4_type_validator,
 @patch('jsonschema._validators.type_draft4')
 def test_skip_when_nullable_property_schema_and_value_is_None(
         m_draft4_type_validator, minimal_swagger_spec):
-    param_schema = {'name': 'foo', 'x-nullable': True, 'type': 'string'}
-    type_validator(
+    prop_schema = {'x-nullable': True, 'type': 'string'}
+    list(type_validator(
         minimal_swagger_spec,
         validator=None,
-        types=param_schema['type'],
+        types=prop_schema['type'],
         instance=None,  # property value
-        schema=param_schema)
+        schema=prop_schema))
     assert m_draft4_type_validator.call_count == 0
 
 
 @patch('jsonschema._validators.type_draft4')
 def test_validate_when_not_nullable_property_schema_and_value_is_None(
         m_draft4_type_validator, minimal_swagger_spec):
-    param_schema = {'name': 'foo', 'x-nullable': False, 'type': 'string'}
-    args = (None, param_schema['type'], None, param_schema)
-    type_validator(minimal_swagger_spec, *args)
+    prop_schema = {'x-nullable': False, 'type': 'string'}
+    args = (None, prop_schema['type'], None, prop_schema)
+    list(type_validator(minimal_swagger_spec, *args))
     m_draft4_type_validator.assert_called_once_with(*args)

--- a/tests/unmarshal/unmarshal_nullable_test.py
+++ b/tests/unmarshal/unmarshal_nullable_test.py
@@ -5,60 +5,66 @@ from bravado_core.validate import validate_schema_object
 from jsonschema.exceptions import ValidationError
 
 
-@pytest.mark.parametrize('value', ['x', None])
-@pytest.mark.parametrize('nullable', [True, False])
-def test_unmarshal_with_primitive(empty_swagger_spec, value, nullable):
-    """If the value is a primitive, validation should pass if
-    `x-nullable` is `True` and the value is `None`. `required` is not
-    possible in this scenario.
+"""If the value is a primitive, validation should pass if
+`x-nullable` is `True` and the value is `None`. `required` is not
+possible in this scenario.
 
-    +---------------------+--------------+
-    | x-nullable == False | 'x'  -> pass |
-    |                     | None -> fail |
-    +---------------------+--------------+
-    | x-nullable == True  | 'x'  -> pass |
-    |                     | None -> pass |
-    +---------------------+--------------+
-    """
++---------------------+------------------+
+| x-nullable == False | 'x'  -> pass (1) |
+|                     | None -> fail (2) |
++---------------------+------------------+
+| x-nullable == True  | 'x'  -> pass (3) |
+|                     | None -> pass (4) |
++---------------------+------------------+
+"""
+
+
+@pytest.mark.parametrize(['nullable', 'value'],
+                         [(False, 'x'), (True, 'x'), (True, None)])
+def test_unmarshal_with_primitive_pass(empty_swagger_spec, value, nullable):
+    """Test scenarios in which validation should pass: (1), (3), (4)"""
     content_spec = {
         'type': 'string',
         'x-nullable': nullable,
     }
-
-    try:
-        validate_schema_object(empty_swagger_spec, content_spec, value)
-        result = unmarshal_schema_object(
-            empty_swagger_spec, content_spec, value)
-    except ValidationError as e:
-        result = e
-
-    if nullable is False and not value:
-        assert result.message == "None is not of type 'string'"
-    else:
-        assert result == value
+    validate_schema_object(empty_swagger_spec, content_spec, value)
+    result = unmarshal_schema_object(empty_swagger_spec, content_spec, value)
+    assert result == value
 
 
-@pytest.mark.parametrize('value', [{'x': 'y'}, {'x': None}, {}])
-@pytest.mark.parametrize('nullable', [True, False])
-@pytest.mark.parametrize('required', [True, False])
-def test_unmarshal_with_object(empty_swagger_spec, value, nullable, required):
-    """If the value is an object, validation should pass if
-    `x-nullable` is `True` and the value is `None`. `required` doesn't
-    have an influence.
-
-    +---------------------+---------------------+---------------------+
-    |                     | required == False   | required == True    |
-    +---------------------+---------------------+---------------------+
-    | x-nullable == False | {}          -> pass | {}          -> fail |
-    |                     | {'x': 'y'}  -> pass | {'x': 'y'}  -> pass |
-    |                     | {'x': None} -> fail | {'x': None} -> fail |
-    +---------------------+---------------------+---------------------+
-    | x-nullable == True  | {}          -> pass | {}          -> fail |
-    |                     | {'x': 'y'}  -> pass | {'x': 'y'}  -> pass |
-    |                     | {'x': None} -> pass | {'x': None} -> pass |
-    +---------------------+---------------------+---------------------+
-    """
+def test_unmarshal_with_primitive_fail(empty_swagger_spec):
+    """Test scenarios in which validation should fail: (2)"""
     content_spec = {
+        'type': 'string',
+        'x-nullable': False,
+    }
+    value = None
+    with pytest.raises(ValidationError) as excinfo:
+        validate_schema_object(empty_swagger_spec, content_spec, value)
+        unmarshal_schema_object(empty_swagger_spec, content_spec, value)
+    assert excinfo.value.message == "None is not of type 'string'"
+
+
+"""If the value is an object, validation should pass if
+`x-nullable` is `True` and the value is `None`. `required` doesn't
+have an influence.
+
++---------------------+-------------------------+--------------------------+
+|                     | required == False       | required == True         |
++---------------------+-------------------------+--------------------------+
+| x-nullable == False | {}          -> pass (1) | {}          -> fail  (4) |
+|                     | {'x': 'y'}  -> pass (2) | {'x': 'y'}  -> pass  (5) |
+|                     | {'x': None} -> fail (3) | {'x': None} -> fail  (6) |
++---------------------+-------------------------+--------------------------+
+| x-nullable == True  | {}          -> pass (7) | {}          -> fail (10) |
+|                     | {'x': 'y'}  -> pass (8) | {'x': 'y'}  -> pass (11) |
+|                     | {'x': None} -> pass (9) | {'x': None} -> pass (12) |
++---------------------+-------------------------+--------------------------+
+"""
+
+
+def content_spec_factory(required, nullable):
+    return {
         'type': 'object',
         'required': ['x'] if required else [],
         'properties': {
@@ -69,19 +75,68 @@ def test_unmarshal_with_object(empty_swagger_spec, value, nullable, required):
         }
     }
 
-    try:
-        validate_schema_object(empty_swagger_spec, content_spec, value)
-        result = unmarshal_schema_object(
-            empty_swagger_spec, content_spec, value)
-    except ValidationError as e:
-        result = e
 
-    if value == {} and required is True:
-        assert result.message == "'x' is a required property"
-    elif value == {} and required is False:
-        # Unmarshal re-introduces missing properties with None which is ok.
-        assert result == {'x': None}
-    elif nullable is False and value['x'] is None:
-        assert result.message == "None is not of type 'string'"
-    else:
-        result == value
+@pytest.mark.parametrize('nullable', [True, False])
+@pytest.mark.parametrize('required', [True, False])
+def test_unmarshal_with_object_default(empty_swagger_spec, nullable, required):
+    """With a value set, validation should always pass: (2), (5), (8), (11)"""
+    content_spec = content_spec_factory(required, nullable)
+    value = {'x': 'y'}
+
+    validate_schema_object(empty_swagger_spec, content_spec, value)
+    result = unmarshal_schema_object(empty_swagger_spec, content_spec, value)
+    assert result == value
+
+
+@pytest.mark.parametrize('nullable', [True, False])
+def test_unmarshal_with_object_req_no_value(empty_swagger_spec, nullable):
+    """When the value is required but not set at all, validation
+    should fail: (4), (10)
+    """
+    content_spec = content_spec_factory(True, nullable)
+    value = {}
+
+    with pytest.raises(ValidationError) as excinfo:
+        validate_schema_object(empty_swagger_spec, content_spec, value)
+        unmarshal_schema_object(empty_swagger_spec, content_spec, value)
+    assert excinfo.value.message == "'x' is a required property"
+
+
+@pytest.mark.parametrize('nullable', [True, False])
+def test_unmarshal_with_object_no_req_no_value(empty_swagger_spec, nullable):
+    """When the value is not required and not set at all, validation
+    should pass: (1), (7)
+    """
+    content_spec = content_spec_factory(False, nullable=nullable)
+    value = {}
+
+    validate_schema_object(empty_swagger_spec, content_spec, value)
+    result = unmarshal_schema_object(empty_swagger_spec, content_spec, value)
+    assert result == {'x': None}  # Missing parameters are re-introduced
+
+
+@pytest.mark.parametrize('required', [True, False])
+def test_unmarshal_with_object_no_null_value_none(empty_swagger_spec, required):
+    """When nullable is `False` and the value is set to `None`, validation
+    should fail: (3), (6)
+    """
+    content_spec = content_spec_factory(required, False)
+    value = {'x': None}
+
+    with pytest.raises(ValidationError) as excinfo:
+        validate_schema_object(empty_swagger_spec, content_spec, value)
+        unmarshal_schema_object(empty_swagger_spec, content_spec, value)
+    assert excinfo.value.message == "None is not of type 'string'"
+
+
+@pytest.mark.parametrize('required', [True, False])
+def test_unmarshal_with_object_null_value_none(empty_swagger_spec, required):
+    """When nullable is `True` and the value is set to `None`, validation
+    should pass: (9), (12)
+    """
+    content_spec = content_spec_factory(required, True)
+    value = {'x': None}
+
+    validate_schema_object(empty_swagger_spec, content_spec, value)
+    result = unmarshal_schema_object(empty_swagger_spec, content_spec, value)
+    assert result == {'x': None}

--- a/tests/unmarshal/unmarshal_nullable_test.py
+++ b/tests/unmarshal/unmarshal_nullable_test.py
@@ -1,0 +1,87 @@
+import pytest
+
+from bravado_core.unmarshal import unmarshal_schema_object
+from bravado_core.validate import validate_schema_object
+from jsonschema.exceptions import ValidationError
+
+
+@pytest.mark.parametrize('value', ['x', None])
+@pytest.mark.parametrize('nullable', [True, False])
+def test_unmarshal_with_primitive(empty_swagger_spec, value, nullable):
+    """If the value is a primitive, validation should pass if
+    `x-nullable` is `True` and the value is `None`. `required` is not
+    possible in this scenario.
+
+    +---------------------+--------------+
+    | x-nullable == False | 'x'  -> pass |
+    |                     | None -> fail |
+    +---------------------+--------------+
+    | x-nullable == True  | 'x'  -> pass |
+    |                     | None -> pass |
+    +---------------------+--------------+
+    """
+    content_spec = {
+        'type': 'string',
+        'x-nullable': nullable,
+    }
+
+    try:
+        validate_schema_object(empty_swagger_spec, content_spec, value)
+        result = unmarshal_schema_object(
+            empty_swagger_spec, content_spec, value)
+    except ValidationError as e:
+        result = e
+
+    if nullable is False and not value:
+        assert result.message == "None is not of type 'string'"
+    else:
+        assert result == value
+
+
+@pytest.mark.parametrize('value', [{'x': 'y'}, {'x': None}, {}])
+@pytest.mark.parametrize('nullable', [True, False])
+@pytest.mark.parametrize('required', [True, False])
+def test_unmarshal_with_object(empty_swagger_spec, value, nullable, required):
+    """If the value is an object, validation should pass if
+    `x-nullable` is `True` and the value is `None`. `required` doesn't
+    have an influence.
+
+    +---------------------+---------------------+---------------------+
+    |                     | required == False   | required == True    |
+    +---------------------+---------------------+---------------------+
+    | x-nullable == False | {}          -> pass | {}          -> fail |
+    |                     | {'x': 'y'}  -> pass | {'x': 'y'}  -> pass |
+    |                     | {'x': None} -> fail | {'x': None} -> fail |
+    +---------------------+---------------------+---------------------+
+    | x-nullable == True  | {}          -> pass | {}          -> fail |
+    |                     | {'x': 'y'}  -> pass | {'x': 'y'}  -> pass |
+    |                     | {'x': None} -> pass | {'x': None} -> pass |
+    +---------------------+---------------------+---------------------+
+    """
+    content_spec = {
+        'type': 'object',
+        'required': ['x'] if required else [],
+        'properties': {
+            'x': {
+                'type': 'string',
+                'x-nullable': nullable,
+            }
+        }
+    }
+
+    try:
+        validate_schema_object(empty_swagger_spec, content_spec, value)
+        result = unmarshal_schema_object(
+            empty_swagger_spec, content_spec, value)
+    except ValidationError as e:
+        result = e
+
+    if value == {} and required is True:
+        assert result.message == "'x' is a required property"
+    elif value == {} and required is False:
+        # Unmarshal re-introduces missing properties with None which is ok.
+        assert result == {'x': None}
+    elif nullable is False and value['x'] is None:
+        assert result.message == "None is not of type 'string'"
+    else:
+        result == value


### PR DESCRIPTION
Proposal for solving #47

The Swagger specification in version 2 doesn't support 'null' as
property value. This adds a vendor extension 'x-nullable' which
allows properties to be 'null' if set to 'true'.