### PR TITLE
Contribution guidelines and master changelog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,10 @@
 Changelog
 =========
+X.X.X (XXXX-XX-XX)
+------------------
+- The content will be used to build the Changelog for the new bravado-core release
+  (add before this line your modifications summary and PR reference)
+
 4.5.1 (2016-09-27)
 ------------------
 - Add marshal and unmarshal methods to models - PR #113, #120.

--- a/README.rst
+++ b/README.rst
@@ -67,6 +67,17 @@ Setup
     .tox/py27/bin/pre-commit install
 
 
+Contributing
+------------
+
+1. Fork it ( http://github.com/Yelp/bravado-core/fork )
+2. Create your feature branch (``git checkout -b my-new-feature``)
+3. Add your modifications
+4. Add short summary of your modifications on ``CHANGELOG.rst``
+5. Commit your changes (``git commit -m "Add some feature"``)
+6. Push to the branch (``git push origin my-new-feature``)
+7. Create new Pull Request
+
 License
 -------
 


### PR DESCRIPTION
As done in [bravado](https://github.com/Yelp/bravado) could be helpful having a sort of guideline for the project contribution.

The CHANGELOG-MASTER.rst file is added in order to avoid to have the changelog related to the master modifications on readthedocs.
