### PR TITLE
Fix marshalling optional array query parameter when not passed in service call

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,10 @@
 Changelog
 =========
+4.2.2 (2016-XX-XX)
+------------------
+- Fix marshalling of an optional array query parameter when not passed in the
+  service call - PR TODO
+
 4.2.1 (2016-03-23)
 ------------------
 - Fix optional enums in request params - Issue #77

--- a/tests/param/marshal_param_test.py
+++ b/tests/param/marshal_param_test.py
@@ -5,6 +5,7 @@ from mock import Mock, patch
 import pytest
 
 from bravado_core.content_type import APP_JSON
+from bravado_core.exception import SwaggerMappingError
 from bravado_core.param import Param, marshal_param
 from bravado_core.operation import Operation
 from bravado_core.spec import Spec
@@ -65,6 +66,24 @@ def test_query_array(empty_swagger_spec, array_param_spec, request_dict):
     expected['params']['animals'] = ','.join(value)
     marshal_param(param, value, request_dict)
     assert expected == request_dict
+
+
+def test_optional_query_array_with_no_value(empty_swagger_spec,
+                                            array_param_spec, request_dict):
+    array_param_spec['required'] = False
+    param = Param(empty_swagger_spec, Mock(spec=Operation), array_param_spec)
+    expected = copy.deepcopy(request_dict)
+    marshal_param(param, value=None, request=request_dict)
+    assert expected == request_dict
+
+
+def test_required_query_array_with_no_value(empty_swagger_spec,
+                                            array_param_spec, request_dict):
+    array_param_spec['required'] = True
+    param = Param(empty_swagger_spec, Mock(spec=Operation), array_param_spec)
+    with pytest.raises(SwaggerMappingError) as excinfo:
+        marshal_param(param, value=None, request=request_dict)
+    assert 'Expected list like type' in str(excinfo.value)
 
 
 def test_path_integer(empty_swagger_spec, param_spec):

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ commands =
 deps =
     {[testenv]deps}
     sphinx
+    sphinx-rtd-theme
 changedir = docs
 commands = sphinx-build -b html -d build/doctrees source build/html
 


### PR DESCRIPTION
Fix for https://github.com/Yelp/bravado/issues/202