### PR TITLE
Check if parameter value is a bool-type before assuming it's a string

### DIFF
--- a/bravado_core/param.py
+++ b/bravado_core/param.py
@@ -198,8 +198,11 @@ def unmarshal_param(param, request):
 
 
 def string_to_boolean(value):
-    """Coerce the provided boolean-typed parameter value into its Python
-    boolean value if it's a string or return the value as-is if already casted.
+    """Coerce the provided value into its Python boolean value if it's a string
+    or return the value as-is if already casted.
+
+    :param value: the value of a Swagger parameter with a boolean type
+    :type value: usually string, but sometimes a bool
     """
     if isinstance(value, bool):
         return value

--- a/bravado_core/param.py
+++ b/bravado_core/param.py
@@ -198,6 +198,12 @@ def unmarshal_param(param, request):
 
 
 def string_to_boolean(value):
+    """Coerce the provided boolean-typed parameter value into its Python
+    boolean value if it's a string or return the value as-is if already casted.
+    """
+    if isinstance(value, bool):
+        return value
+
     lowercase_value = value.lower()
     true = ['true', '1']
     false = ['false', '0']

--- a/tests/param/unmarshal_param_test.py
+++ b/tests/param/unmarshal_param_test.py
@@ -63,6 +63,16 @@ def param_spec():
     }
 
 
+@pytest.fixture
+def boolean_param_spec():
+    return {
+        'name': 'isPet',
+        'in': 'query',
+        'description': 'True if resource is a pet, False otherwise.',
+        'type': 'boolean',
+    }
+
+
 def test_path_string(empty_swagger_spec, param_spec):
     param_spec['in'] = 'path'
     param = Param(empty_swagger_spec, Mock(spec=Operation), param_spec)
@@ -148,6 +158,12 @@ def test_query_int_array(
         spec=IncomingRequest,
         query={'numbers': test_input})
     assert expected == unmarshal_param(param, request)
+
+
+def test_query_string_boolean_values(empty_swagger_spec, boolean_param_spec):
+    param = Param(empty_swagger_spec, Mock(spec=Operation), boolean_param_spec)
+    request = Mock(spec=IncomingRequest, query={'isPet': True})
+    assert True is unmarshal_param(param, request)
 
 
 def test_header_string(empty_swagger_spec, param_spec):


### PR DESCRIPTION
Hey there!

I use pyramid_swagger, which relies on bravado-core. pyramid_swagger converts primitives when it can, which happens before it ends up calling bravado-core's `unmarshal_request`.

An issue I ran into today is essentially the test I've included with this change. I have a query parameter of a boolean type and by the time pyramid_swagger sends it to bravado_core for unmarshalling, the boolean is already a Python-bool and not a string-bool (i.e. 'true'), which causes `string_to_boolean` to raise a `ValueError`.

This change checks to see if a value passed into `string_to_boolean` is of type `bool` before treating it like a string.

I think it makes sense to fix this issue in this project so people who build on top of this can send Python bools if they want (which seems reasonable?). However, if this is not the right place to fix this problem, and instead I should be fixing this in pyramid_swagger, let me know.

Thanks.