### PR TITLE
Add benchmarking pytests

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@
 mock<1.1.0
 pre-commit
 pytest
+pytest-benchmark

--- a/test-data/2.0/multi-file-recursive/swagger.json
+++ b/test-data/2.0/multi-file-recursive/swagger.json
@@ -49,6 +49,21 @@
                     }
                 }
             }
+        },
+        "/recursive/responses": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "A list of recursive response",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "aux.json#/definitions/ping"
+                            }
+                        }
+                    }
+                }
+            }
         }
     },
     "swagger": "2.0"

--- a/test-data/flattened-multi-file-recursive-spec.json
+++ b/test-data/flattened-multi-file-recursive-spec.json
@@ -82,6 +82,21 @@
                     }
                 }
             }
+        },
+        "/recursive/responses": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "A list of recursive response",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                            		"$ref": "#/definitions/lfile:aux.json|..definitions..ping"
+                            }
+                        }
+                    }
+                }
+            }
         }
     },
     "swagger": "2.0"

--- a/tests/profiling/conftest.py
+++ b/tests/profiling/conftest.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+import uuid
+
+import pytest
+
+from bravado_core.operation import Operation
+
+
+@pytest.fixture(params=[100, 1000, 5000])
+def small_pets(request, scope="module"):
+    pets = []
+    for i in range(request.param):
+        pets.append({
+            'name': str(uuid.uuid4()),
+            'photoUrls': [str(uuid.uuid4())]
+        })
+    return pets
+
+
+@pytest.fixture(params=[100, 1000, 5000])
+def large_pets(request, scope="module"):
+    pets = []
+    for i in range(request.param):
+        pets.append({
+            'id': i + 1,
+            'name': str(uuid.uuid4()),
+            'status': 'available',
+            'photoUrls': ['wagtail.png', 'bark.png'],
+            'category': {
+                'id': 200,
+                'name': 'friendly',
+            },
+            'tags': [
+                {
+                    'id': 99,
+                    'name': 'mini'
+                },
+                {
+                    'id': 100,
+                    'name': 'brown'
+                },
+            ],
+        })
+    return pets
+
+
+@pytest.fixture(params=[True, False])
+def petstore_op(request, petstore_spec):
+    spec_dict = petstore_spec.spec_dict['paths']['/pet/findByTags']['get']
+    op = Operation(petstore_spec, '/pet/findByStatus', 'get', spec_dict)
+    op.swagger_spec.config['validate_responses'] = request.param
+    return op

--- a/tests/profiling/unmarshal_response_profiler_test.py
+++ b/tests/profiling/unmarshal_response_profiler_test.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from bravado_core.response import IncomingResponse
+from bravado_core.response import unmarshal_response
+
+
+class FakeJsonResponse(IncomingResponse):
+
+    def __init__(
+        self,
+        text,
+        status_code=200,
+        reason='OK',
+        headers=None
+    ):
+        self.text = text
+        self.status_code = 200
+        self.reason = 'OK'
+        self.headers = {'content-type': 'application/json'}
+        if headers:
+            self.headers = headers
+
+    def json(self, **kwargs):
+        return self.text
+
+
+def test_small_objects(petstore_op, benchmark, small_pets):
+    resp = FakeJsonResponse(small_pets)
+    benchmark(unmarshal_response, resp, petstore_op)
+
+
+def test_large_objects(petstore_op, benchmark, large_pets):
+    resp = FakeJsonResponse(large_pets)
+    benchmark(unmarshal_response, resp, petstore_op)

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,7 @@ envlist = py27, py35, py36, pre-commit
 deps =
     -rrequirements-dev.txt
 commands =
-    python -m pytest --capture=no {posargs:tests}
-
+    python -m pytest --capture=no {posargs:tests} --benchmark-min-rounds=25
 
 [testenv:cover]
 basepython = /usr/bin/python2.7


### PR DESCRIPTION
We've noticed bravado response unmarshalling slows down as the number of objects & object complexity increases. Not super surprising, but this at least gives an idea of how each change will effect these benchmarks.

pytest-benchmark has a way to compare benchmarks, but I haven't come up with a decent way to compare a branch's benchmark against some master benchmark. On top of that I'm not sure we're at the point where we should make speed regressions cause failures. 

The output of the benchmarks are available at the end of the pytest suite so people can just look at that.