### PR TITLE
[RFC] Test processing of binary body of request

### DIFF
--- a/tests/param/marshal_param_test.py
+++ b/tests/param/marshal_param_test.py
@@ -157,6 +157,63 @@ def test_body(empty_swagger_spec, param_spec):
     assert APP_JSON == request['headers']['Content-Type']
 
 
+def test_body_binary_octet_stream(empty_swagger_spec, param_spec):
+    param_spec['in'] = 'body'
+    param_spec['schema'] = {
+        'type': 'string',
+        'format': 'binary'
+    }
+    del param_spec['type']
+    del param_spec['format']
+    param = Param(empty_swagger_spec, Mock(spec=Operation), param_spec)
+    request = {
+        'headers': {
+            'Content-Type': 'application/octet-stream'
+        }
+    }
+    marshal_param(param, bytes(10), request)
+    assert b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00' == request['data']
+    assert 'application/octet-stream' == request['headers']['Content-Type']
+
+
+def test_body_binary_json(empty_swagger_spec, param_spec):
+    param_spec['in'] = 'body'
+    param_spec['schema'] = {
+        'type': 'string',
+        'format': 'binary'
+    }
+    del param_spec['type']
+    del param_spec['format']
+    param = Param(empty_swagger_spec, Mock(spec=Operation), param_spec)
+    request = {
+        'headers': {
+            'Content-Type': 'application/json'
+        }
+    }
+    marshal_param(param, bytes(10), request)
+    assert b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00' == request['data']
+    assert 'application/json' == request['headers']['Content-Type']
+
+
+def test_body_binary_foo(empty_swagger_spec, param_spec):
+    param_spec['in'] = 'body'
+    param_spec['schema'] = {
+        'type': 'string',
+        'format': 'binary'
+    }
+    del param_spec['type']
+    del param_spec['format']
+    param = Param(empty_swagger_spec, Mock(spec=Operation), param_spec)
+    request = {
+        'headers': {
+            'Content-Type': 'application/foo'
+        }
+    }
+    marshal_param(param, bytes(10), request)
+    assert b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00' == request['data']
+    assert 'application/foo' == request['headers']['Content-Type']
+
+
 def test_formData_integer(empty_swagger_spec, param_spec):
     param_spec['in'] = 'formData'
     param = Param(empty_swagger_spec, Mock(spec=Operation), param_spec)


### PR DESCRIPTION
I am trying to use bravado for generating a python client from a swagger 2.0 specification that has a PUT request with body whose `Content-Type` header is arbitrary and body is arbitrary sequence of bytes (type string, format binary). The client gets generated but when issuing request the client throws exception. I distilled exception to failing tests in bravado-core - this PR - and I welcome comments. The impression I have is that on Python 3 bravado forces body to be valid Unicode sequence, but I am not sure.

The 3 test failures are similar - the first one is:
```
=================================== FAILURES ===================================
________________________ test_body_binary_octet_stream _________________________

empty_swagger_spec = <bravado_core.spec.Spec object at 0x10e739a90>
param_spec = {'description': 'ID of pet that needs to be fetched', 'in': 'body', 'name': 'petId', 'schema': {'format': 'binary', 'type': 'string'}}

    def test_body_binary_octet_stream(empty_swagger_spec, param_spec):
        param_spec['in'] = 'body'
        param_spec['schema'] = {
            'type': 'string',
            'format': 'binary'
        }
        del param_spec['type']
        del param_spec['format']
        param = Param(empty_swagger_spec, Mock(spec=Operation), param_spec)
        request = {
            'headers': {
                'Content-Type': 'application/octet-stream'
            }
        }
>       marshal_param(param, bytes(10), request)

tests/param/marshal_param_test.py:174:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
bravado_core/param.py:122: in marshal_param
    validate_schema_object(swagger_spec, param_spec, value)
bravado_core/validate.py:24: in validate_schema_object
    validate_primitive(swagger_spec, schema_object_spec, value)
bravado_core/validate.py:49: in validate_primitive
    resolver=swagger_spec.resolver).validate(value)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <jsonschema.validators.create.<locals>.Validator object at 0x10e46fe10>
args = (b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00',), kwargs = {}
error = <ValidationError: "b'\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00' is not of type 'string'">

    def validate(self, *args, **kwargs):
        for error in self.iter_errors(*args, **kwargs):
>           raise error
E           jsonschema.exceptions.ValidationError: b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00' is not of type 'string'
E
E           Failed validating 'type' in schema:
E               {'format': 'binary', 'type': 'string'}
E
E           On instance:
E               b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'

.tox/py36/lib/python3.6/site-packages/jsonschema/validators.py:130: ValidationError
```


----
Original exception using bravado:
```
**********************************************************************
Exception raised:
    Traceback (most recent call last):
      File "/Users/luca/homebrew/Cellar/python3/3.6.0/Frameworks/Python.framework/Versions/3.6/lib/python3.6/doctest.py", line 1330, in __run
        compileflags, 1), test.globs)
...
      File "<FILE.rst[13]>", line 2, in FUNCTION
        return CLIENT.TAG.OP(..., body=b, _request_options={'Content-Type': ct
      File "/Users/luca/dev/.../src/bravado/bravado/client.py", line 250, in __call__
        self.operation, request_options, **op_kwargs)
      File "/Users/luca/dev/.../src/bravado/bravado/client.py", line 291, in construct_request
        construct_params(operation, request, op_kwargs)
      File "/Users/luca/dev/.../src/bravado/bravado/client.py", line 313, in construct_params
        marshal_param(param, param_value, request)
      File "/Users/luca/homebrew/lib/python3.6/site-packages/bravado_core/param.py", line 122, in marshal_param
        validate_schema_object(swagger_spec, param_spec, value)
      File "/Users/luca/homebrew/lib/python3.6/site-packages/bravado_core/validate.py", line 24, in validate_schema_object
        validate_primitive(swagger_spec, schema_object_spec, value)
      File "/Users/luca/homebrew/lib/python3.6/site-packages/bravado_core/validate.py", line 49, in validate_primitive
        resolver=swagger_spec.resolver).validate(value)
      File "/Users/luca/homebrew/lib/python3.6/site-packages/jsonschema/validators.py", line 123, in validate
        raise error
    jsonschema.exceptions.ValidationError: b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00' is not of type 'string'

    Failed validating 'type' in schema:
        {'format': 'binary', 'type': 'string'}

    On instance:
        b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
```