### PR TITLE
Return methods return value instead of None

### DIFF
--- a/bravado_core/exception.py
+++ b/bravado_core/exception.py
@@ -41,7 +41,7 @@ def wrap_exception(exception_class):
     def generic_exception(method):
         def wrapper(*args, **kwargs):
             try:
-                method(*args, **kwargs)
+                return method(*args, **kwargs)
             except Exception as e:
                 six.reraise(
                     exception_class,

--- a/tests/exception/wrap_exception_test.py
+++ b/tests/exception/wrap_exception_test.py
@@ -11,3 +11,11 @@ def test_exception_gets_correctly_wrapped():
     with pytest.raises(IOError) as excinfo:
         raise_assertion_error()
     assert 'bla' == str(excinfo.value)
+
+
+def test_return_value_when_no_exception():
+    @wrap_exception(IOError)
+    def do_not_raise_exception():
+        return 'bla'
+
+    assert 'bla' == do_not_raise_exception()


### PR DESCRIPTION
Currently methods decorated with wrap_exception will be called but their result is not returned hence making it impossible to get and further work with a wrap_exception decorated method.

In this pull request I‘m adding the `return` statement + a test case.