### PR TITLE
Give Models an easier way to roundtrip

### DIFF
--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -81,6 +81,8 @@ def create_model_type(swagger_spec, model_name, model_spec):
     :returns: dynamic type created with attributes, docstrings attached
     :rtype: type
     """
+    from bravado_core.marshal import marshal_model
+    from bravado_core.unmarshal import unmarshal_model
     doc = docstring_property(partial(
         create_model_docstring, swagger_spec, model_spec))
 
@@ -91,6 +93,8 @@ def create_model_type(swagger_spec, model_name, model_spec):
                                                           kwargs),
         __repr__=lambda self: create_model_repr(self, model_spec),
         __dir__=lambda self: model_dir(self, model_spec),
+        marshal=lambda self: marshal_model(swagger_spec, model_spec, self),
+        unmarshal=lambda value: unmarshal_model(swagger_spec, model_spec, value),
     )
     return type(str(model_name), (object,), methods)
 

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -94,7 +94,7 @@ def create_model_type(swagger_spec, model_name, model_spec):
         __repr__=lambda self: create_model_repr(self, model_spec),
         __dir__=lambda self: model_dir(self, model_spec),
         marshal=lambda self: marshal_model(swagger_spec, model_spec, self),
-        unmarshal=lambda value: unmarshal_model(swagger_spec, model_spec, value),
+        unmarshal=lambda val: unmarshal_model(swagger_spec, model_spec, val),
     )
     return type(str(model_name), (object,), methods)
 


### PR DESCRIPTION
Provide access to the existing marshal and unmarshal implementations on the Model objects to help us serialize / deserialize more easily without needing to keep track of specs. 

ref: COREBACK-452 Bravado model object responses can't be cached with memcached because it cannot be serialized by pickle