### PR TITLE
Add marshal and unmarshal to bravado-core.model's and testing

### DIFF
--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -82,6 +82,8 @@ def create_model_type(swagger_spec, model_name, model_spec):
     :returns: dynamic type created with attributes, docstrings attached
     :rtype: type
     """
+    from bravado_core.marshal import marshal_model
+    from bravado_core.unmarshal import unmarshal_model
     doc = docstring_property(partial(
         create_model_docstring, swagger_spec, model_spec))
 
@@ -94,6 +96,8 @@ def create_model_type(swagger_spec, model_name, model_spec):
         __repr__=lambda self: create_model_repr(self, model_spec,
                                                 swagger_spec),
         __dir__=lambda self: model_dir(self, model_spec, swagger_spec),
+        marshal=lambda self: marshal_model(swagger_spec, model_spec, self),
+        unmarshal=staticmethod(lambda val: unmarshal_model(swagger_spec, model_spec, val)),
     )
     return type(str(model_name), (object,), methods)
 

--- a/tests/model/conftest.py
+++ b/tests/model/conftest.py
@@ -83,6 +83,7 @@ def definitions_spec():
                     }
                 },
             },
+            "x-model": "Pet",
         },
         "Cat": {
             "allOf": [

--- a/tests/model/create_model_type_test.py
+++ b/tests/model/create_model_type_test.py
@@ -41,3 +41,19 @@ def test_create_model_type_lazy_docstring(mock_create_docstring,
     assert mock_create_docstring.call_count == 0
     assert pet_type.__doc__ == mock_create_docstring.return_value
     assert mock_create_docstring.call_count == 1
+
+
+def test_marshal_and_unmarshal(petstore_spec):
+    Pet = petstore_spec.definitions['Pet']
+    pet_id = 1
+    pet_name = 'Darwin'
+    pet_photo_urls = []
+    pet = Pet(id=pet_id, name=pet_name, photoUrls=pet_photo_urls)
+    marshalled_model = pet.marshal()
+    unmarshalled_marshalled_model = Pet.unmarshal(marshalled_model)
+
+    assert marshalled_model == {'id': pet_id, 'name': pet_name, 'photoUrls': pet_photo_urls}
+    assert isinstance(unmarshalled_marshalled_model, Pet)
+    assert unmarshalled_marshalled_model.id == pet_id
+    assert unmarshalled_marshalled_model.name == pet_name
+    assert unmarshalled_marshalled_model.photoUrls == pet_photo_urls


### PR DESCRIPTION
Add marshal and unmarshal functionality, so we can deserialize and serialize easily in frontend services.

Same as this PR - https://github.com/Yelp/bravado-core/pull/113  But, I added tests, and found the unmarshal lambda function needed to be wrapped with staticmethod for python 2.6 and 2.7.  Otherwise, I'd get "TypeError: unbound method <lambda>()..."