### PR TITLE
[allow-model-self-property]: Allow models to have a "self" property.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,7 @@ Changelog
 =========
 X.X.X (XXXX-XX-XX)
 ------------------
+- Allow self as name for model property, adds new "create" alternate model constructor - Issue #125, PR #126.
 - Allow overriding of security specs - PR #121
 - The content will be used to build the Changelog for the new bravado-core release
   (add before this line your modifications summary and PR reference)

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -87,6 +87,11 @@ def create_model_type(swagger_spec, model_name, model_spec):
     doc = docstring_property(partial(
         create_model_docstring, swagger_spec, model_spec))
 
+    def create(cls, kwargs):
+        self = cls.__new__(cls)
+        model_constructor(self, model_spec, swagger_spec, kwargs)
+        return self
+
     methods = dict(
         __doc__=doc,
         __eq__=lambda self, other: compare(self, other),
@@ -96,6 +101,7 @@ def create_model_type(swagger_spec, model_name, model_spec):
         __repr__=lambda self: create_model_repr(self, model_spec,
                                                 swagger_spec),
         __dir__=lambda self: model_dir(self, model_spec, swagger_spec),
+        create=classmethod(create),
         marshal=lambda self: marshal_model(swagger_spec, model_spec, self),
         unmarshal=staticmethod(lambda val: unmarshal_model(swagger_spec, model_spec, val)),
     )

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -171,5 +171,5 @@ def unmarshal_model(swagger_spec, model_spec, model_value):
             .format(model_value, model_type, type(model_value)))
 
     model_as_dict = unmarshal_object(swagger_spec, model_spec, model_value)
-    model_instance = model_type(**model_as_dict)
+    model_instance = model_type.create(model_as_dict)
     return model_instance

--- a/tests/unmarshal/unmarshal_object_test.py
+++ b/tests/unmarshal/unmarshal_object_test.py
@@ -224,6 +224,65 @@ def test_with_model(minimal_swagger_dict, address_spec, location_spec):
     assert expected_address == address
 
 
+def test_self_property_with_model(minimal_swagger_dict):
+    link_spec = {
+        'type': 'object',
+        'required': ['_links'],
+        'properties': {
+            '_links': {
+                '$ref': '#/definitions/Self',
+            },
+        },
+    }
+
+    self_spec = {
+        'type': 'object',
+        'required': ['self'],
+        'properties': {
+            'self': {
+                'type': 'object',
+                'required': ['href'],
+                'properties': {
+                    'href': {
+                        'type': 'string',
+                    },
+                },
+            },
+        },
+    }
+
+    minimal_swagger_dict['definitions']['Links'] = link_spec
+    minimal_swagger_dict['definitions']['Self'] = self_spec
+
+    self_link_response = {
+        'get': {
+            'responses': {
+                '200': {
+                    'description': 'A self link.',
+                    'schema': {
+                        '$ref': '#/definitions/Links',
+                    }
+                }
+            }
+        }
+    }
+    minimal_swagger_dict['paths']['/foo'] = self_link_response
+
+    self_link_swagger_spec = Spec.from_dict(minimal_swagger_dict)
+
+    href = "http://example.com"
+    self_link_dict = {
+        "_links": {
+            "self": {
+                "href": href,
+            },
+        },
+    }
+
+    self_link = unmarshal_object(self_link_swagger_spec, link_spec, self_link_dict)
+    assert self_link["_links"].self["href"] == href
+
+
 def test_object_not_dict_like_raises_error(empty_swagger_spec, address_spec):
     i_am_not_dict_like = 34
     with pytest.raises(SwaggerMappingError) as excinfo:


### PR DESCRIPTION
This adds support for models to contain properties named "self", without
triggering a name clash in the `__init__` method.

Unmarshaling is changed to use a new constructor in order to avoid
changing the signature of the `__init__` method.

I'm unsure how to simplify the test case, as how bravado chooses to create models is unclear to me. Worked towards my use case until was able to replicate a model with a self property.

In reference to issue #125 