### PR TITLE
Fix for unmarshalling array query param that is optional

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+4.0.1 (2016-XX-XX)
+------------------
+- Fix unmarshalling of an optional array query parameter when not passed in the
+  query string.
+
 4.0.0 (2015-11-17)
 ------------------
 - Support for recursive $refs - Issue #35

--- a/bravado_core/param.py
+++ b/bravado_core/param.py
@@ -301,10 +301,15 @@ def unmarshal_collection_format(swagger_spec, param_spec, value):
         # http client lib should have already unmarshaled to an array
         return value
 
+    if value is None and not schema.is_required(swagger_spec, param_spec):
+        # Just pass through an optional array that has no value
+        return None
+
     sep = COLLECTION_FORMATS[collection_format]
     items_spec = param_spec['items']
     items_type = deref(items_spec).get('type')
     param_name = param_spec['name']
+
     return [
         cast_request_param(items_type, param_name, item)
         for item in value.split(sep)

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -83,6 +83,9 @@ def unmarshal_array(swagger_spec, array_spec, array_value):
     :raises: SwaggerMappingError
     """
     if not is_list_like(array_value):
+        if array_value is None and not schema.is_required(swagger_spec,
+                                                          array_spec):
+            return None
         raise SwaggerMappingError('Expected list like type for {0}:{1}'.format(
             type(array_value), array_value))
 

--- a/tests/param/unmarshal_collection_format_test.py
+++ b/tests/param/unmarshal_collection_format_test.py
@@ -51,3 +51,8 @@ def test_ref(minimal_swagger_dict, array_spec):
         param_value = sep.join(['1', '2', '3'])
         assert [1, 2, 3] == unmarshal_collection_format(
             swagger_spec, ref_spec, param_value)
+
+
+def test_array_is_none_and_not_required(empty_swagger_spec, array_spec):
+    assert unmarshal_collection_format(empty_swagger_spec, array_spec,
+                                       value=None) is None

--- a/tests/param/unmarshal_param_test.py
+++ b/tests/param/unmarshal_param_test.py
@@ -78,6 +78,17 @@ def test_query_array(empty_swagger_spec, array_param_spec):
     assert ['cat', 'dog', 'mouse'] == unmarshal_param(param, request)
 
 
+def test_optional_query_array_with_no_default(empty_swagger_spec,
+                                              array_param_spec):
+    array_param_spec['required'] = False
+    # Set to something other than 'mutli' because 'multi' is a no-op in
+    # unmarshal_collection_format()
+    array_param_spec['collectionFormat'] = 'csv'
+    param = Param(empty_swagger_spec, Mock(spec=Operation), array_param_spec)
+    request = Mock(spec=IncomingRequest, query={})
+    assert unmarshal_param(param, request) is None
+
+
 def test_optional_query_array_with_default(
         empty_swagger_spec, array_param_spec):
     array_param_spec['required'] = False

--- a/tests/param/unmarshal_param_test.py
+++ b/tests/param/unmarshal_param_test.py
@@ -81,7 +81,7 @@ def test_query_array(empty_swagger_spec, array_param_spec):
 def test_optional_query_array_with_no_default(empty_swagger_spec,
                                               array_param_spec):
     array_param_spec['required'] = False
-    # Set to something other than 'mutli' because 'multi' is a no-op in
+    # Set to something other than 'multi' because 'multi' is a no-op in
     # unmarshal_collection_format()
     array_param_spec['collectionFormat'] = 'csv'
     param = Param(empty_swagger_spec, Mock(spec=Operation), array_param_spec)


### PR DESCRIPTION
From @tomelm 

Unmarshalling fails when the below parameter is not present in the request's query string

```
http://foo.com/search/v1?term=burrito&location=sf
```

```json
                    {
                        "name": "categories",
                        "description": "The categories to filter on",
                        "in": "query",
                        "required": false,
                        "type": "array",
                        "items": {
                            "name": "category",
                            "type": "string"
                        }
                    },
```

```json
{
  "traceback": [
    "Traceback (most recent call last):\n",
    "  File \"/nail/home/telmalem/pg/yelp-main/virtualenv_run/lib/python2.7/site-packages/pyramid/tweens.py\", line 21, in excview_tween\n    response = handler(request)\n",
    "  File \"/nail/home/telmalem/pg/yelp-main/virtualenv_run/lib/python2.7/site-packages/pyramid_swagger/tween.py\", line 170, in validator_tween\n    validation_context=validation_context)\n",
    "  File \"/nail/home/telmalem/pg/yelp-main/virtualenv_run/lib/python2.7/site-packages/pyramid_swagger/tween.py\", line 412, in _validate\n    return f(*args, **kwargs)\n",
    "  File \"/nail/home/telmalem/pg/yelp-main/virtualenv_run/lib/python2.7/site-packages/pyramid_swagger/tween.py\", line 521, in swaggerize_request\n    request_data = unmarshal_request(request, op)\n",
    "  File \"/nail/home/telmalem/pg/yelp-main/virtualenv_run/lib/python2.7/site-packages/bravado_core/request.py\", line 60, in unmarshal_request\n    param_value = unmarshal_param(param, request)\n",
    "  File \"/nail/home/telmalem/pg/yelp-main/virtualenv_run/lib/python2.7/site-packages/bravado_core/param.py\", line 171, in unmarshal_param\n    raw_value = unmarshal_collection_format(param_spec, raw_value)\n",
    "  File \"/nail/home/telmalem/pg/yelp-main/virtualenv_run/lib/python2.7/site-packages/bravado_core/param.py\", line 294, in unmarshal_collection_format\n    for item in value.split(sep)\n",
    "AttributeError: NoneType object has no attribute split\n"
  ],
```