### PR TITLE
Set basepython for pre-commit environment in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -36,6 +36,7 @@ exclude = .svn,CVS,.bzr,.hg,.git,__pycache__,.tox,docs,virtualenv_run
 max_line_length = 120
 
 [testenv:pre-commit]
+basepython = /usr/bin/python2.7
 envdir = {toxworkdir}/pre-commit
 deps = pre-commit>=0.12.0
 commands = pre-commit {posargs}


### PR DESCRIPTION
@macisamuele this fixes the build failure we've been seeing internally. I'm going to make a release once this fix is in.