### PR TITLE
Adds minimal support for responses with text/* content_types

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ Changelog
 X.X.X (XXXX-XX-XX)
 ------------------
 - Allow overriding of security specs - PR #121
+- Adds minimal support for responses with text/* content_type.
 - The content will be used to build the Changelog for the new bravado-core release
   (add before this line your modifications summary and PR reference)
 

--- a/bravado_core/response.py
+++ b/bravado_core/response.py
@@ -190,6 +190,10 @@ def validate_response_body(op, response_spec, response):
         response_value = response.json()
         validate_schema_object(
             op.swagger_spec, response_body_spec, response_value)
+    elif response.content_type.startswith("text/"):
+        # TODO: support some kind of validation for text/* responses
+        # TODO: but in the meantime don't raise errors for them
+        pass
     else:
         # TODO: Expand content-type support for non-json types
         raise SwaggerMappingError(

--- a/tests/response/validate_response_body_test.py
+++ b/tests/response/validate_response_body_test.py
@@ -93,3 +93,18 @@ def test_failure_response_content_type_not_supported_by_bravado_core(
     with pytest.raises(SwaggerMappingError) as excinfo:
         validate_response_body(op, response_spec, response)
     assert 'Unsupported content-type' in str(excinfo.value)
+
+
+def test_success_text_plain_response(minimal_swagger_spec):
+    response_spec = {
+        'description': 'Plain Text Response',
+        'schema': {}
+    }
+    op = Operation(minimal_swagger_spec, '/foo', 'get',
+                   op_spec={'produces': ['text/plain']})
+    response = Mock(
+        spec=OutgoingResponse,
+        content_type='text/plain',
+        text="Plain Text"
+    )
+    validate_response_body(op, response_spec, response)


### PR DESCRIPTION
Does not validate their body  in any meaningful way, but allows
us to take advantage of all the other request/response validations.

Main use case for us is defining some mandatory endpoints that cannot be implemented as `application/json` because of external requirements. For example:
 
```yaml
  /metrics:
    get:
      produces:
        - "text/plain"
      responses:
        "200":
          description: "Prometheus metrics"
          schema: 
            type: string
```