### PR TITLE
Handle root path with no tag resource generation

### DIFF
--- a/bravado_core/resource.py
+++ b/bravado_core/resource.py
@@ -3,7 +3,6 @@ import logging
 
 from six import iteritems
 
-from bravado_core.exception import SwaggerMappingError
 from bravado_core.operation import Operation
 
 log = logging.getLogger(__name__)
@@ -15,6 +14,7 @@ def convert_path_to_resource(path_name):
     name on a best effort basis when an operation has no tags.
 
     Examples:
+      /                   ->  _
       /pet                ->  pet
       /pet/findByStatus   ->  pet
       /pet/findByTags     ->  pet
@@ -25,10 +25,9 @@ def convert_path_to_resource(path_name):
         should be associated with.
     """
     tokens = path_name.lstrip('/').split('/')
-    err_msg = "Could not extract resource name from path {0}"
     resource_name = tokens[0]
     if not resource_name:
-        raise SwaggerMappingError(err_msg.format(path_name))
+        return '_'
     return resource_name
 
 
@@ -83,6 +82,7 @@ class Resource(object):
     :param ops: operations associated with this resource (by tag)
     :type ops: dict where (key, value) = (op_name, Operation)
     """
+
     def __init__(self, name, ops):
         log.debug(u"Building resource '%s'" % name)
         self.name = name

--- a/tests/resource/convert_path_to_resource_test.py
+++ b/tests/resource/convert_path_to_resource_test.py
@@ -1,6 +1,3 @@
-import pytest
-from bravado_core.exception import SwaggerMappingError
-
 from bravado_core.resource import convert_path_to_resource
 
 
@@ -14,13 +11,5 @@ def test_success():
         assert 'pet' == convert_path_to_resource(path_name)
 
 
-def test_fails_on_empty_string():
-    with pytest.raises(SwaggerMappingError) as excinfo:
-        convert_path_to_resource('')
-    assert 'name from path' in str(excinfo.value)
-
-
-def test_fails_on_slash():
-    with pytest.raises(SwaggerMappingError) as excinfo:
-        convert_path_to_resource('/')
-    assert 'name from path' in str(excinfo.value)
+def test_root_path():
+    assert convert_path_to_resource('/') == '_'


### PR DESCRIPTION
The PR would relax a little the constraint of the resource building process (issue #116).
At the moment the resource building requires either the path has a `tag` or the path matches the following regex `/.+`.

I believe that the constraint could be relaxed in order to allow the correct validation of specs like this

``` json
{
    "info": {
        "version": "0.0.0",
        "title": "Simple API"
    },
    "paths": {
        "/": {
            "get": {
                "responses": {
                    "200": {
                        "description": "OK"
                    }
                }
            }
        }
    },
    "swagger": "2.0"
}
```
