### PR TITLE
Updated test so that behavior reflects its name

### DIFF
--- a/tests/param/unmarshal_param_test.py
+++ b/tests/param/unmarshal_param_test.py
@@ -63,7 +63,7 @@ def test_query_string(empty_swagger_spec, string_param_spec):
 
 def test_optional_query_string_with_default(
         empty_swagger_spec, string_param_spec):
-    string_param_spec['required'] = True
+    string_param_spec['required'] = False
     string_param_spec['default'] = 'bozo'
     param = Param(empty_swagger_spec, Mock(spec=Operation), string_param_spec)
     request = Mock(spec=IncomingRequest, query={})


### PR DESCRIPTION
`test_optional_query_string_with_default` implies that the param is optional, previously the param string was described as `string_param_spec['required'] = True` it seems to me that it should actually be `False`. 