### PR TITLE
fix: working x-nullable for not required properties

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,8 @@
 Changelog
 =========
 
+- Fix marshalling of null values for properties with x-nullable set to True - Issue #185, PR #186
+
 4.8.1 (2017-08-24)
 ------------------
 - Make unmarshalling objects roughly 30% faster - PR #182.

--- a/bravado_core/marshal.py
+++ b/bravado_core/marshal.py
@@ -11,6 +11,7 @@ from bravado_core.schema import get_spec_for_prop
 from bravado_core.schema import handle_null_value
 from bravado_core.schema import is_dict_like
 from bravado_core.schema import is_list_like
+from bravado_core.schema import is_prop_nullable
 from bravado_core.schema import SWAGGER_PRIMITIVES
 
 
@@ -142,7 +143,9 @@ def marshal_object(swagger_spec, object_spec, object_value):
             swagger_spec, object_spec, object_value, k)
 
         if v is None and k not in required_fields:
-            continue
+            if not is_prop_nullable(swagger_spec, prop_spec):
+                continue
+
         if prop_spec:
             result[k] = marshal_schema_object(swagger_spec, prop_spec, v)
         else:

--- a/tests/marshal/marshal_object_test.py
+++ b/tests/marshal/marshal_object_test.py
@@ -241,7 +241,7 @@ def test_recursive_ref_with_depth_n(recursive_swagger_spec):
     assert result == expected
 
 
-def test_marshal_with_nullable_property(empty_swagger_spec):
+def test_marshal_with_nullable_required_property(empty_swagger_spec):
     object_spec = {
         'type': 'object',
         'required': ['x'],
@@ -257,7 +257,7 @@ def test_marshal_with_nullable_property(empty_swagger_spec):
     assert result == value
 
 
-def test_marshal_with_non_nullable_property(empty_swagger_spec):
+def test_marshal_with_non_nullable_required_property(empty_swagger_spec):
     object_spec = {
         'type': 'object',
         'required': ['x'],
@@ -273,7 +273,22 @@ def test_marshal_with_non_nullable_property(empty_swagger_spec):
     assert 'is a required value' in str(excinfo.value)
 
 
-def test_marshal_with_non_required_property(empty_swagger_spec):
+def test_marshal_with_nullable_non_required_property(empty_swagger_spec):
+    object_spec = {
+        'type': 'object',
+        'properties': {
+            'x': {
+                'type': 'string',
+                'x-nullable': True,
+            }
+        }
+    }
+    value = {'x': None}
+    result = marshal_object(empty_swagger_spec, object_spec, value)
+    assert result == value
+
+
+def test_marshal_with_non_nullable_non_required_property(empty_swagger_spec):
     object_spec = {
         'type': 'object',
         'properties': {
@@ -285,19 +300,3 @@ def test_marshal_with_non_required_property(empty_swagger_spec):
     value = {'x': None}
     result = marshal_object(empty_swagger_spec, object_spec, value)
     assert result == {}
-
-
-def test_marshal_with_required_property(empty_swagger_spec):
-    object_spec = {
-        'type': 'object',
-        'required': ['x'],
-        'properties': {
-            'x': {
-                'type': 'string'
-            }
-        }
-    }
-    value = {'x': None}
-    with pytest.raises(SwaggerMappingError) as excinfo:
-        marshal_object(empty_swagger_spec, object_spec, value)
-    assert 'is a required value' in str(excinfo.value)


### PR DESCRIPTION
fixes bug which caused not required None values to be omitted regardless of x-nullable being True
issue #185  