### PR TITLE
Add back old private method names with deprecation warning

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,10 @@ Changelog
 - The content will be used to build the Changelog for the new bravado-core release
   (add before this line your modifications summary and PR reference)
 
+4.7.1 (2017-03-21)
+------------------
+- Fix backward-incompatible Model API change which renames all model methods to have a single underscore infront of them. A deprecation warning has been added.
+
 4.7.0 (2017-03-21)
 ------------------
 - Added support for nullable fields in the format validator - PR #143. Thanks Adam Ever-Hadani

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 - The content will be used to build the Changelog for the new bravado-core release
   (add before this line your modifications summary and PR reference)
 
-4.7.1 (2017-03-21)
+4.7.1 (2017-03-22)
 ------------------
 - Fix backward-incompatible Model API change which renames all model methods to have a single underscore infront of them. A deprecation warning has been added.
 

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -309,7 +309,7 @@ class Model(object):
 
     def marshal(self):
         warn(
-            "Private model object methods are now prefixed with single underscore - use _marshal() instead.",
+            "Model object methods are now prefixed with single underscore - use _marshal() instead.",
             DeprecationWarning,
         )
         return self._marshal()
@@ -325,7 +325,7 @@ class Model(object):
     @classmethod
     def unmarshal(cls, val):
         warn(
-            "Private model object methods are now prefixed with single underscore - use _unmarshal() instead.",
+            "Model object methods are now prefixed with single underscore - use _unmarshal() instead.",
             DeprecationWarning,
         )
         return cls._unmarshal(val)
@@ -343,7 +343,7 @@ class Model(object):
     @classmethod
     def isinstance(cls, obj):
         warn(
-            "Private model object methods are now prefixed with single underscore - use _isinstance() instead.",
+            "Model object methods are now prefixed with single underscore - use _isinstance() instead.",
             DeprecationWarning,
         )
         return cls._isinstance(obj)

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
+from warnings import warn
 
 from six import iteritems
 
@@ -306,6 +307,13 @@ class Model(object):
         )
         return model
 
+    def marshal(self):
+        warn(
+            "Private model object methods are now prefixed with single underscore - use _marshal() instead.",
+            DeprecationWarning,
+        )
+        return self._marshal()
+
     def _marshal(self):
         """Marshal into a json-like dict.
 
@@ -313,6 +321,14 @@ class Model(object):
         """
         from bravado_core.marshal import marshal_model
         return marshal_model(self._swagger_spec, self._model_spec, self)
+
+    @classmethod
+    def unmarshal(cls, val):
+        warn(
+            "Private model object methods are now prefixed with single underscore - use _unmarshal() instead.",
+            DeprecationWarning,
+        )
+        return cls._unmarshal(val)
 
     @classmethod
     def _unmarshal(cls, val):
@@ -323,6 +339,14 @@ class Model(object):
         """
         from bravado_core.unmarshal import unmarshal_model
         return unmarshal_model(cls._swagger_spec, cls._model_spec, val)
+
+    @classmethod
+    def isinstance(cls, obj):
+        warn(
+            "Private model object methods are now prefixed with single underscore - use _isinstance() instead.",
+            DeprecationWarning,
+        )
+        return cls._isinstance(obj)
 
     @classmethod
     def _isinstance(cls, obj):


### PR DESCRIPTION
See related Issue #160 for fuller description of underlying issue.
TL;DR - there was an API change that is backward incompatible which is breaking usage of the library. This change re-introduces the old method names with a deprecation warning to allow for a migration grace period.