### PR TITLE
Raise an exception when the required type field is missing for an schema_object_spec.

### DIFF
--- a/bravado_core/__init__.py
+++ b/bravado_core/__init__.py
@@ -1,1 +1,1 @@
-version = "4.2.2"
+version = "4.3.0"

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -28,7 +28,12 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
     """
     deref = swagger_spec.deref
     schema_object_spec = deref(schema_object_spec)
-    obj_type = schema_object_spec['type']
+    try:
+        obj_type = schema_object_spec['type']
+    except KeyError:
+        raise SwaggerMappingError(
+            "The following schema object is missing a type field: {0}"
+            .format(schema_object_spec.get('x-model', str(schema_object_spec))))
 
     if obj_type in SWAGGER_PRIMITIVES:
         return unmarshal_primitive(swagger_spec, schema_object_spec, value)

--- a/tests/unmarshal/unmarshal_schema_object_test.py
+++ b/tests/unmarshal/unmarshal_schema_object_test.py
@@ -1,4 +1,8 @@
 # -*- coding: utf-8 -*-
+import copy
+import pytest
+
+from bravado_core.exception import SwaggerMappingError
 from bravado_core.spec import Spec
 from bravado_core.unmarshal import unmarshal_schema_object
 
@@ -26,3 +30,18 @@ def test_use_models_false(petstore_dict):
         {'id': 200, 'name': 'short-hair'})
 
     assert isinstance(result, dict)
+
+
+def test_bad_object_spec(petstore_dict):
+    petstore_spec = Spec.from_dict(petstore_dict, config={'use_models': False})
+    category_spec = copy.deepcopy(
+        petstore_spec.spec_dict['definitions']['Category']
+    )
+    # Type is a required field for objects.
+    category_spec['properties']['id'].pop('type')
+
+    with pytest.raises(SwaggerMappingError):
+        unmarshal_schema_object(
+            petstore_spec,
+            category_spec,
+            {'id': 200, 'name': 'short-hair'})


### PR DESCRIPTION
Right now it just raises a `KeyError`, which is difficult to understand. For example here are the relevant portions of the stack trace:
```python
[cut 42 lines...]
  File "/nail/home/wting/code/services/public_api/.tox/py27/local/lib/python2.7/site-packages/bravado/http_future.py", line 77, in result
    self.response_callbacks)
  File "/nail/home/wting/code/services/public_api/.tox/py27/local/lib/python2.7/site-packages/bravado/http_future.py", line 115, in unmarshal_response
    operation)
  File "/nail/home/wting/code/services/public_api/.tox/py27/local/lib/python2.7/site-packages/bravado_core/response.py", line 110, in unmarshal_response
    op.swagger_spec, content_spec, content_value)
  File "/nail/home/wting/code/services/public_api/.tox/py27/local/lib/python2.7/site-packages/bravado_core/unmarshal.py", line 44, in unmarshal_schema_object
    return unmarshal_model(swagger_spec, schema_object_spec, value)
  File "/nail/home/wting/code/services/public_api/.tox/py27/local/lib/python2.7/site-packages/bravado_core/unmarshal.py", line 156, in unmarshal_model
    model_as_dict = unmarshal_object(swagger_spec, model_spec, model_value)
  File "/nail/home/wting/code/services/public_api/.tox/py27/local/lib/python2.7/site-packages/bravado_core/unmarshal.py", line 119, in unmarshal_object
    result[k] = unmarshal_schema_object(swagger_spec, prop_spec, v)
  File "/nail/home/wting/code/services/public_api/.tox/py27/local/lib/python2.7/site-packages/bravado_core/unmarshal.py", line 31, in unmarshal_schema_object
    obj_type = schema_object_spec['type']
KeyError: 'type'
```

Reviewer: @jnb, @ATRAN2 