### PR TITLE
Fix Python 2.6 build issue

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,23 +1,22 @@
-
-- repo: git://github.com/pre-commit/pre-commit-hooks
-  sha: c8a1c91
-  hooks:
-    - id: autopep8-wrapper
-      args: ['-i', '--ignore=E309,E501']
-    - id: check-json
-    - id: check-yaml
-    - id: debug-statements
-    - id: end-of-file-fixer
-    - id: flake8
-      args: [--max-line-length=131]
-    - id: name-tests-test
-    - id: trailing-whitespace
-    - id: requirements-txt-fixer
-      files: 'requirements-dev.txt'
-
-# TODO: re-enable in bravado_core, disabled for now to avoid excessive merge
-# conflicts
-#- repo: git://github.com/FalconSocial/pre-commit-python-sorter
-#  sha: 1.0.1
-#  hooks:
-#    - id: python-import-sorter
+-   repo: git://github.com/pre-commit/pre-commit-hooks
+    sha: 46251c9523506b68419aefdf5ff6ff2fbc4506a4
+    hooks:
+    -   id: autopep8-wrapper
+        args:
+        - -i
+        - --ignore=E309,E501
+    -   id: check-json
+    -   id: check-yaml
+    -   id: debug-statements
+    -   id: end-of-file-fixer
+    -   id: flake8
+        args:
+        - --max-line-length=131
+    -   id: name-tests-test
+    -   id: trailing-whitespace
+    -   id: requirements-txt-fixer
+        files: requirements-dev.txt
+-   repo: git://github.com/asottile/reorder_python_imports
+    sha: 9aa4d08f9a28d3defc5e4db3c3b77d1a9980fd1a
+    hooks:
+    -   id: reorder-python-imports

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,25 @@
 language: python
-env:
-- TOX_ENV=py26
-- TOX_ENV=py27
-- TOX_ENV=py34
-- TOX_ENV=cover
-- TOX_ENV=docs
-- TOX_ENV=flake8
+
+matrix:
+  include:
+  - python: "2.6"
+    env: TOX_ENV=py26
+  - python: "2.7"
+    env: TOX_ENV=py27
+  - python: "3.4"
+    env: TOX_ENV=py34
+  - python: "3.5"
+    env: TOX_ENV=py35
+  - python: "3.6"
+    env: TOX_ENV=py36
+  - python: "2.7"
+    env: TOX_ENV=cover
+  - python: "2.7"
+    env: TOX_ENV=docs
+  - python: "2.7"
+    env: TOX_ENV=flake8
 install:
-- "pip install --use-mirrors tox coveralls"
+- "pip install tox coveralls"
 script:
 - tox -e $TOX_ENV
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: python
 
 matrix:
   include:
-  - python: "2.6"
-    env: TOX_ENV=py26
   - python: "2.7"
     env: TOX_ENV=py27
   - python: "3.4"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ X.X.X (XXXX-XX-XX)
 ------------------
 - The content will be used to build the Changelog for the new bravado-core release
   (add before this line your modifications summary and PR reference)
+- Removed support for Python 2.6
 
 4.6.0 (2016-11-28)
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,8 @@ setup(
         "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
     ],
     install_requires=install_requires,
 )

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 # Copyright (c) 2013, Digium, Inc.
 # Copyright (c) 2014-2015, Yelp, Inc.
-
 import os
-import sys
 
 from setuptools import setup
 
@@ -11,6 +9,7 @@ import bravado_core
 
 
 install_requires = [
+    "jsonschema[format]>=2.5.1",
     "python-dateutil",
     "pyyaml",
     "simplejson",
@@ -18,18 +17,6 @@ install_requires = [
     "swagger-spec-validator>=2.0.1",
     "pytz",
 ]
-
-
-# The [format] extras of jsonschema installs and imports some packages
-# (webcolors) that raise a syntax error in Python 2.6.
-if sys.version_info[:2] >= (2, 7):
-    install_requires.append("jsonschema[format]>=2.5.1")
-else:
-    install_requires.extend([
-        "jsonschema>=2.5.1",
-        "rfc3987",
-        "strict-rfc3339",
-    ])
 
 
 setup(
@@ -49,7 +36,6 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules",
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",

--- a/tox.ini
+++ b/tox.ini
@@ -38,5 +38,5 @@ max_line_length = 120
 
 [testenv:pre-commit]
 envdir = {toxworkdir}/pre-commit
-deps = pre-commit>=0.2.10
+deps = pre-commit>=0.12.0
 commands = pre-commit {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py34, flake8
+envlist = py26, py27, py34, py35, py36, flake8
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py34, py35, py36, flake8
+envlist = py27, py34, py35, py36, flake8
 
 [testenv]
 deps =
@@ -20,7 +20,6 @@ deps =
     pytest-cov
 commands =
     py.test --cov bravado_core {posargs:tests}
-    coverage combine --append
     coverage report --omit=.tox/*,tests/*,/usr/share/pyshared/*,/usr/lib/pymodules/* -m
 
 [testenv:docs]


### PR DESCRIPTION
I'm limiting the ``jsonschema`` dependency in case of Python 2.6 since from [``jsonschema>=2.6.0``](https://github.com/Julian/jsonschema/blob/master/CHANGELOG.rst#v260) it is dropped support for Python 2.6. This solution is a temporary fix until we decide to completely drop Python 2.6 support on ``bravado-core``.
In the mean time I have update ``pre-commit`` hooks and dependencies and added travis tests against python 3.5 and 3.6