### PR TITLE
Allow overriding security spec with empty list

### DIFF
--- a/bravado_core/operation.py
+++ b/bravado_core/operation.py
@@ -59,8 +59,9 @@ class Operation(object):
             deref = self.swagger_spec.deref
             op_spec = deref(self.op_spec)
             spec_dict = deref(self.swagger_spec.spec_dict)
-            security_spec = deref(op_spec.get('security', []))
-            if len(security_spec) == 0:
+            if 'security' in op_spec:
+                security_spec = deref(op_spec['security'])
+            else:
                 security_spec = spec_dict.get('security', [])
             security_defs_dict = spec_dict.get('securityDefinitions', {})
 

--- a/tests/operation/conftest.py
+++ b/tests/operation/conftest.py
@@ -146,3 +146,15 @@ def specs_with_security_obj_in_root_and_no_security_specs(
 ):
     del specs_with_security_obj_in_root_and_security_specs['securityDefinitions']  # noqa
     return specs_with_security_obj_in_root_and_security_specs
+
+
+@pytest.fixture
+def specs_with_security_obj_in_root_and_empty_security_spec(
+    specs_with_security_obj_in_root_and_security_specs
+):
+    path_spec = specs_with_security_obj_in_root_and_security_specs['paths']
+    for path, path_item in iteritems(path_spec):
+        for http_method in path_item.keys():
+            path_item[http_method]['security'] = []
+
+    return specs_with_security_obj_in_root_and_security_specs

--- a/tests/operation/security_object_test.py
+++ b/tests/operation/security_object_test.py
@@ -67,6 +67,21 @@ def test_op_with_security_in_root_with_security_defs(
     )
 
 
+def test_op_with_security_in_root_with_empty_security_spec(
+        specs_with_security_obj_in_root_and_empty_security_spec,
+):
+    resources = build_resources(Spec(
+            specs_with_security_obj_in_root_and_empty_security_spec,
+    ))
+
+    resource = resources.get('pet')
+    assert resource is not None
+
+    operation = getattr(resource, 'findPetsByStatus')
+    assert operation is not None
+    assert len(operation.security_objects) == 0
+
+
 def test_correct_request_with_apiKey_security(petstore_spec):
     request = Mock(
         spec=IncomingRequest,


### PR DESCRIPTION
Currently the global `security` property of the spec can be overridden in specific operations, but only if the list of security requirements is non-empty.

In the [official spec](http://swagger.io/specification/#operationObject) it states that

>  To remove a top-level security declaration, an empty array can be used

for an operation's `security` property.

This change should bring things in line with the official spec.