### PR TITLE
date-time formatter to-wire defaults to UTC timezone

### DIFF
--- a/bravado_core/formatter.py
+++ b/bravado_core/formatter.py
@@ -9,7 +9,7 @@ import six
 import dateutil.parser
 
 from bravado_core import schema
-
+import pytz
 
 if six.PY3:
     long = int
@@ -53,7 +53,7 @@ def to_python(swagger_spec, primitive_spec, value):
 
 
 class SwaggerFormat(namedtuple('SwaggerFormat',
-                    'format to_python to_wire validate description')):
+                               'format to_python to_wire validate description')):
     """User-defined format which can be registered with a
     :class:`bravado_core.spec.Spec` to handle marshalling to wire format,
     unmarshalling to a python type, and format specific validation.
@@ -111,7 +111,7 @@ DEFAULT_FORMATS = {
         description='Converts [wire]number:double <=> python float'),
     'date-time': SwaggerFormat(
         format='date-time',
-        to_wire=lambda dt: dt.isoformat(),
+        to_wire=lambda dt: (dt if dt.tzinfo else pytz.utc.localize(dt)).isoformat(),
         to_python=lambda dt: dateutil.parser.parse(dt),
         validate=NO_OP,  # jsonschema validates date-time
         description=(
@@ -134,4 +134,4 @@ DEFAULT_FORMATS = {
         to_python=lambda i: i if isinstance(i, long) else long(i),
         validate=NO_OP,  # jsonschema validates integer
         description='Converts [wire]integer:int64 <=> python long'),
-    }
+}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@
 mock<1.1.0
 pre-commit
 pytest
+pytz

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ install_requires = [
     "simplejson",
     "six",
     "swagger-spec-validator>=2.0.1",
+    "pytz",
 ]
 
 

--- a/tests/formatter/to_wire_test.py
+++ b/tests/formatter/to_wire_test.py
@@ -5,6 +5,7 @@ import six
 
 from bravado_core.formatter import to_wire
 from bravado_core.spec import Spec
+from pytz import timezone
 
 
 def test_none(minimal_swagger_spec):
@@ -23,10 +24,19 @@ def test_date(minimal_swagger_spec):
         minimal_swagger_spec, string_spec, date(2015, 4, 1))
 
 
-def test_datetime(minimal_swagger_spec):
+def test_naive_datetime(minimal_swagger_spec):
     string_spec = {'type': 'string', 'format': 'date-time'}
-    assert '2015-03-22T13:19:54' == to_wire(
+    assert '2015-03-22T13:19:54+00:00' == to_wire(
         minimal_swagger_spec, string_spec, datetime(2015, 3, 22, 13, 19, 54))
+
+
+def test_localized_datetime(minimal_swagger_spec):
+    string_spec = {'type': 'string', 'format': 'date-time'}
+    assert '2015-03-22T13:19:54-07:00' == to_wire(
+        minimal_swagger_spec,
+        string_spec,
+        timezone('America/Los_Angeles').localize(datetime(2015, 3, 22, 13, 19, 54)),
+    )
 
 
 @patch('bravado_core.spec.warnings.warn')


### PR DESCRIPTION
As highlighted on #133 ``date-time`` to-wire function generates invalid result in case of näive datetime objects.
To workaround this issue I'm defaulting the datetime timezone to UTC (in case it is not present).