### PR TITLE
Add debug log for json decode error

### DIFF
--- a/bravado_core/response.py
+++ b/bravado_core/response.py
@@ -1,9 +1,13 @@
+import logging
+
 from six import iteritems
 
 from bravado_core.content_type import APP_JSON
 from bravado_core.unmarshal import unmarshal_schema_object
 from bravado_core.validate import validate_schema_object
 from bravado_core.exception import MatchingResponseNotFound, SwaggerMappingError
+
+log = logging.getLogger(__name__)
 
 # Response bodies considered to be empty
 EMPTY_BODIES = (None, '', '{}', 'null')
@@ -101,7 +105,12 @@ def unmarshal_response(response, op):
 
     # TODO: Non-json response contents
     content_spec = deref(response_spec['schema'])
-    content_value = response.json()
+
+    # TODO(schmaltz|3-28-2016)  Remove try catch and logging when done debugging
+    try:
+        content_value = response.json()
+    except ValueError:
+        log.debug('No JSON object could be decoded for response: {0}'.format(response.text))
 
     if op.swagger_spec.config['validate_responses']:
         validate_schema_object(op.swagger_spec, content_spec, content_value)

--- a/bravado_core/response.py
+++ b/bravado_core/response.py
@@ -109,8 +109,9 @@ def unmarshal_response(response, op):
     # TODO(schmaltz|3-28-2016)  Remove try catch and logging when done debugging
     try:
         content_value = response.json()
-    except ValueError:
+    except ValueError as error:
         log.debug('No JSON object could be decoded for response: {0}'.format(response.text))
+        raise error
 
     if op.swagger_spec.config['validate_responses']:
         validate_schema_object(op.swagger_spec, content_spec, content_value)

--- a/tests/response/unmarshal_response_test.py
+++ b/tests/response/unmarshal_response_test.py
@@ -27,6 +27,20 @@ def test_no_content(empty_swagger_spec):
         result = unmarshal_response(response, op)
         assert result is None
 
+def test_invalid_json_content(empty_swagger_spec, response_spec):
+    response = Mock(
+        spec=IncomingResponse,
+        status_code=200,
+        json=Mock(side_effect=ValueError()),
+        text='blah',
+    )
+
+    with patch('bravado_core.response.get_response_spec') as m:
+        with pytest.raises(ValueError):
+            m.return_value = response_spec
+            op = Mock(swagger_spec=empty_swagger_spec)
+            unmarshal_response(response, op)
+
 
 def test_json_content(empty_swagger_spec, response_spec):
     response = Mock(


### PR DESCRIPTION
Trying to get more info on this error that's only occurring in stage and prod for requests with special characters.

For setting up the logger, I just followed what other files did. 
https://github.com/Yelp/bravado-core/blob/master/bravado_core/model.py
https://github.com/Yelp/bravado-core/blob/master/bravado_core/resource.py#L9

How are these logs accessed? 

`
-----------------------------------------------------------------
 
Date 2016-03-28 14:04:16.767988
Hostname: d2e162b44655
Level: ERROR
Logger: yelp_pyramid.exception_logging
Message: service exception
Host: www.yelp.com
IP: 8.18.218.201, 162.158.252.65, 127.0.0.1
Referer: https://www.yelp.com/list_search?q=&location=montreal
URI: http://www.yelp.com/list/pubs-bars-montr%C3%A9al-5
Useragent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.87 Safari/537.36
Code Version: None
Unique Request ID: 2ec2fea97dbf572e
 
    Traceback (most recent call last):
      File "/code/virtualenv_run/lib/python2.7/site-packages/pyramid_exclog/__init__.py", line 111, in exclog_tween
        return handler(request)
      File "/code/virtualenv_run/lib/python2.7/site-packages/pyramid_zipkin/zipkin.py", line 33, in tween
        response = handler(request)
      File "/code/virtualenv_run/lib/python2.7/site-packages/pyramid/router.py", line 163, in handle_request
        response = view_callable(context, request)
      File "/code/virtualenv_run/lib/python2.7/site-packages/pyramid/config/views.py", line 355, in rendered_view
        result = view(context, request)
      File "/code/virtualenv_run/lib/python2.7/site-packages/pyramid/config/views.py", line 501, in _requestonly_view
        response = view(request)
      File "./www_pages/views/lists/details.py", line 71, in details
        list_alias_or_id=list_alias_or_id,
      File "/code/virtualenv_run/lib/python2.7/site-packages/bravado_promised/twisted_promise.py", line 392, in result
        return self.__result(timeout or self._result_timeout)
      File "/code/virtualenv_run/lib/python2.7/site-packages/bravado_promised/twisted_promise.py", line 414, in __result
        return self.__result(timeout)
      File "/code/virtualenv_run/lib/python2.7/site-packages/bravado_promised/twisted_promise.py", line 407, in __result
        result = self.eventual.wait(timeout=timeout)
      File "/code/virtualenv_run/lib/python2.7/site-packages/crochet/_eventloop.py", line 231, in wait
        result.raiseException()
      File "/code/virtualenv_run/lib/python2.7/site-packages/twisted/internet/defer.py", line 588, in _runCallbacks
        current.result = callback(current.result, *args, **kw)
      File "/code/virtualenv_run/lib/python2.7/site-packages/bravado_promised/twisted_promise.py", line 54, in result_callback
        resp = callback(result)
      File "/code/virtualenv_run/lib/python2.7/site-packages/bravado_promised/twisted_client.py", line 99, in _unmarshal_response
        response_callbacks
      File "/code/virtualenv_run/lib/python2.7/site-packages/bravado/http_future.py", line 94, in unmarshal_response
        operation)
      File "/code/virtualenv_run/lib/python2.7/site-packages/bravado_core/response.py", line 104, in unmarshal_response
        content_value = response.json()
      File "/code/virtualenv_run/lib/python2.7/site-packages/bravado_promised/twisted_client.py", line 140, in json
        return json.loads(self.body)
      File "/usr/lib/python2.7/json/__init__.py", line 338, in loads
        return _default_decoder.decode(s)
      File "/usr/lib/python2.7/json/decoder.py", line 365, in decode
        obj, end = self.raw_decode(s, idx=_w(s, 0).end())
      File "/usr/lib/python2.7/json/decoder.py", line 383, in raw_decode
        raise ValueError("No JSON object could be decoded")
    ValueError: No JSON object could be decoded
`