### PR TITLE
Add basepython python2.7 to all tox envs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,9 @@
 Changelog
 =========
+4.2.5 (2016-07-27)
+------------------
+- Add basepython python2.7 for flake8, docs, and coverage tox commands
+
 4.2.4 (2016-07-26)
 ------------------
 - coverage v4.2 was incompatible and was breaking the build. Added --append for the fix.

--- a/bravado_core/__init__.py
+++ b/bravado_core/__init__.py
@@ -1,1 +1,1 @@
-version = "4.2.4"
+version = "4.2.5"

--- a/tox.ini
+++ b/tox.ini
@@ -8,11 +8,13 @@ commands =
     py.test --capture=no {posargs:tests}
 
 [testenv:flake8]
+basepython = /usr/bin/python2.7
 deps = flake8
 commands =
     flake8 bravado_core tests
 
 [testenv:cover]
+basepython = /usr/bin/python2.7
 deps =
     {[testenv]deps}
     pytest-cov
@@ -22,6 +24,7 @@ commands =
     coverage report --omit=.tox/*,tests/*,/usr/share/pyshared/*,/usr/lib/pymodules/* -m
 
 [testenv:docs]
+basepython = /usr/bin/python2.7
 deps =
     {[testenv]deps}
     sphinx


### PR DESCRIPTION
This will fix an OSError while running flake8 in our Jenkins cluster.