### PR TITLE
Simplify travis and send coveralls only once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,5 @@ matrix:
   - env: TOXENV=flake8
 install: pip install tox coveralls
 script: tox
-after_success: coveralls
+after_success: if [ "$TOXENV" == "cover" ]; then coveralls; fi
 sudo: false


### PR DESCRIPTION
As is possible to observe on the last PRs (#155, #152, etc.) we are getting multiple coveralls notification for the same branch.
It happen because ``coveralls`` is executed for all the tox environments.
But actually only one is generating the correct coverage information ``cover``.
To avoid this "spam" in our CR I'm proposing to run ``coveralls`` only if the correct tox environment is executed