### PR TITLE
make unmarshal_collection_format unmarshal empty lists properly

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,7 @@ Changelog
 =========
 X.X.X (XXXX-XX-XX)
 ------------------
-- The content will be used to build the Changelog for the new bravado-core release
-  (add before this line your modifications summary and PR reference)
+- Fix unmarshalling empty array types
 
 4.6.0 (2016-11-28)
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,8 @@ Changelog
 =========
 X.X.X (XXXX-XX-XX)
 ------------------
+- The content will be used to build the Changelog for the new bravado-core release
+  (add before this line your modifications summary and PR reference)
 - Fix unmarshalling empty array types
 
 4.6.0 (2016-11-28)

--- a/bravado_core/param.py
+++ b/bravado_core/param.py
@@ -349,7 +349,10 @@ def unmarshal_collection_format(swagger_spec, param_spec, value):
         value_array = value if isinstance(value, list) else [value]
     else:
         sep = COLLECTION_FORMATS[collection_format]
-        value_array = value.split(sep)
+        if value == '':
+            value_array = []
+        else:
+            value_array = value.split(sep)
 
     items_spec = param_spec['items']
     items_type = deref(items_spec).get('type')

--- a/tests/param/unmarshal_collection_format_test.py
+++ b/tests/param/unmarshal_collection_format_test.py
@@ -33,6 +33,17 @@ def test_formats(empty_swagger_spec, array_spec):
             empty_swagger_spec, array_spec, param_value)
 
 
+@pytest.mark.parametrize('format_name,separator', COLLECTION_FORMATS.items())
+def test_formats_empty_list(empty_swagger_spec, array_spec, format_name, separator):
+    array_spec['collectionFormat'] = format_name
+    param_value = separator.join([])
+    assert [] == unmarshal_collection_format(
+        empty_swagger_spec,
+        array_spec,
+        param_value,
+    )
+
+
 def test_multi_no_op_because_handled_by_http_client_lib(empty_swagger_spec,
                                                         array_spec):
     array_spec['collectionFormat'] = 'multi'


### PR DESCRIPTION
I added a test to check this as well. This fixes an issue where if empty string is an invalid value of the array's format, then it doesn't 400. Not to mention, getting `['']` instead of `[]` is just wrong.