### PR TITLE
Use x-scope annotations when resolving refs during request/response validation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ Changelog
 4.2.1 (2016-XX-XX)
 ------------------
 - Fix optional enums in request params - Issue #77
+- Fix resolving refs during validation - Issue #82
 
 4.2.0 (2016-03-10)
 ------------------

--- a/bravado_core/swagger20_validator.py
+++ b/bravado_core/swagger20_validator.py
@@ -97,8 +97,6 @@ def ref_validator(validator, ref, instance, schema):
      validation to use the `x-scope` annotations that were created during spec
      ingestion (see post_process_spec in spec.py).
 
-    :param swagger_spec: needed for access to deref()
-    :type swagger_spec: :class:`bravado_core.spec.Spec`
     :param validator: Validator class used to validate the object
     :type validator: :class: `Swagger20Validator` or
         :class: `jsonschema.validators.Draft4Validator`
@@ -109,7 +107,9 @@ def ref_validator(validator, ref, instance, schema):
         eg {'$ref': '#/foo/bar/Baz'}
     :type schema: dict
     """
-    resolve = getattr(validator.resolver, "resolve", None)
+    # This is a copy of jsonscehama._validators.ref(..) with the
+    # in_scope(..) context manager applied before any refs are resolved.
+    resolve = getattr(validator.resolver, "resolve")
     if resolve is None:
         with in_scope(validator.resolver, schema):
             with validator.resolver.resolving(ref) as resolved:

--- a/bravado_core/swagger20_validator.py
+++ b/bravado_core/swagger20_validator.py
@@ -6,6 +6,7 @@ from jsonschema.validators import Draft4Validator
 
 from bravado_core.schema import is_param_spec
 from bravado_core.schema import is_required
+from swagger_spec_validator.ref_validators import in_scope
 
 """Draft4Validator is not completely compatible with Swagger 2.0 schema
 objects like parameter, etc. Swagger20Validator is an extension of
@@ -68,7 +69,7 @@ def enum_validator(swagger_spec, validator, enums, instance, schema):
     :type swagger_spec: :class:`bravado_core.spec.Spec`
     :param validator: Validator class used to validate the object
     :type validator: :class: `Swagger20Validator` or
-                             `jsonschema.validators.Draft4Validator`
+        :class: `jsonschema.validators.Draft4Validator`
     :param enums: allowed enum values
     :type enums: list
     :param instance: enum instance value
@@ -87,6 +88,45 @@ def enum_validator(swagger_spec, validator, enums, instance, schema):
     return _validators.enum(validator, enums, instance, schema)
 
 
+def ref_validator(validator, ref, instance, schema):
+    """When validating a request or response that contain $refs, jsonschema's
+     RefResolver only contains scope (RefResolver._scopes_stack) for the
+     request_spec or response_spec that it is fed. This scope doesn't contain
+     the full scope built when ingesting the spec from its root
+     (#/ in swagger.json). So, we need to modify the behavior of ref
+     validation to use the `x-scope` annotations that were created during spec
+     ingestion (see post_process_spec in spec.py).
+
+    :param swagger_spec: needed for access to deref()
+    :type swagger_spec: :class:`bravado_core.spec.Spec`
+    :param validator: Validator class used to validate the object
+    :type validator: :class: `Swagger20Validator` or
+        :class: `jsonschema.validators.Draft4Validator`
+    :param ref: the target of the ref. eg. #/foo/bar/Baz
+    :type ref: string
+    :param instance: the object being validated
+    :param schema: swagger spec that contains the ref.
+        eg {'$ref': '#/foo/bar/Baz'}
+    :type schema: dict
+    """
+    resolve = getattr(validator.resolver, "resolve", None)
+    if resolve is None:
+        with in_scope(validator.resolver, schema):
+            with validator.resolver.resolving(ref) as resolved:
+                for error in validator.descend(instance, resolved):
+                    yield error
+    else:
+        with in_scope(validator.resolver, schema):
+            scope, resolved = validator.resolver.resolve(ref)
+        validator.resolver.push_scope(scope)
+
+        try:
+            for error in validator.descend(instance, resolved):
+                yield error
+        finally:
+            validator.resolver.pop_scope()
+
+
 def get_validator_type(swagger_spec):
     """Create a custom jsonschema validator for Swagger 2.0 specs.
 
@@ -95,6 +135,7 @@ def get_validator_type(swagger_spec):
     return validators.extend(
         Draft4Validator,
         {
+            '$ref': ref_validator,
             'required': functools.partial(required_validator, swagger_spec),
             'enum': functools.partial(enum_validator, swagger_spec),
             'type': functools.partial(type_validator, swagger_spec),

--- a/tests/swagger20_validator/ref_validator_test.py
+++ b/tests/swagger20_validator/ref_validator_test.py
@@ -91,8 +91,6 @@ def test_when_resolve_is_not_None(address_target, address, original_scope,
     assert mock_validator.resolver._scopes_stack == original_scope
 
 
-@pytest.mark.skip(reason="Can't get mock + context managers to work. "
-                         "Leaving partially authored test to pick up later.")
 def test_when_resolve_is_None(address_target, address, original_scope,
                               annotated_scope, address_ref, address_schema,
                               mock_validator):
@@ -104,7 +102,7 @@ def test_when_resolve_is_None(address_target, address, original_scope,
         return 'file:///tmp/swagger.json', address_target
 
     mock_validator.resolver.resolve = None
-    mock_validator.resolver.resolving = MagicMock(
+    mock_validator.resolver.resolving.return_value = MagicMock(
         side_effect=assert_correct_scope_and_resolve)
 
     # Force iteration over generator function

--- a/tests/swagger20_validator/ref_validator_test.py
+++ b/tests/swagger20_validator/ref_validator_test.py
@@ -1,0 +1,114 @@
+import pytest
+from jsonschema.validators import Draft4Validator
+from jsonschema.validators import RefResolver
+from mock import Mock, MagicMock
+
+from bravado_core.swagger20_validator import ref_validator
+
+
+@pytest.fixture
+def address_target():
+    return {
+        'type': 'object',
+        'properties': {
+            'street': {
+                'type': 'string',
+            },
+            'city': {
+                'type': 'string',
+            },
+            'state': {
+                'type': 'string',
+            },
+        },
+        'required': ['street', 'city', 'state'],
+    }
+
+
+@pytest.fixture
+def address_ref():
+    return '#/definitions/Address'
+
+
+@pytest.fixture
+def address_schema(address_ref, annotated_scope):
+    return {
+        '$ref': address_ref,
+        'x-scope': annotated_scope,
+    }
+
+
+@pytest.fixture
+def address():
+    return {
+        'street': '1000 Main St',
+        'city': 'Austin',
+        'state': 'TX',
+    }
+
+
+@pytest.fixture
+def original_scope():
+    return ['file:///tmp/swagger.json']
+
+
+@pytest.fixture
+def annotated_scope():
+    return [
+        'file:///tmp/swagger.json',
+        'file:///tmp/models.json',
+    ]
+
+
+@pytest.fixture
+def mock_validator(original_scope):
+    validator = Mock(spec=Draft4Validator)
+    validator.resolver = Mock(spec=RefResolver)
+    validator.resolver._scopes_stack = original_scope
+    # Make descend() return an empty list to StopIteration.
+    validator.descend.return_value = []
+    return validator
+
+
+def test_when_resolve_is_not_None(address_target, address, original_scope,
+                                  annotated_scope, address_ref,
+                                  address_schema, mock_validator):
+    # Verify RefResolver._scopes_stack is replaced by the x-scope
+    # annotation's scope stack during the call to RefResolver.resolve(...)
+
+    def assert_correct_scope_and_resolve(*args, **kwargs):
+        assert mock_validator.resolver._scopes_stack == annotated_scope
+        return 'file:///tmp/swagger.json', address_target
+
+    mock_validator.resolver.resolve = Mock(
+        side_effect=assert_correct_scope_and_resolve)
+
+    # Force iteration over generator function
+    list(ref_validator(mock_validator, ref=address_ref, instance=address,
+                       schema=address_schema))
+
+    assert mock_validator.resolver.resolve.call_count == 1
+    assert mock_validator.resolver._scopes_stack == original_scope
+
+
+@pytest.mark.skip(reason="Can't get mock + context managers to work. "
+                         "Leaving partially authored test to pick up later.")
+def test_when_resolve_is_None(address_target, address, original_scope,
+                              annotated_scope, address_ref, address_schema,
+                              mock_validator):
+    # Verify RefResolver._scopes_stack is replaced by the x-scope
+    # annotation's scope stack during the call to RefResolver.resolving(...)
+
+    def assert_correct_scope_and_resolve(*args, **kwargs):
+        assert mock_validator.resolver._scopes_stack == annotated_scope
+        return 'file:///tmp/swagger.json', address_target
+
+    mock_validator.resolver.resolve = None
+    mock_validator.resolver.resolving = MagicMock(
+        side_effect=assert_correct_scope_and_resolve)
+
+    # Force iteration over generator function
+    list(ref_validator(mock_validator, ref=address_ref, instance=address,
+                       schema=address_schema))
+    assert mock_validator.resolver.resolving.call_count == 1
+    assert mock_validator.resolver._scopes_stack == original_scope

--- a/tests/swagger20_validator/ref_validator_test.py
+++ b/tests/swagger20_validator/ref_validator_test.py
@@ -66,7 +66,7 @@ def mock_validator(original_scope):
     validator.resolver = Mock(spec=RefResolver)
     validator.resolver._scopes_stack = original_scope
     # Make descend() return an empty list to StopIteration.
-    validator.descend.return_value = []
+    validator.descend.return_value = [Mock()]
     return validator
 
 


### PR DESCRIPTION
Fixes #82, closes #83.

Created a second PR based on the fix by @analogue. The only change is fixing and enabling the second test. I verified internally that our service works with this fix. Your change lg2m, thumbs up from me for merging this.