### PR TITLE
Add a test to make sure Model.marshal() and unmarshal() continue to work

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ Changelog
 
 4.7.1 (2017-03-22)
 ------------------
-- Fix backward-incompatible Model API change which renames all model methods to have a single underscore infront of them. A deprecation warning has been added.
+- Fix backward-incompatible Model API change which renames all model methods to have a single underscore infront of them. A deprecation warning has been added - Issue #160, PR #161. Thanks Adam Ever-Hadani for the contribution!
 
 4.7.0 (2017-03-21)
 ------------------

--- a/tests/model/create_model_type_test.py
+++ b/tests/model/create_model_type_test.py
@@ -58,3 +58,21 @@ def test_marshal_and_unmarshal(petstore_spec):
     assert unmarshalled_marshalled_model.id == pet_id
     assert unmarshalled_marshalled_model.name == pet_name
     assert unmarshalled_marshalled_model.photoUrls == pet_photo_urls
+
+
+def test_deprecated_marshal_and_unmarshal(petstore_spec):
+    """This test is a copy of the test above. It will be removed once we remove the deprecated
+    marshal() and unmarshal() methods."""
+    Pet = petstore_spec.definitions['Pet']
+    pet_id = 1
+    pet_name = 'Darwin'
+    pet_photo_urls = []
+    pet = Pet(id=pet_id, name=pet_name, photoUrls=pet_photo_urls)
+    marshalled_model = pet.marshal()
+    unmarshalled_marshalled_model = Pet.unmarshal(marshalled_model)
+
+    assert marshalled_model == {'id': pet_id, 'name': pet_name, 'photoUrls': pet_photo_urls}
+    assert isinstance(unmarshalled_marshalled_model, Pet)
+    assert unmarshalled_marshalled_model.id == pet_id
+    assert unmarshalled_marshalled_model.name == pet_name
+    assert unmarshalled_marshalled_model.photoUrls == pet_photo_urls


### PR DESCRIPTION
Let's make sure we don't break these methods again until we do a major release.