### PR TITLE
Allow nullable enum

### DIFF
--- a/bravado_core/swagger20_validator.py
+++ b/bravado_core/swagger20_validator.py
@@ -83,6 +83,10 @@ def enum_validator(swagger_spec, validator, enums, instance, schema):
     :param schema: swagger spec for the object
     :type schema: dict
     """
+
+    if is_prop_nullable(swagger_spec, schema) and instance is None:
+        return
+
     if schema.get('type') == 'array':
         for element in instance:
             for error in _validators.enum(validator, enums, element, schema):


### PR DESCRIPTION
This PR tries to solve Issue #137.
Additionally it fixes a Python2.6 dependency issue  ([jsonschema==2.6.0 drops support Python2.6 support](https://github.com/Julian/jsonschema/blob/master/CHANGELOG.rst#v260)) and fixes the cover tox task which was constantly failing. 

The current setup of the enum validation checks that ``instance`` is within the accepted values without caring about ``x-nullable`` field.

Without the ``if`` statement added on ``enum_validator`` the added tests would have the following results:
```
=================================== FAILURES ===================================
 test_validate_object_with_different_enum_configurations[value1-enum_values1-False] 

minimal_swagger_spec = <bravado_core.spec.Spec object at 0x10eb1f5f8>
value = {'prop': None}, enum_values = ['VAL'], expect_exception = False

    @pytest.mark.parametrize(
        'value, enum_values, expect_exception',
        (
            [{'prop': 'VAL'}, ['VAL'], False],
            [{'prop': None}, ['VAL'], False],
            [{'prop': 'In-Valid Value'}, ['VAL'], True],
        )
    )
    def test_validate_object_with_different_enum_configurations(minimal_swagger_spec, value, enum_values, expect_exception):
        minimal_swagger_spec.spec_dict['definitions']['obj'] = {
            'properties': {
                'prop': {
                    'type': 'string',
                    'enum': enum_values,
                    'x-nullable': True
                }
            }
        }
        captured_exception = None
        try:
            validate_object(
                swagger_spec=minimal_swagger_spec,
                object_spec=minimal_swagger_spec.spec_dict['definitions']['obj'],
                value=value,
            )
        except ValidationError as e:
            captured_exception = e
    
        if not expect_exception:
>           assert captured_exception is None
E           assert <ValidationError: "None is not one of ['VAL']"> is None

enum_validator_test.py:85: AssertionError
====================== 1 failed, 5 passed in 0.10 seconds ======================

Process finished with exit code 0
```

