### PR TITLE
Fix unmarshalling of null values for properties with no spec

### DIFF
--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -76,7 +76,7 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name):
     :param prop_name: name of the property to retrieve the spec for
 
     :return: spec for the given property or None if no spec found
-    :rtype: dict
+    :rtype: dict or None
     """
     deref = swagger_spec.deref
 

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -132,7 +132,7 @@ def unmarshal_object(swagger_spec, object_spec, object_value):
     for k, v in iteritems(object_value):
         prop_spec = get_spec_for_prop(
             swagger_spec, object_spec, object_value, k)
-        if v is None and k not in required_fields:
+        if v is None and k not in required_fields and prop_spec:
             if schema.has_default(swagger_spec, prop_spec):
                 result[k] = schema.get_default(swagger_spec, prop_spec)
             else:

--- a/tests/unmarshal/unmarshal_object_test.py
+++ b/tests/unmarshal/unmarshal_object_test.py
@@ -347,6 +347,12 @@ def test_pass_through_property_with_no_spec(
     assert result == address
 
 
+def test_pass_through_null_property_with_no_spec(empty_swagger_spec, address_spec, address):
+    address['no_spec_field'] = None
+    result = unmarshal_object(empty_swagger_spec, address_spec, address)
+    assert result == address
+
+
 def test_recursive_ref_with_depth_1(recursive_swagger_spec):
     result = unmarshal_object(
         recursive_swagger_spec,


### PR DESCRIPTION
When adding support for default values during unmarshalling in 4.7.0, we didn't handle the case correctly of a property having a null value and no spec. This fixes it. The new test fails without the change and passes with it.

Fixes #163.