### PR TITLE
Make spec_dict available without internal x-scope metadata

### DIFF
--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -71,7 +71,8 @@ class Spec(object):
         self.api_url = None
         self.config = dict(CONFIG_DEFAULTS, **(config or {}))
 
-        # Cached copy of spec_dict with x-scope metadata removed. See @property
+        # Cached copy of spec_dict with x-scope metadata removed.
+        # See @property client_spec_dict().
         self._client_spec_dict = None
 
         # (key, value) = (simple format def name, Model type)

--- a/tests/spec/strip_xscope_test.py
+++ b/tests/spec/strip_xscope_test.py
@@ -1,0 +1,57 @@
+from bravado_core.spec import strip_xscope
+
+
+def test_empty():
+    assert {} == strip_xscope({})
+
+
+def test_contained_in_dict():
+    fragment = {
+      'MON': {
+        '$ref': '#/definitions/DayHours',
+        'x-scope': [
+            'file:///happyhour/api_docs/swagger.json',
+            'file:///happyhour/api_docs/swagger.json#/definitions/WeekHours'
+        ]
+      }
+    }
+    expected = {
+      'MON': {
+        '$ref': '#/definitions/DayHours',
+      }
+    }
+    assert expected == strip_xscope(fragment)
+    assert 'x-scope' in fragment['MON']
+
+
+def test_contained_in_list():
+    fragment = [
+      {
+        '$ref': '#/definitions/DayHours',
+        'x-scope': [
+            'file:///happyhour/api_docs/swagger.json',
+            'file:///happyhour/api_docs/swagger.json#/definitions/WeekHours'
+        ]
+      }
+    ]
+    expected = [
+      {
+        '$ref': '#/definitions/DayHours',
+      }
+    ]
+    assert expected == strip_xscope(fragment)
+    assert 'x-scope' in fragment[0]
+
+
+def test_no_op():
+    fragment = {
+      'MON': {
+        '$ref': '#/definitions/DayHours',
+      }
+    }
+    expected = {
+      'MON': {
+        '$ref': '#/definitions/DayHours',
+      }
+    }
+    assert expected == strip_xscope(fragment)


### PR DESCRIPTION
Fix for #78 

Server-side libraries that use bravado-core (such as pyramid-swagger) now have access to the Swagger spec in dict form without the internally attached x-scope metadata.

```python
spec = Spec.from_dict(spec_dict)
# spec_dict suitable for serving up to Swagger clients
print spec.client_spec_dict
```
Given the options available, this bubbled up as the most straight-forward way to maintain backward compatibility, retain the mutability necessary to tag models, and provide server-side libraries access to the stripping behavior for subsequent remote $ref requests via ``bravado_core.spec.strip_xscope``.

Tested with example_happyhour (a single line change was necessary to pyramid_swagger - will submit PR after this is merged and released).