### PR TITLE
Gracefully handle empty quotes for ints, floats, and booleans

### DIFF
--- a/bravado_core/param.py
+++ b/bravado_core/param.py
@@ -38,6 +38,7 @@ class Param(object):
     :type op: :class:`bravado_core.operation.Operation`
     :type param_spec: parameter specification in dict form
     """
+
     def __init__(self, swagger_spec, op, param_spec):
         self.op = op
         self.swagger_spec = swagger_spec
@@ -204,6 +205,9 @@ def cast_request_param(param_type, param_name, param_value):
     :type  param_value: string
     """
     if param_value is None:
+        return None
+
+    if param_type in CAST_TYPE_TO_FUNC.keys() and param_value == '':
         return None
 
     try:

--- a/bravado_core/param.py
+++ b/bravado_core/param.py
@@ -207,7 +207,7 @@ def cast_request_param(param_type, param_name, param_value):
     if param_value is None:
         return None
 
-    if param_type in CAST_TYPE_TO_FUNC.keys() and param_value == '':
+    if param_type in CAST_TYPE_TO_FUNC and param_value == '':
         return None
 
     try:

--- a/tests/param/cast_request_param_test.py
+++ b/tests/param/cast_request_param_test.py
@@ -7,13 +7,25 @@ def test_integer():
     assert 34 == cast_request_param('integer', 'biz_id', '34')
 
 
+def test_empty_string_becomes_none_for_type_integer():
+    assert cast_request_param('integer', 'biz_id', '') is None
+
+
 def test_boolean():
     assert cast_request_param('boolean', 'is_open', 1)
     assert not cast_request_param('boolean', 'is_open', 0)
 
 
+def test_empty_string_becomes_none_for_type_boolean():
+    assert cast_request_param('boolean', 'is_open', '') is None
+
+
 def test_number():
     assert 2.34 == cast_request_param('number', 'score', '2.34')
+
+
+def test_empty_string_becomes_none_for_type_number():
+    assert cast_request_param('number', 'score', '') is None
 
 
 def test_unknown_type_returns_untouched_value():

--- a/tests/param/unmarshal_param_test.py
+++ b/tests/param/unmarshal_param_test.py
@@ -63,7 +63,7 @@ def test_query_string(empty_swagger_spec, string_param_spec):
 
 def test_optional_query_string_with_default(
         empty_swagger_spec, string_param_spec):
-    string_param_spec['required'] = True
+    string_param_spec['required'] = False
     string_param_spec['default'] = 'bozo'
     param = Param(empty_swagger_spec, Mock(spec=Operation), string_param_spec)
     request = Mock(spec=IncomingRequest, query={})


### PR DESCRIPTION
This closes the issue I opened, #68 