### PR TITLE
Handle responses as JSON only if required to.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,7 @@ Changelog
 =========
 
 - The content will be used to build the Changelog for the new bravado-core release
+- Fix handling of API calls that return non-JSON content (specifically text content).
   (add before this line your modifications summary and PR reference)
 
 4.7.3 (2017-05-05)

--- a/bravado_core/response.py
+++ b/bravado_core/response.py
@@ -101,15 +101,19 @@ def unmarshal_response(response, op):
     if not has_content(response_spec):
         return None
 
+    content_type = response.headers.get('content-type', '').lower()
+
+    if content_type.startswith(APP_JSON):
+        content_spec = deref(response_spec['schema'])
+        content_value = response.json()
+
+        if op.swagger_spec.config['validate_responses']:
+            validate_schema_object(op.swagger_spec, content_spec, content_value)
+
+        return unmarshal_schema_object(
+            op.swagger_spec, content_spec, content_value)
     # TODO: Non-json response contents
-    content_spec = deref(response_spec['schema'])
-    content_value = response.json()
-
-    if op.swagger_spec.config['validate_responses']:
-        validate_schema_object(op.swagger_spec, content_spec, content_value)
-
-    return unmarshal_schema_object(
-        op.swagger_spec, content_spec, content_value)
+    return response.text
 
 
 def get_response_spec(status_code, op):

--- a/tests/response/unmarshal_response_test.py
+++ b/tests/response/unmarshal_response_test.py
@@ -3,6 +3,7 @@ import pytest
 from mock import Mock
 from mock import patch
 
+from bravado_core.content_type import APP_JSON
 from bravado_core.response import IncomingResponse
 from bravado_core.response import unmarshal_response
 
@@ -34,7 +35,21 @@ def test_json_content(empty_swagger_spec, response_spec):
     response = Mock(
         spec=IncomingResponse,
         status_code=200,
+        headers={'content-type': APP_JSON},
         json=Mock(return_value='Monday'))
+
+    with patch('bravado_core.response.get_response_spec') as m:
+        m.return_value = response_spec
+        op = Mock(swagger_spec=empty_swagger_spec)
+        assert 'Monday' == unmarshal_response(response, op)
+
+
+def test_text_content(empty_swagger_spec, response_spec):
+    response = Mock(
+        spec=IncomingResponse,
+        status_code=200,
+        headers={'content-type': 'text/plain'},
+        text='Monday')
 
     with patch('bravado_core.response.get_response_spec') as m:
         m.return_value = response_spec
@@ -47,6 +62,7 @@ def test_skips_validation(empty_swagger_spec, response_spec):
     response = Mock(
         spec=IncomingResponse,
         status_code=200,
+        headers={'content-type': APP_JSON},
         json=Mock(return_value='Monday'))
 
     with patch('bravado_core.response.validate_schema_object') as val_schem:
@@ -62,6 +78,7 @@ def test_performs_validation(empty_swagger_spec, response_spec):
     response = Mock(
         spec=IncomingResponse,
         status_code=200,
+        headers={'content-type': APP_JSON},
         json=Mock(return_value='Monday'))
 
     with patch('bravado_core.response.validate_schema_object') as val_schem:


### PR DESCRIPTION
A JSON response will have "application/json", and only if this is set should
the response content be decoded as such.  Otherwise (until something smarter
comes along), on might as well return the raw response content (which
happens to be the correct thing to do for "text/plain" content).