### PR TITLE
Fix AttributeError if required array param is not supplied

### DIFF
--- a/bravado_core/param.py
+++ b/bravado_core/param.py
@@ -338,9 +338,11 @@ def unmarshal_collection_format(swagger_spec, param_spec, value):
     param_spec = deref(param_spec)
     collection_format = param_spec.get('collectionFormat', 'csv')
 
-    if value is None and not schema.is_required(swagger_spec, param_spec):
-        # Just pass through an optional array that has no value
-        return None
+    if value is None:
+        if not schema.is_required(swagger_spec, param_spec):
+            # Just pass through an optional array that has no value
+            return None
+        return schema.handle_null_value(swagger_spec, param_spec)
 
     if collection_format == 'multi':
         # http client lib should have already unmarshaled to an array

--- a/tests/param/unmarshal_collection_format_test.py
+++ b/tests/param/unmarshal_collection_format_test.py
@@ -1,5 +1,6 @@
 import pytest
 
+from bravado_core.exception import SwaggerMappingError
 from bravado_core.param import unmarshal_collection_format
 from bravado_core.param import COLLECTION_FORMATS
 from bravado_core.spec import Spec
@@ -54,5 +55,19 @@ def test_ref(minimal_swagger_dict, array_spec):
 
 
 def test_array_is_none_and_not_required(empty_swagger_spec, array_spec):
+    assert unmarshal_collection_format(empty_swagger_spec, array_spec,
+                                       value=None) is None
+
+
+def test_array_is_none_and_required(empty_swagger_spec, array_spec):
+    array_spec['required'] = True
+    with pytest.raises(SwaggerMappingError) as excinfo:
+        unmarshal_collection_format(empty_swagger_spec, array_spec, value=None)
+    assert 'is a required value' in str(excinfo.value)
+
+
+def test_array_is_none_and_nullable(empty_swagger_spec, array_spec):
+    array_spec['required'] = True
+    array_spec['x-nullable'] = True
     assert unmarshal_collection_format(empty_swagger_spec, array_spec,
                                        value=None) is None


### PR DESCRIPTION
We've observed AttributeErrors internally if a required parameter of type array is not passed, instead of the expected schema or validation exception. This is because validation happens after unmarshalling of the array, and a missing required parameter is not currently handled correctly during unmarshalling.