### PR TITLE
Cast to string the headers parameters

### DIFF
--- a/bravado_core/param.py
+++ b/bravado_core/param.py
@@ -132,7 +132,7 @@ def marshal_param(param, value, request):
     elif location == 'query':
         request['params'][param.name] = value
     elif location == 'header':
-        request['headers'][param.name] = value
+        request['headers'][param.name] = str(value)
     elif location == 'formData':
         if param_type == 'file':
             add_file(param, value, request)

--- a/tests/param/marshal_param_test.py
+++ b/tests/param/marshal_param_test.py
@@ -128,6 +128,18 @@ def test_header_string(empty_swagger_spec, param_spec):
     assert {'petId': '34'} == request['headers']
 
 
+def test_header_integer(empty_swagger_spec, param_spec):
+    param_spec['in'] = 'header'
+    param_spec['type'] = 'integer'
+    del param_spec['format']
+    param = Param(empty_swagger_spec, Mock(spec=Operation), param_spec)
+    request = {
+        'headers': {}
+    }
+    marshal_param(param, 34, request)
+    assert {'petId': '34'} == request['headers']
+
+
 def test_body(empty_swagger_spec, param_spec):
     param_spec['in'] = 'body'
     param_spec['schema'] = {


### PR DESCRIPTION
The current implementation of the ``bravado-core`` causes troubles if you inject in the header a type that is different from a string or byte.

An example is available on [Gist](https://gist.github.com/macisamuele/5dc3874509135b1ddb16a906b4e50f99).

Checking the stack trace was possible to understand that the ``requests`` python library is checking the type of the header parameters ensuring that them are string or bytes.
Many similar issues are highlighted on the ``requests`` project, ie. [Issue #3477](https://github.com/kennethreitz/requests/issues/3477).

Due to the implementation of the [``check_header_validity``](https://github.com/kennethreitz/requests/blob/master/requests/utils.py#L782) is clear that we cannot pass any primitive type, as header parameter, to the ``requests`` module.
**NOTE**: the change was introduced on [version 2.11](https://github.com/kennethreitz/requests/commit/be31a90906deb5553c2e703fb05cf6964ee23ed5).

Since the current signature of the ``marshal_param`` limit the header parameter value types to primitive or array of primitive types (for which the cast to string is well defined by the platform) we can enforce the string cast.

The proposed workaround should not break any dependency.

