### PR TITLE
Fix syntax error in jsonschema dependency with Python 2.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,33 @@
 # Copyright (c) 2014-2015, Yelp, Inc.
 
 import os
+import sys
 
 from setuptools import setup
 
 import bravado_core
+
+
+install_requires = [
+    "python-dateutil",
+    "pyyaml",
+    "simplejson",
+    "six",
+    "swagger-spec-validator>=2.0.1",
+]
+
+
+# The [format] extras of jsonschema installs and imports some packages
+# (webcolors) that raise a syntax error in Python 2.6.
+if sys.version_info[:2] >= (2, 7):
+    install_requires.append("jsonschema[format]>=2.5.1")
+else:
+    install_requires.extend([
+        "jsonschema>=2.5.1",
+        "rfc3987",
+        "strict-rfc3339",
+    ])
+
 
 setup(
     name="bravado-core",
@@ -29,12 +52,5 @@ setup(
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.4",
     ],
-    install_requires=[
-        "jsonschema[format]>=2.5.1",
-        "python-dateutil",
-        "pyyaml",
-        "simplejson",
-        "six",
-        "swagger-spec-validator>=2.0.1",
-    ],
+    install_requires=install_requires,
 )


### PR DESCRIPTION
Got tired of seeing those py26 builds failing... was a result of the `[format]` extras of the `jsonschema` package containing syntax introduced in 2.7.

The solution was to remove the extras in `install_requires` if installing on version 2.6 and add those extra packages in in manually with the exception of the offending one (`webcolors`).

This isn't the greatest solution but may be a good compromise considering `jsonschema` doesn't even support Python 2.6. We've also lost the ability to validate CSS color codes...