### PR TITLE
Fixed jsonschema dependency to allow date-time validation.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         "Programming Language :: Python :: 3.4",
     ],
     install_requires=[
-        "jsonschema>=2.5.1",
+        "jsonschema[format]>=2.5.1",
         "python-dateutil",
         "pyyaml",
         "simplejson",

--- a/tests/unmarshal/unmarshal_primitive_test.py
+++ b/tests/unmarshal/unmarshal_primitive_test.py
@@ -35,6 +35,20 @@ def test_number(minimal_swagger_spec):
     assert 3.1 == unmarshal_primitive(minimal_swagger_spec, number_spec, 3.1)
 
 
+def test_datetime_string(minimal_swagger_spec):
+    from datetime import datetime
+    date_spec = {
+        'type': 'string',
+        'format': 'date-time'
+    }
+    # the validator requires a time zone, but that's a pain to scaffold:
+    # this just tests that naive date parsing happens as expected
+    input_date = "2016-06-07T20:59:00.480"
+    expected_date = datetime(2016, 6, 7, 20, 59, 0, 480000)
+    assert expected_date == unmarshal_primitive(minimal_swagger_spec,
+                                                date_spec, input_date)
+
+
 def test_required_success(minimal_swagger_spec):
     integer_spec = {
         'type': 'integer',

--- a/tests/validate/validate_primitive_test.py
+++ b/tests/validate/validate_primitive_test.py
@@ -192,6 +192,20 @@ def test_string_enum_failure(minimal_swagger_spec, string_spec):
     assert "is not one of" in str(excinfo.value)
 
 
+def test_string_datetime_success(minimal_swagger_spec, string_spec):
+    string_spec['format'] = 'date-time'
+    datestring = "2016-06-07T20:59:00.480Z"
+    validate_primitive(minimal_swagger_spec, string_spec, datestring)
+
+
+def test_string_datetime_invalid_exception(minimal_swagger_spec, string_spec):
+    string_spec['format'] = 'date-time'
+    datestring = "nope nope nope"
+    with pytest.raises(ValidationError) as excinfo:
+        validate_primitive(minimal_swagger_spec, string_spec, datestring)
+    assert "is not a 'date-time'" in str(excinfo.value)
+
+
 def test_doesnt_blow_up_when_spec_has_a_required_key(minimal_swagger_spec):
     string_spec = {
         'type': 'string',


### PR DESCRIPTION
Added tests for datetime parsing and validation, including a test that  should fail but does not with the current jsonschema dependency, then updated the jsonschema dependency to include the "format" option, which brings in the necessary additional libraries to make that validation run correctly.

This is an implementation of the solution proposed in #88: if that proposal is unacceptable, this PR will presumably also be unacceptable.