### PR TITLE
Convert ValueErrors from JSON reading to SwaggerMappingErrors.

### DIFF
--- a/bravado_core/param.py
+++ b/bravado_core/param.py
@@ -176,7 +176,11 @@ def unmarshal_param(param, request):
             raw_value = cast_param(request.form.get(param.name, default_value))
     elif location == 'body':
         # TODO: verify content-type header
-        raw_value = request.json()
+        try:
+            raw_value = request.json()
+        except ValueError as json_error:
+            raise SwaggerMappingError("Error reading request body JSON: {0}".
+                                      format(str(json_error)))
     else:
         raise SwaggerMappingError(
             "Don't know how to unmarshal_param with location {0}".

--- a/tests/request/unmarshal_request_test.py
+++ b/tests/request/unmarshal_request_test.py
@@ -1,6 +1,8 @@
 from mock import Mock
+import pytest
 
 from bravado_core.request import IncomingRequest, unmarshal_request
+from bravado_core.exception import SwaggerMappingError
 
 
 def test_request_with_path_parameter(petstore_spec):
@@ -17,3 +19,12 @@ def test_request_with_no_parameters(petstore_spec):
     op = petstore_spec.resources['user'].operations['logoutUser']
     request_data = unmarshal_request(request, op)
     assert 0 == len(request_data)
+
+
+def test_request_with_no_json(petstore_spec):
+    request = Mock(spec=IncomingRequest, path={'petId': '1234'},
+                   json=Mock(side_effect=ValueError("No json here bub")))
+    op = petstore_spec.resources['pet'].operations['updatePet']
+    with pytest.raises(SwaggerMappingError) as excinfo:
+        unmarshal_request(request, op)
+    assert "Error reading request body JSON" in str(excinfo.value)


### PR DESCRIPTION
This patch is motivated by a situation I encountered using pyramid_swagger: when the user sends a request with invalid (or no) JSON, the ValueError from attempting to deserialize the request body is untrapped, leading to a 500 error. Ideally, this should be a 400 error, since the problem is that the request is incorrectly formatted, not that the server encountered an unexpected problem.  Trapping the ValueError raised by JSON translation and re-raising it as a more specific error is one way of accomplishing that.

It is possible that this behavior actually represents a bug in the pyramid_swagger IncomingRequest implementation, but the definition of the `json` method in IncomingRequest does not seem to specify any specific error handing behavior, so it's not clear to me what the appropriate change there would be.