### PR TITLE
Add nonefy_missing_properties configuration

### DIFF
--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -56,7 +56,10 @@ CONFIG_DEFAULTS = {
     # :class:`bravado_core.formatter.SwaggerFormat`. These formats are in
     # addition to the formats already supported by the Swagger 2.0
     # Specification.
-    'formats': []
+    'formats': [],
+
+    # Fill with None all the missing properties during object unmarshal-ing
+    'include_missing_properties': True,
 }
 
 

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -140,11 +140,11 @@ def unmarshal_object(swagger_spec, object_spec, object_value):
             # Don't marshal when a spec is not available - just pass through
             result[k] = v
 
-    # re-introduce and None'ify any properties that weren't passed
     properties = collapsed_properties(deref(object_spec), swagger_spec)
     for prop_name, prop_spec in iteritems(properties):
-        if prop_name not in result:
+        if prop_name not in result and swagger_spec.config['include_missing_properties']:
             result[prop_name] = None
+
     return result
 
 

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -17,21 +17,25 @@ All configuration is stored in a ``dict``.
     swagger_spec = Spec.from_dict(spec_dict, config=config)
 
 
-========================= =============== =========  ====================================================
-Config key                Type            Default    Description
-------------------------- --------------- ---------  ----------------------------------------------------
-*validate_swagger_spec*   boolean         True       | Validate the Swagger spec against
-                                                     | the Swagger 2.0 Specification.
-------------------------- --------------- ---------  ----------------------------------------------------
-*validate_requests*       boolean         True       | On the client side, validates outgoing requests.
-                                                     | On the server side, validates incoming requests.
-------------------------- --------------- ---------  ----------------------------------------------------
-*validate_responses*      boolean         True       | On the client side, validates incoming responses.
-                                                     | On the server side, validates outgoing responses.
-------------------------- --------------- ---------  ----------------------------------------------------
-*use_models*              boolean         True       | Use python classes to represent models
-                                                     | instead of dicts. See :ref:`models`.
-------------------------- --------------- ---------  ----------------------------------------------------
-*formats*                 list of         []         | List of user-defined formats to support.
-                          SwaggerFormat              | See :ref:`formats`.
-========================= =============== =========  ====================================================
+
+============================= =============== ========= ====================================================
+Config key                    Type            Default   Description
+----------------------------- --------------- --------- ----------------------------------------------------
+*validate_swagger_spec*       boolean         True      | Validate the Swagger spec against
+                                                        | the Swagger 2.0 Specification.
+----------------------------- --------------- --------- ----------------------------------------------------
+*validate_requests*           boolean         True      | On the client side, validates outgoing requests.
+                                                        | On the server side, validates incoming requests.
+----------------------------- --------------- --------- ----------------------------------------------------
+*validate_responses*          boolean         True      | On the client side, validates incoming responses.
+                                                        | On the server side, validates outgoing responses.
+----------------------------- --------------- --------- ----------------------------------------------------
+*use_models*                  boolean         True      | Use python classes to represent models
+                                                        | instead of dicts. See :ref:`models`.
+----------------------------- --------------- --------- ----------------------------------------------------
+*formats*                     list of         []        | List of user-defined formats to support.
+                              SwaggerFormat             | See :ref:`formats`.
+----------------------------- --------------- --------- ----------------------------------------------------
+*include_missing_properties*   boolean         True     | Create properties with the value ``None`` if they
+                                                        | were not submitted during object unmarshalling
+============================= =============== ========= ====================================================

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,9 +55,12 @@ def composition_dict(composition_abspath):
         return json.loads(f.read())
 
 
-@pytest.fixture
-def composition_spec(composition_dict, composition_url):
-    return Spec.from_dict(composition_dict, origin_url=composition_url)
+@pytest.fixture(params=[
+    {'include_missing_properties': True},
+    {'include_missing_properties': False},
+])
+def composition_spec(request, composition_dict, composition_url):
+    return Spec.from_dict(composition_dict, origin_url=composition_url, config=request.param)
 
 
 @pytest.fixture

--- a/tests/unmarshal/unmarshal_model_test.py
+++ b/tests/unmarshal/unmarshal_model_test.py
@@ -30,15 +30,23 @@ def pet_dict():
     }
 
 
-def test_definitions_with_ref(composition_spec):
+@pytest.mark.parametrize(
+    'releaseDate',
+    (
+        '1981',
+        None
+    )
+)
+def test_definitions_with_ref(composition_spec, releaseDate):
     PongClone = composition_spec.definitions['pongClone']
     pong_clone_spec = composition_spec.spec_dict['definitions']['pongClone']
     pong_clone_dict = {
         'pang': 'hello',
         'additionalFeature': 'new!',
         'gameSystem': 'Fatari',
-        'releaseDate': '1981'
     }
+    if releaseDate:
+        pong_clone_dict['releaseDate'] = releaseDate
 
     pong_clone = unmarshal_model(composition_spec, pong_clone_spec,
                                  pong_clone_dict)
@@ -47,7 +55,11 @@ def test_definitions_with_ref(composition_spec):
     assert 'hello' == pong_clone.pang
     assert 'new!' == pong_clone.additionalFeature
     assert 'Fatari' == pong_clone.gameSystem
-    assert '1981' == pong_clone.releaseDate
+    if releaseDate or composition_spec.config['include_missing_properties']:
+        assert hasattr(pong_clone, 'releaseDate') is True
+        assert releaseDate == pong_clone.releaseDate
+    else:
+        assert hasattr(pong_clone, 'releaseDate') is False
 
 
 def test_pet(petstore_dict, pet_dict):

--- a/tests/unmarshal/unmarshal_object_test.py
+++ b/tests/unmarshal/unmarshal_object_test.py
@@ -44,8 +44,12 @@ def business_address_spec():
                 'properties': {
                     'name': {
                         'type': 'string'
-                    }
-                }
+                    },
+                    'floor': {
+                        'type': 'integer',
+                        'x-nullable': True,
+                    },
+                },
             }
         ]
     }
@@ -68,7 +72,7 @@ def location_spec():
 
 
 @pytest.fixture
-def business_address_swagger_spec(minimal_swagger_dict, address_spec, business_address_spec):
+def business_address_swagger_dict(minimal_swagger_dict, address_spec, business_address_spec):
     minimal_swagger_dict['definitions']['Address'] = address_spec
     minimal_swagger_dict['definitions']['BusinessAddress'] = business_address_spec
 
@@ -85,8 +89,15 @@ def business_address_swagger_spec(minimal_swagger_dict, address_spec, business_a
         }
     }
     minimal_swagger_dict['paths']['/foo'] = business_address_response
+    return minimal_swagger_dict
 
-    return Spec.from_dict(minimal_swagger_dict)
+
+@pytest.fixture(params=[
+    {'include_missing_properties': True},
+    {'include_missing_properties': False},
+])
+def business_address_swagger_spec(request, business_address_swagger_dict):
+    return Spec.from_dict(business_address_swagger_dict, config=request.param)
 
 
 @pytest.fixture
@@ -180,10 +191,12 @@ def test_with_model_composition(business_address_swagger_spec, address_spec, bus
     expected_business_address = {
         'company': 'n/a',
         'number': 1600,
-        'name': None,
         'street_name': 'Pennsylvania',
-        'street_type': 'Avenue'
+        'street_type': 'Avenue',
     }
+
+    if business_address_swagger_spec.config['include_missing_properties']:
+        expected_business_address.update(floor=None, name=None)
 
     business_address = unmarshal_object(business_address_swagger_spec, business_address_spec,
                                         business_address_dict)


### PR DESCRIPTION
This CR target Issue #150 (open by @dpopowich).

I have added an additional configuration flag ``nonefy_missing_properties`` which is defaulted to ``True`` for backward compatibility.

Setting the flag to ``False`` [bravado-core](https://github.com/Yelp/bravado-core/blob/master/bravado_core/unmarshal.py#L138-L142) will not set the to all the missing properties to ``None``.

**NOTE**: ``unmarshal_model`` will not be affected by this change since [``model_constructor``](https://github.com/Yelp/bravado-core/blob/master/bravado_core/model.py#L167-L171) will default to ``None`` all the missing properties.

An example is available on https://gist.github.com/macisamuele/b903295f1935ab7270e31145601dd5cb