### PR TITLE
Updated is_ref to make unmarshal_response ~30% faster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all install test tests clean docs
+.PHONY: all install test tests clean docs benchmark
 
 all: test
 
@@ -15,10 +15,12 @@ install:
 	pip install .
 
 test: install-hooks
-	tox
+	tox -- tests --ignore tests/profiling
 
 tests: test
 
+benchmark: install-hooks
+	tox -e benchmark
 
 .PHONY: install-hooks
 install-hooks:

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -47,7 +47,10 @@ def is_prop_nullable(swagger_spec, schema_object_spec):
 
 
 def is_ref(spec):
-    return is_dict_like(spec) and '$ref' in spec
+    try:
+        return '$ref' in spec and is_dict_like(spec)
+    except TypeError:
+        return False
 
 
 def is_dict_like(spec):

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -47,6 +47,15 @@ def is_prop_nullable(swagger_spec, schema_object_spec):
 
 
 def is_ref(spec):
+    """ Check if the given spec is a Mapping and contains a $ref.
+
+    FYI: This function gets called A LOT during unmarshaling and is_dict_like
+    adds a bunch of extra time. It is faster to use a try/except than it is
+    to call is_dict_like first for every spec input.
+
+    :param spec: swagger object specification
+    :rtype: boolean
+    """
     try:
         return '$ref' in spec and is_dict_like(spec)
     except TypeError:

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,13 @@ envlist = py27, py35, py36, pre-commit
 deps =
     -rrequirements-dev.txt
 commands =
-    python -m pytest --capture=no {posargs:tests} --benchmark-min-rounds=10
+    python -m pytest --capture=no {posargs:tests} 
+
+[testenv:benchmark]
+deps =
+    -rrequirements-dev.txt
+commands =
+    python -m pytest --capture=no {posargs:tests/profiling} --benchmark-min-rounds=15
 
 [testenv:cover]
 basepython = /usr/bin/python2.7
@@ -34,4 +40,4 @@ deps =
 setenv =
     LC_CTYPE=en_US.UTF-8
 commands =
-    pre-commit {posargs:run --all-files}
+    pre-commit run --all-files

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = py27, py35, py36, pre-commit
 deps =
     -rrequirements-dev.txt
 commands =
-    python -m pytest --capture=no {posargs:tests} --benchmark-min-rounds=25
+    python -m pytest --capture=no {posargs:tests} --benchmark-min-rounds=10
 
 [testenv:cover]
 basepython = /usr/bin/python2.7


### PR DESCRIPTION
Updated is_ref to reduce the number of times is_dict_like gets called. Instance checking is a huge source of slowdown because of the number of times isinstance gets called. Did some comparisons between the benchmarks seen in https://travis-ci.org/Yelp/bravado-core/jobs/264892454 and https://travis-ci.org/Yelp/bravado-core/jobs/264894131

| Py27 - Validated | Old Mean (ms) | New Mean (ms) | Change (% faster) |
|------------------|---------------|---------------|-------------------|
| 1000 small obj   | 201.2373      | 152.8966      | 24.02%            |
| 5000 small obj   | 995.7440      | 783.1190      | 21.35%            |
| 1000 large obj   | 716.8537      | 527.9353      | 26.35%            |
| 5000 large obj   | 3,748.9801    | 2,718.8094    | 27.48%            |

| Py36 - Validated | Old Mean (ms) | New Mean (ms) | Change (% faster) |
|------------------|---------------|---------------|-------------------|
| 1000 small obj   | 191.4858      | 138.5805      | 27.63%            |
| 5000 small obj   | 959.6830      | 704.6253      | 26.58%            |
| 1000 large obj   | 720.0888      | 493.1808      | 31.51%            |
| 5000 large obj   | 3,592.0855    | 2,496.4199    | 30.5%             |

| Py27 - Not Validated | Old Mean (ms) | New Mean (ms) | Change (% faster) |
|----------------------|---------------|---------------|-------------------|
| 1000 small obj       | 110.8196      | 82.8784       | 25.21%            |
| 5000 small obj       | 566.4803      | 474.1994      | 16.29%            |
| 1000 large obj       | 376.0710      | 248.5105      | 33.92%            |
| 5000 large obj       | 1,845.8902    | 1,320.3167    | 28.47%            |

| Py36 - Not Validated | Old Mean (ms) | New Mean (ms) | Change (% faster) |
|----------------------|---------------|---------------|-------------------|
| 1000 small obj       | 117.8748      | 80.1987       | 31.96%            |
| 5000 small obj       | 581.2813      | 408.2662      | 29.76%            |
| 1000 large obj       | 386.8550      | 251.3254      | 35.03%            |
| 5000 large obj       | 1,945.9027    | 1,287.6521    | 33.83%            |

