### PR TITLE
Fix to marshalling to better handle x-nullable and required properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build
 *.swp
 *.tox
 .idea/
+*.iml

--- a/bravado_core/param.py
+++ b/bravado_core/param.py
@@ -186,6 +186,9 @@ def unmarshal_param(param, request):
             "Don't know how to unmarshal_param with location {0}".
             format(location))
 
+    if raw_value is None and not schema.is_required(swagger_spec, param_spec):
+        return None
+
     if param_type == 'array' and location != 'body':
         raw_value = unmarshal_collection_format(swagger_spec, param_spec,
                                                 raw_value)

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -1,4 +1,5 @@
 from collections import Mapping
+import copy
 
 from bravado_core.exception import SwaggerMappingError
 
@@ -79,7 +80,16 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name):
     prop_spec = deref(props_spec).get(prop_name)
 
     if prop_spec is not None:
-        return deref(prop_spec)
+        result_spec = deref(prop_spec)
+        # If the de-referenced specification is for a x-nullable property
+        # then copy the spec and add the x-nullable property.
+        # If in the future there are other attributes on the property that
+        # modify a referenced schema, it can be done here (or rewrite
+        # unmarshal to pass the unreferenced property spec as another arg).
+        if 'x-nullable' in prop_spec and 'x-nullable' not in result_spec:
+            result_spec = copy.deepcopy(result_spec)
+            result_spec['x-nullable'] = prop_spec['x-nullable']
+        return result_spec
 
     additional_props = deref(object_spec).get('additionalProperties', True)
 

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -106,3 +106,19 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name):
     raise SwaggerMappingError(
         "Don't know what to do with `additionalProperties` in spec {0} "
         "when inspecting value {1}".format(object_spec, object_value))
+
+
+def handle_null_value(swagger_spec, schema_object_spec):
+    """Handle a null value for the associated schema object spec. Checks the
+     x-nullable attribute in the spec to see if it is allowed and returns None
+     if so and raises an exception otherwise.
+
+    :param swagger_spec: :class:`bravado_core.spec.Spec`
+    :param schema_object_spec: dict
+    :return: None if the spec is nullable
+    :raises: SwaggerMappingError if the spec is not nullable
+    """
+    if is_prop_nullable(swagger_spec, schema_object_spec):
+        return None
+    raise SwaggerMappingError(
+        'Spec {0} is a required value'.format(schema_object_spec))

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -7,7 +7,7 @@ from bravado_core.model import is_model, MODEL_MARKER
 from bravado_core.schema import get_spec_for_prop
 from bravado_core.schema import is_dict_like
 from bravado_core.schema import is_list_like
-from bravado_core.schema import is_prop_nullable
+from bravado_core.schema import handle_null_value
 from bravado_core.schema import SWAGGER_PRIMITIVES
 
 
@@ -72,11 +72,7 @@ def unmarshal_primitive(swagger_spec, primitive_spec, value):
     :raises: SwaggerMappingError
     """
     if value is None:
-        if is_prop_nullable(swagger_spec, primitive_spec):
-            return None
-        else:
-            raise SwaggerMappingError(
-                'Spec {0} is a required value'.format(primitive_spec))
+        return handle_null_value(swagger_spec, primitive_spec)
 
     value = formatter.to_python(swagger_spec, primitive_spec, value)
     return value
@@ -92,11 +88,7 @@ def unmarshal_array(swagger_spec, array_spec, array_value):
     :raises: SwaggerMappingError
     """
     if array_value is None:
-        if is_prop_nullable(swagger_spec, array_spec):
-            return None
-        else:
-            raise SwaggerMappingError(
-                'Spec {0} is a required value'.format(array_spec))
+        return handle_null_value(swagger_spec, array_spec)
 
     if not is_list_like(array_value):
         raise SwaggerMappingError('Expected list like type for {0}:{1}'.format(
@@ -120,14 +112,8 @@ def unmarshal_object(swagger_spec, object_spec, object_value):
     """
     deref = swagger_spec.deref
 
-    # TODO: default values for objects
-
     if object_value is None:
-        if is_prop_nullable(swagger_spec, object_spec):
-            return None
-        else:
-            raise SwaggerMappingError(
-                'Spec {0} is a required value'.format(object_spec))
+        return handle_null_value(swagger_spec, object_spec)
 
     if not is_dict_like(object_value):
         raise SwaggerMappingError('Expected dict like type for {0}:{1}'.format(
@@ -136,18 +122,13 @@ def unmarshal_object(swagger_spec, object_spec, object_value):
     object_spec = deref(object_spec)
     required_fields = object_spec.get('required', [])
 
-    # Protect against the case where a parameter with an inline definition
-    # and a required field is passed to this method.
-    if isinstance(required_fields, bool):
-        required_fields = []
-
     result = {}
     for k, v in iteritems(object_value):
         prop_spec = get_spec_for_prop(
             swagger_spec, object_spec, object_value, k)
         if v is None and k not in required_fields:
-            continue
-        if prop_spec:
+            result[k] = None
+        elif prop_spec:
             result[k] = unmarshal_schema_object(swagger_spec, prop_spec, v)
         else:
             # Don't marshal when a spec is not available - just pass through
@@ -180,11 +161,7 @@ def unmarshal_model(swagger_spec, model_spec, model_value):
             .format(model_name, model_value))
 
     if model_value is None:
-        if is_prop_nullable(swagger_spec, model_spec):
-            return None
-        else:
-            raise SwaggerMappingError(
-                'Spec {0} is a required value'.format(model_spec))
+        return handle_null_value(swagger_spec, model_spec)
 
     if not is_dict_like(model_value):
         raise SwaggerMappingError(

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 from six import iteritems
 
-from bravado_core import formatter, schema
+from bravado_core import formatter
 from bravado_core.exception import SwaggerMappingError
 from bravado_core.model import is_model, MODEL_MARKER
 from bravado_core.schema import get_spec_for_prop
 from bravado_core.schema import is_dict_like
 from bravado_core.schema import is_list_like
+from bravado_core.schema import is_prop_nullable
 from bravado_core.schema import SWAGGER_PRIMITIVES
 
 
@@ -70,9 +71,12 @@ def unmarshal_primitive(swagger_spec, primitive_spec, value):
         based on 'format'
     :raises: SwaggerMappingError
     """
-    if value is None and schema.is_required(swagger_spec, primitive_spec):
-        raise SwaggerMappingError(
-            'Spec {0} says this is a required value'.format(primitive_spec))
+    if value is None:
+        if is_prop_nullable(swagger_spec, primitive_spec):
+            return None
+        else:
+            raise SwaggerMappingError(
+                'Spec {0} is a required value'.format(primitive_spec))
 
     value = formatter.to_python(swagger_spec, primitive_spec, value)
     return value
@@ -87,10 +91,14 @@ def unmarshal_array(swagger_spec, array_spec, array_value):
     :rtype: list
     :raises: SwaggerMappingError
     """
-    if not is_list_like(array_value):
-        if (array_value is None and (schema.is_prop_nullable(swagger_spec, array_spec) or
-                                     not schema.is_required(swagger_spec, array_spec))):
+    if array_value is None:
+        if is_prop_nullable(swagger_spec, array_spec):
             return None
+        else:
+            raise SwaggerMappingError(
+                'Spec {0} is a required value'.format(array_spec))
+
+    if not is_list_like(array_value):
         raise SwaggerMappingError('Expected list like type for {0}:{1}'.format(
             type(array_value), array_value))
 
@@ -112,20 +120,33 @@ def unmarshal_object(swagger_spec, object_spec, object_value):
     """
     deref = swagger_spec.deref
 
+    # TODO: default values for objects
+
     if object_value is None:
-        if schema.is_prop_nullable(swagger_spec, object_spec):
+        if is_prop_nullable(swagger_spec, object_spec):
             return None
         else:
-            raise SwaggerMappingError("Expected dict value for non-nullable property")
+            raise SwaggerMappingError(
+                'Spec {0} is a required value'.format(object_spec))
 
     if not is_dict_like(object_value):
         raise SwaggerMappingError('Expected dict like type for {0}:{1}'.format(
             type(object_value), object_value))
 
+    object_spec = deref(object_spec)
+    required_fields = object_spec.get('required', [])
+
+    # Protect against the case where a parameter with an inline definition
+    # and a required field is passed to this method.
+    if isinstance(required_fields, bool):
+        required_fields = []
+
     result = {}
     for k, v in iteritems(object_value):
         prop_spec = get_spec_for_prop(
             swagger_spec, object_spec, object_value, k)
+        if v is None and k not in required_fields:
+            continue
         if prop_spec:
             result[k] = unmarshal_schema_object(swagger_spec, prop_spec, v)
         else:
@@ -159,11 +180,11 @@ def unmarshal_model(swagger_spec, model_spec, model_value):
             .format(model_name, model_value))
 
     if model_value is None:
-        if schema.is_prop_nullable(swagger_spec, model_spec):
+        if is_prop_nullable(swagger_spec, model_spec):
             return None
         else:
-            raise SwaggerMappingError("Expected dict value for non-nullable property of type {0}"
-                                      .format(model_type))
+            raise SwaggerMappingError(
+                'Spec {0} is a required value'.format(model_spec))
 
     if not is_dict_like(model_value):
         raise SwaggerMappingError(

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -88,8 +88,8 @@ def unmarshal_array(swagger_spec, array_spec, array_value):
     :raises: SwaggerMappingError
     """
     if not is_list_like(array_value):
-        if array_value is None and not schema.is_required(swagger_spec,
-                                                          array_spec):
+        if (array_value is None and (schema.is_prop_nullable(swagger_spec, array_spec) or
+                                     not schema.is_required(swagger_spec, array_spec))):
             return None
         raise SwaggerMappingError('Expected list like type for {0}:{1}'.format(
             type(array_value), array_value))
@@ -111,6 +111,12 @@ def unmarshal_object(swagger_spec, object_spec, object_value):
     :raises: SwaggerMappingError
     """
     deref = swagger_spec.deref
+
+    if object_value is None:
+        if schema.is_prop_nullable(swagger_spec, object_spec):
+            return None
+        else:
+            raise SwaggerMappingError("Expected dict value for non-nullable property")
 
     if not is_dict_like(object_value):
         raise SwaggerMappingError('Expected dict like type for {0}:{1}'.format(
@@ -151,6 +157,13 @@ def unmarshal_model(swagger_spec, model_spec, model_value):
         raise SwaggerMappingError(
             'Unknown model {0} when trying to unmarshal {1}'
             .format(model_name, model_value))
+
+    if model_value is None:
+        if schema.is_prop_nullable(swagger_spec, model_spec):
+            return None
+        else:
+            raise SwaggerMappingError("Expected dict value for non-nullable property of type {0}"
+                                      .format(model_type))
 
     if not is_dict_like(model_value):
         raise SwaggerMappingError(

--- a/tests/marshal/marshal_array_test.py
+++ b/tests/marshal/marshal_array_test.py
@@ -171,3 +171,15 @@ def test_ref(minimal_swagger_dict, int_array_spec):
     swagger_spec = Spec(minimal_swagger_dict)
     result = marshal_array(swagger_spec, ref_spec, [1, 2, 3])
     assert [1, 2, 3] == result
+
+
+def test_nullable_array(empty_swagger_spec, int_array_spec):
+    int_array_spec['x-nullable'] = True
+    result = marshal_array(empty_swagger_spec, int_array_spec, None)
+    assert result is None
+
+
+def test_non_nullable_array(empty_swagger_spec, int_array_spec):
+    with pytest.raises(SwaggerMappingError) as excinfo:
+        marshal_array(empty_swagger_spec, int_array_spec, None)
+    assert 'is a required value' in str(excinfo.value)

--- a/tests/marshal/marshal_model_test.py
+++ b/tests/marshal/marshal_model_test.py
@@ -88,17 +88,8 @@ def test_value_is_not_dict_like_raises_error(petstore_dict):
 
 def test_marshal_model_with_none_model_type(petstore_spec):
     model_spec = {'x-model': 'Foobar'}
-    Pet = petstore_spec.definitions['Pet']
-    pet = Pet(
-        id=1,
-        name='Fido',
-        status=None,
-        photoUrls=['wagtail.png', 'bark.png'],
-        category=None,
-        tags=None
-    )
     with pytest.raises(SwaggerMappingError) as excinfo:
-        marshal_model(petstore_spec, model_spec, pet)
+        marshal_model(petstore_spec, model_spec, object())
     assert 'Unknown model Foobar' in str(excinfo.value)
 
 

--- a/tests/marshal/marshal_model_test.py
+++ b/tests/marshal/marshal_model_test.py
@@ -1,3 +1,4 @@
+import copy
 import pytest
 
 from bravado_core.exception import SwaggerMappingError
@@ -83,3 +84,32 @@ def test_value_is_not_dict_like_raises_error(petstore_dict):
     with pytest.raises(SwaggerMappingError) as excinfo:
         marshal_model(petstore_spec, pet_spec, 'i am not a dict')
     assert 'Expected model of type' in str(excinfo.value)
+
+
+def test_marshal_model_with_none_model_type(petstore_spec):
+    model_spec = {'x-model': 'Foobar'}
+    Pet = petstore_spec.definitions['Pet']
+    pet = Pet(
+        id=1,
+        name='Fido',
+        status=None,
+        photoUrls=['wagtail.png', 'bark.png'],
+        category=None,
+        tags=None
+    )
+    with pytest.raises(SwaggerMappingError) as excinfo:
+        marshal_model(petstore_spec, model_spec, pet)
+    assert 'Unknown model Foobar' in str(excinfo.value)
+
+
+def test_marshal_nullable_model(petstore_spec):
+    pet_spec = copy.deepcopy(petstore_spec.spec_dict['definitions']['Pet'])
+    pet_spec['x-nullable'] = True
+    assert marshal_model(petstore_spec, pet_spec, None) is None
+
+
+def test_marshal_non_nullable_model(petstore_spec):
+    pet_spec = petstore_spec.spec_dict['definitions']['Pet']
+    with pytest.raises(SwaggerMappingError) as excinfo:
+        marshal_model(petstore_spec, pet_spec, None)
+    assert 'is a required value' in str(excinfo.value)

--- a/tests/marshal/marshal_object_test.py
+++ b/tests/marshal/marshal_object_test.py
@@ -301,22 +301,3 @@ def test_marshal_with_required_property(empty_swagger_spec):
     with pytest.raises(SwaggerMappingError) as excinfo:
         marshal_object(empty_swagger_spec, object_spec, value)
     assert 'is a required value' in str(excinfo.value)
-
-
-def test_marshal_with_required_boolean(empty_swagger_spec):
-    """
-    Test the case where the type of the required attribute
-        is a boolean instead of the expected list.
-    """
-    object_spec = {
-        'type': 'object',
-        'required': True,
-        'properties': {
-            'x': {
-                'type': 'string'
-            }
-        }
-    }
-    value = {'x': None}
-    result = marshal_object(empty_swagger_spec, object_spec, value)
-    assert result == {}

--- a/tests/marshal/marshal_object_test.py
+++ b/tests/marshal/marshal_object_test.py
@@ -241,18 +241,82 @@ def test_recursive_ref_with_depth_n(recursive_swagger_spec):
     assert result == expected
 
 
-def test_marshal_with_object(empty_swagger_spec):
-        param_spec = {
-            'type': 'object',
-            'required': ['x'],
-            'properties': {
-                'x': {
-                    'type': 'string',
-                    'x-nullable': True,
-                }
+def test_marshal_with_nullable_property(empty_swagger_spec):
+    object_spec = {
+        'type': 'object',
+        'required': ['x'],
+        'properties': {
+            'x': {
+                'type': 'string',
+                'x-nullable': True,
             }
         }
-        value = {'x': None}
+    }
+    value = {'x': None}
+    result = marshal_object(empty_swagger_spec, object_spec, value)
+    assert result == value
 
-        result = marshal_object(empty_swagger_spec, param_spec, value)
-        assert result == value
+
+def test_marshal_with_non_nullable_property(empty_swagger_spec):
+    object_spec = {
+        'type': 'object',
+        'required': ['x'],
+        'properties': {
+            'x': {
+                'type': 'string'
+            }
+        }
+    }
+    value = {'x': None}
+    with pytest.raises(SwaggerMappingError) as excinfo:
+        marshal_object(empty_swagger_spec, object_spec, value)
+    assert 'is a required value' in str(excinfo.value)
+
+
+def test_marshal_with_non_required_property(empty_swagger_spec):
+    object_spec = {
+        'type': 'object',
+        'properties': {
+            'x': {
+                'type': 'string'
+            }
+        }
+    }
+    value = {'x': None}
+    result = marshal_object(empty_swagger_spec, object_spec, value)
+    assert result == {}
+
+
+def test_marshal_with_required_property(empty_swagger_spec):
+    object_spec = {
+        'type': 'object',
+        'required': ['x'],
+        'properties': {
+            'x': {
+                'type': 'string'
+            }
+        }
+    }
+    value = {'x': None}
+    with pytest.raises(SwaggerMappingError) as excinfo:
+        marshal_object(empty_swagger_spec, object_spec, value)
+    assert 'is a required value' in str(excinfo.value)
+
+
+def test_marshal_with_required_boolean(empty_swagger_spec):
+    """
+    Test the case where the type of the required attribute
+        is a boolean instead of the expected list.
+    """
+    object_spec = {
+        'type': 'object',
+        'required': True,
+        'properties': {
+            'x': {
+                'type': 'string'
+            }
+        }
+    }
+    value = {'x': None}
+    result = marshal_object(empty_swagger_spec, object_spec, value)
+    assert result == {}

--- a/tests/marshal/marshal_primitive_test.py
+++ b/tests/marshal/marshal_primitive_test.py
@@ -39,24 +39,6 @@ def test_skips_default(mock_to_wire, minimal_swagger_spec):
     assert mock_to_wire.call_count == 1
 
 
-def test_required(minimal_swagger_spec):
-    integer_spec = {
-        'type': 'integer',
-        'required': True,
-    }
-    assert 99 == marshal_primitive(minimal_swagger_spec, integer_spec, 99)
-
-
-def test_required_failure(minimal_swagger_spec):
-    integer_spec = {
-        'type': 'integer',
-        'required': True,
-    }
-    with pytest.raises(SwaggerMappingError) as excinfo:
-        marshal_primitive(minimal_swagger_spec, integer_spec, None)
-    assert 'is a required value' in str(excinfo.value)
-
-
 def test_ref(minimal_swagger_dict):
     integer_spec = {
         'type': 'integer',
@@ -68,9 +50,18 @@ def test_ref(minimal_swagger_dict):
     assert 10 == marshal_primitive(swagger_spec, ref_spec, 10)
 
 
-def test_nullable(empty_swagger_spec):
+def test_nullable_primitive(empty_swagger_spec):
     string_spec = {
         'type': 'string',
         'x-nullable': True,
     }
-    assert None is marshal_primitive(empty_swagger_spec, string_spec, None)
+    assert marshal_primitive(empty_swagger_spec, string_spec, None) is None
+
+
+def test_not_nullable_primitive(empty_swagger_spec):
+    string_spec = {
+        'type': 'string',
+    }
+    with pytest.raises(SwaggerMappingError) as excinfo:
+        marshal_primitive(empty_swagger_spec, string_spec, None)
+    assert 'is a required value' in str(excinfo.value)

--- a/tests/param/marshal_param_test.py
+++ b/tests/param/marshal_param_test.py
@@ -83,7 +83,7 @@ def test_required_query_array_with_no_value(empty_swagger_spec,
     param = Param(empty_swagger_spec, Mock(spec=Operation), array_param_spec)
     with pytest.raises(SwaggerMappingError) as excinfo:
         marshal_param(param, value=None, request=request_dict)
-    assert 'Expected list like type' in str(excinfo.value)
+    assert 'is a required value' in str(excinfo.value)
 
 
 def test_path_integer(empty_swagger_spec, param_spec):

--- a/tests/param/marshal_param_test.py
+++ b/tests/param/marshal_param_test.py
@@ -201,3 +201,25 @@ def test_ref(minimal_swagger_dict, array_param_spec, request_dict):
     expected['params']['animals'] = ','.join(value)
     marshal_param(param, value, request_dict)
     assert expected == request_dict
+
+
+def test_required_param(minimal_swagger_spec, string_param_spec, request_dict):
+    string_param_spec['required'] = True
+    value = 'abc'
+    param = Param(minimal_swagger_spec, Mock(
+        spec=Operation), string_param_spec)
+    expected = copy.deepcopy(request_dict)
+    expected['params']['username'] = value
+    marshal_param(param, value, request_dict)
+    assert expected == request_dict
+
+
+def test_required_param_failure(minimal_swagger_spec, string_param_spec,
+                                request_dict):
+    string_param_spec['required'] = True
+    value = None
+    param = Param(minimal_swagger_spec, Mock(
+        spec=Operation), string_param_spec)
+    with pytest.raises(SwaggerMappingError) as excinfo:
+        marshal_param(param, value, request_dict)
+    assert 'is a required value' in str(excinfo.value)

--- a/tests/unmarshal/unmarshal_model_test.py
+++ b/tests/unmarshal/unmarshal_model_test.py
@@ -110,7 +110,9 @@ def test_value_is_not_dict_like_raises_error(petstore_dict):
 
 def test_nullable_object_properties(petstore_dict):
     petstore_dict = copy.deepcopy(petstore_dict)
-    petstore_dict['definitions']['Pet']['properties']['category']['x-nullable'] = True
+    pet_spec_dict = petstore_dict['definitions']['Pet']
+    pet_spec_dict['required'].append('category')
+    pet_spec_dict['properties']['category']['x-nullable'] = True
     petstore_spec = Spec.from_dict(petstore_dict)
     Pet = petstore_spec.definitions['Pet']
     pet_spec = petstore_spec.spec_dict['definitions']['Pet']
@@ -140,6 +142,8 @@ def test_nullable_object_properties(petstore_dict):
 def test_non_nullable_object_properties(petstore_dict):
     petstore_dict = copy.deepcopy(petstore_dict)
     petstore_spec = Spec.from_dict(petstore_dict)
+    pet_spec_dict = petstore_dict['definitions']['Pet']
+    pet_spec_dict['required'].append('category')
     pet_spec = petstore_spec.spec_dict['definitions']['Pet']
     pet_dict = {
         'id': 1,
@@ -165,8 +169,9 @@ def test_non_nullable_object_properties(petstore_dict):
 
 def test_nullable_array_properties(petstore_dict):
     petstore_dict = copy.deepcopy(petstore_dict)
-    petstore_dict['definitions']['Pet']['properties']['tags']['x-nullable'] = True
-    petstore_dict['definitions']['Pet']['required'].append('tags')
+    pet_spec_dict = petstore_dict['definitions']['Pet']
+    pet_spec_dict['properties']['tags']['x-nullable'] = True
+    pet_spec_dict['required'].append('tags')
     petstore_spec = Spec.from_dict(petstore_dict)
     Pet = petstore_spec.definitions['Pet']
     pet_spec = petstore_spec.spec_dict['definitions']['Pet']
@@ -187,10 +192,10 @@ def test_nullable_array_properties(petstore_dict):
     assert pet.tags is None
 
 
-@pytest.mark.skip(reason="Unmarshalling of required and non-nullable array succeeds")
 def test_non_nullable_array_properties(petstore_dict):
     petstore_dict = copy.deepcopy(petstore_dict)
-    petstore_dict['definitions']['Pet']['required'].append('tags')
+    pet_spec_dict = petstore_dict['definitions']['Pet']
+    pet_spec_dict['required'].append('tags')
     petstore_spec = Spec.from_dict(petstore_dict)
     pet_spec = petstore_spec.spec_dict['definitions']['Pet']
     pet_dict = {

--- a/tests/unmarshal/unmarshal_model_test.py
+++ b/tests/unmarshal/unmarshal_model_test.py
@@ -1,4 +1,3 @@
-import copy
 import pytest
 from bravado_core.exception import SwaggerMappingError
 
@@ -6,17 +5,9 @@ from bravado_core.unmarshal import unmarshal_model
 from bravado_core.spec import Spec
 
 
-def test_pet(petstore_dict):
-    # Covers:
-    #   - model with primitives properties
-    #   - model with an array
-    #   - model with a nested model
-    petstore_spec = Spec.from_dict(petstore_dict)
-    Pet = petstore_spec.definitions['Pet']
-    Category = petstore_spec.definitions['Category']
-    Tag = petstore_spec.definitions['Tag']
-    pet_spec = petstore_spec.spec_dict['definitions']['Pet']
-    pet_dict = {
+@pytest.fixture
+def pet_dict():
+    return {
         'id': 1,
         'name': 'Fido',
         'status': 'sold',
@@ -36,6 +27,18 @@ def test_pet(petstore_dict):
             }
         ],
     }
+
+
+def test_pet(petstore_dict, pet_dict):
+    # Covers:
+    #   - model with primitives properties
+    #   - model with an array
+    #   - model with a nested model
+    petstore_spec = Spec.from_dict(petstore_dict)
+    Pet = petstore_spec.definitions['Pet']
+    Category = petstore_spec.definitions['Category']
+    Tag = petstore_spec.definitions['Tag']
+    pet_spec = petstore_spec.spec_dict['definitions']['Pet']
 
     pet = unmarshal_model(petstore_spec, pet_spec, pet_dict)
 
@@ -58,7 +61,7 @@ def test_pet(petstore_dict):
 
 
 def test_Nones_are_reintroduced_for_declared_properties_that_are_not_present(
-        petstore_dict):
+        petstore_dict, pet_dict):
     petstore_spec = Spec.from_dict(petstore_dict)
     Pet = petstore_spec.definitions['Pet']
     Tag = petstore_spec.definitions['Tag']
@@ -66,21 +69,8 @@ def test_Nones_are_reintroduced_for_declared_properties_that_are_not_present(
 
     # Deleting "status" and "category" from pet_dict means that should still be
     # attrs on Pet with a None value after unmarshaling
-    pet_dict = {
-        'id': 1,
-        'name': 'Fido',
-        'photoUrls': ['wagtail.png', 'bark.png'],
-        'tags': [
-            {
-                'id': 99,
-                'name': 'mini'
-            },
-            {
-                'id': 100,
-                'name': 'brown'
-            }
-        ],
-    }
+    del pet_dict['status']
+    del pet_dict['category']
 
     pet = unmarshal_model(petstore_spec, pet_spec, pet_dict)
 
@@ -103,112 +93,60 @@ def test_Nones_are_reintroduced_for_declared_properties_that_are_not_present(
 def test_value_is_not_dict_like_raises_error(petstore_dict):
     petstore_spec = Spec.from_dict(petstore_dict)
     pet_spec = petstore_spec.spec_dict['definitions']['Pet']
+
     with pytest.raises(SwaggerMappingError) as excinfo:
         unmarshal_model(petstore_spec, pet_spec, 'i am not a dict')
+
     assert 'Expected type to be dict' in str(excinfo.value)
 
 
-def test_nullable_object_properties(petstore_dict):
-    petstore_dict = copy.deepcopy(petstore_dict)
+def test_nullable_object_properties(petstore_dict, pet_dict):
     pet_spec_dict = petstore_dict['definitions']['Pet']
     pet_spec_dict['required'].append('category')
     pet_spec_dict['properties']['category']['x-nullable'] = True
     petstore_spec = Spec.from_dict(petstore_dict)
     Pet = petstore_spec.definitions['Pet']
     pet_spec = petstore_spec.spec_dict['definitions']['Pet']
-    pet_dict = {
-        'id': 1,
-        'name': 'Fido',
-        'status': 'sold',
-        'photoUrls': ['wagtail.png', 'bark.png'],
-        'category': None,
-        'tags': [
-            {
-                'id': 99,
-                'name': 'mini'
-            },
-            {
-                'id': 100,
-                'name': 'brown'
-            }
-        ],
-    }
+    pet_dict['category'] = None
+
     pet = unmarshal_model(petstore_spec, pet_spec, pet_dict)
 
     assert isinstance(pet, Pet)
     assert pet.category is None
 
 
-def test_non_nullable_object_properties(petstore_dict):
-    petstore_dict = copy.deepcopy(petstore_dict)
-    petstore_spec = Spec.from_dict(petstore_dict)
+def test_non_nullable_object_properties(petstore_dict, pet_dict):
     pet_spec_dict = petstore_dict['definitions']['Pet']
     pet_spec_dict['required'].append('category')
+    petstore_spec = Spec.from_dict(petstore_dict)
     pet_spec = petstore_spec.spec_dict['definitions']['Pet']
-    pet_dict = {
-        'id': 1,
-        'name': 'Fido',
-        'status': 'sold',
-        'photoUrls': ['wagtail.png', 'bark.png'],
-        'category': None,
-        'tags': [
-            {
-                'id': 99,
-                'name': 'mini'
-            },
-            {
-                'id': 100,
-                'name': 'brown'
-            }
-        ],
-    }
+    pet_dict['category'] = None
 
     with pytest.raises(SwaggerMappingError):
         unmarshal_model(petstore_spec, pet_spec, pet_dict)
 
 
-def test_nullable_array_properties(petstore_dict):
-    petstore_dict = copy.deepcopy(petstore_dict)
+def test_nullable_array_properties(petstore_dict, pet_dict):
     pet_spec_dict = petstore_dict['definitions']['Pet']
     pet_spec_dict['properties']['tags']['x-nullable'] = True
     pet_spec_dict['required'].append('tags')
     petstore_spec = Spec.from_dict(petstore_dict)
     Pet = petstore_spec.definitions['Pet']
     pet_spec = petstore_spec.spec_dict['definitions']['Pet']
-    pet_dict = {
-        'id': 1,
-        'name': 'Fido',
-        'status': 'sold',
-        'photoUrls': ['wagtail.png', 'bark.png'],
-        'category': {
-            'id': 200,
-            'name': 'friendly',
-        },
-        'tags': None
-    }
+    pet_dict['tags'] = None
+
     pet = unmarshal_model(petstore_spec, pet_spec, pet_dict)
 
     assert isinstance(pet, Pet)
     assert pet.tags is None
 
 
-def test_non_nullable_array_properties(petstore_dict):
-    petstore_dict = copy.deepcopy(petstore_dict)
+def test_non_nullable_array_properties(petstore_dict, pet_dict):
     pet_spec_dict = petstore_dict['definitions']['Pet']
     pet_spec_dict['required'].append('tags')
     petstore_spec = Spec.from_dict(petstore_dict)
     pet_spec = petstore_spec.spec_dict['definitions']['Pet']
-    pet_dict = {
-        'id': 1,
-        'name': 'Fido',
-        'status': 'sold',
-        'photoUrls': ['wagtail.png', 'bark.png'],
-        'category': {
-            'id': 200,
-            'name': 'friendly',
-        },
-        'tags': None
-    }
+    pet_dict['tags'] = None
 
     with pytest.raises(SwaggerMappingError):
         unmarshal_model(petstore_spec, pet_spec, pet_dict)
@@ -216,21 +154,8 @@ def test_non_nullable_array_properties(petstore_dict):
 
 def test_unmarshal_model_with_none_model_type(petstore_spec):
     model_spec = {'x-model': 'Foobar'}
-    pet_dict = {
-        'id': 1,
-        'name': 'Fido',
-        'photoUrls': ['wagtail.png', 'bark.png'],
-        'tags': [
-            {
-                'id': 99,
-                'name': 'mini'
-            },
-            {
-                'id': 100,
-                'name': 'brown'
-            }
-        ],
-    }
+
     with pytest.raises(SwaggerMappingError) as excinfo:
-        unmarshal_model(petstore_spec, model_spec, pet_dict)
+        unmarshal_model(petstore_spec, model_spec, {})
+
     assert 'Unknown model Foobar' in str(excinfo.value)

--- a/tests/unmarshal/unmarshal_model_test.py
+++ b/tests/unmarshal/unmarshal_model_test.py
@@ -212,3 +212,25 @@ def test_non_nullable_array_properties(petstore_dict):
 
     with pytest.raises(SwaggerMappingError):
         unmarshal_model(petstore_spec, pet_spec, pet_dict)
+
+
+def test_unmarshal_model_with_none_model_type(petstore_spec):
+    model_spec = {'x-model': 'Foobar'}
+    pet_dict = {
+        'id': 1,
+        'name': 'Fido',
+        'photoUrls': ['wagtail.png', 'bark.png'],
+        'tags': [
+            {
+                'id': 99,
+                'name': 'mini'
+            },
+            {
+                'id': 100,
+                'name': 'brown'
+            }
+        ],
+    }
+    with pytest.raises(SwaggerMappingError) as excinfo:
+        unmarshal_model(petstore_spec, model_spec, pet_dict)
+    assert 'Unknown model Foobar' in str(excinfo.value)

--- a/tests/unmarshal/unmarshal_object_test.py
+++ b/tests/unmarshal/unmarshal_object_test.py
@@ -301,3 +301,13 @@ def test_non_nullable_none_value(empty_swagger_spec, property_type):
     with pytest.raises(SwaggerMappingError) as excinfo:
         unmarshal_object(empty_swagger_spec, content_spec, value)
     assert 'is a required value' in str(excinfo.value)
+
+
+@pytest.mark.parametrize('property_type', ['string', 'object', 'array'])
+def test_non_required_none_value(empty_swagger_spec, property_type):
+    content_spec = nullable_spec_factory(required=False,
+                                         nullable=False,
+                                         property_type=property_type)
+    value = {'x': None}
+    result = unmarshal_object(empty_swagger_spec, content_spec, value)
+    assert result == {'x': None}

--- a/tests/unmarshal/unmarshal_object_test.py
+++ b/tests/unmarshal/unmarshal_object_test.py
@@ -292,3 +292,31 @@ def test_nullable_none_value(empty_swagger_spec, required, property_type):
 
     result = unmarshal_object(empty_swagger_spec, content_spec, value)
     assert result == {'x': None}
+
+
+@pytest.mark.parametrize('property_type', ['string', 'object', 'array'])
+def test_non_nullable_none_value(empty_swagger_spec, property_type):
+    content_spec = nullable_spec_factory(True, False, property_type)
+    value = {'x': None}
+    with pytest.raises(SwaggerMappingError) as excinfo:
+        unmarshal_object(empty_swagger_spec, content_spec, value)
+    assert 'is a required value' in str(excinfo.value)
+
+
+def test_unmarshal_object_with_required_boolean(empty_swagger_spec):
+    """
+    Test the case where the type of the required attribute
+        is a boolean instead of the expected list.
+    """
+    object_spec = {
+        'type': 'object',
+        'required': True,
+        'properties': {
+            'x': {
+                'type': 'string'
+            }
+        }
+    }
+    value = {'x': None}
+    result = unmarshal_object(empty_swagger_spec, object_spec, value)
+    assert result == {'x': None}

--- a/tests/unmarshal/unmarshal_object_test.py
+++ b/tests/unmarshal/unmarshal_object_test.py
@@ -258,7 +258,8 @@ def nullable_spec_factory(required, nullable, property_type):
 @pytest.mark.parametrize('nullable', [True, False])
 @pytest.mark.parametrize('required', [True, False])
 @pytest.mark.parametrize('property_type', ['string', 'object', 'array'])
-def test_nullable_with_value(empty_swagger_spec, nullable, required, property_type):
+def test_nullable_with_value(empty_swagger_spec, nullable, required,
+                             property_type):
     content_spec = nullable_spec_factory(required, nullable, property_type)
     if property_type == 'object':
         value = {'x': {'y': 'z'}}


### PR DESCRIPTION
This is the proposed fix for https://github.com/Yelp/bravado-core/issues/108

I updated unmarshal to better handle x-nullable properties and added additional test cases to cover the changes.

There are a number of remaining issues which I would prefer to leave for someone else to address:

- Unmarshalling of required non-nullable arrays works when it probably shouldn't (existing behavior)
- I had to make a copy of the dereferenced property specification dictionary to add in the x-nullable flag if present. My experience with serde in the past is that I often needed to pass the property specification in addition to the referenced type information. I chose not to do that here for expediency. The extra dictionary copy could be optimized by refactoring the code to do so.
