### PR TITLE
Ensure that Marshal raises only SwaggerMappingError

### DIFF
--- a/tests/marshal/marshal_schema_object_test.py
+++ b/tests/marshal/marshal_schema_object_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import copy
+import datetime
 from collections import defaultdict
 
 import pytest
@@ -66,6 +67,28 @@ def test_ref(minimal_swagger_dict):
     minimal_swagger_dict['refs'] = {'Foo': foo_spec}
     swagger_spec = Spec(minimal_swagger_dict)
     assert 'foo' == marshal_schema_object(swagger_spec, ref_spec, 'foo')
+
+
+def test_marshal_raises_SwaggerMappingError_if_SwaggerFormat_fails_during_to_wire(minimal_swagger_dict):
+    minimal_swagger_dict['definitions']['test'] = {
+        'properties': {
+            'date': {
+                'type': 'string',
+                'format': 'date',
+            },
+        },
+        'required': [
+            'date',
+        ],
+        'type': 'object'
+    }
+    swagger_spec = Spec(minimal_swagger_dict)
+    with pytest.raises(SwaggerMappingError):
+        marshal_schema_object(
+            swagger_spec=swagger_spec,
+            schema_object_spec=minimal_swagger_dict['definitions']['test'],
+            value={'date': datetime.date.today().isoformat()},
+        )
 
 
 def test_allOf_with_ref(composition_spec):

--- a/tests/marshal/marshal_schema_object_test.py
+++ b/tests/marshal/marshal_schema_object_test.py
@@ -83,12 +83,17 @@ def test_marshal_raises_SwaggerMappingError_if_SwaggerFormat_fails_during_to_wir
         'type': 'object'
     }
     swagger_spec = Spec(minimal_swagger_dict)
-    with pytest.raises(SwaggerMappingError):
+    date_str = datetime.date.today().isoformat()
+    with pytest.raises(SwaggerMappingError) as excinfo:
         marshal_schema_object(
             swagger_spec=swagger_spec,
             schema_object_spec=minimal_swagger_dict['definitions']['test'],
-            value={'date': datetime.date.today().isoformat()},
+            value={'date': date_str},
         )
+    message, wrapped_exception = excinfo.value.args
+    assert message == 'Error while marshalling value={} to type=string/date.'.format(date_str)
+    assert type(wrapped_exception) is AttributeError
+    assert wrapped_exception.args == ('\'str\' object has no attribute \'isoformat\'', )
 
 
 def test_allOf_with_ref(composition_spec):


### PR DESCRIPTION
This PR makes sure that while formatting/marshaling a primitive type only ``SwaggerMappingError`` could be raised in case of error (as declared by ``marshal_primitive``'s docstring).

Without the code change introduced by this PR ``test_marshal_raises_SwaggerMappingError_if_SwaggerFormat_fails_during_to_wire`` will fail with the following stacktrace
```
F
tests/marshal/marshal_schema_object_test.py:71 (test_marshal_raises_SwaggerMappingError_if_SwaggerFormat_fails_during_to_wire)
minimal_swagger_dict = {'definitions': {'test': {'properties': {'date': {'format': 'date', 'type': 'string'}}, 'required': ['date'], 'type': 'object'}}, 'info': {'title': 'Test', 'version': '1.0'}, 'paths': {}, 'swagger': '2.0'}

    def test_marshal_raises_SwaggerMappingError_if_SwaggerFormat_fails_during_to_wire(minimal_swagger_dict):
        minimal_swagger_dict['definitions']['test'] = {
            'properties': {
                'date': {
                    'type': 'string',
                    'format': 'date',
                },
            },
            'required': [
                'date',
            ],
            'type': 'object'
        }
        swagger_spec = Spec(minimal_swagger_dict)
        with pytest.raises(SwaggerMappingError):
            marshal_schema_object(
                swagger_spec=swagger_spec,
                schema_object_spec=minimal_swagger_dict['definitions']['test'],
>               value={'date': datetime.date.today().isoformat()},
            )

marshal_schema_object_test.py:90: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../../bravado_core/marshal.py:54: in marshal_schema_object
    return marshal_object(swagger_spec, schema_object_spec, value)
../../bravado_core/marshal.py:147: in marshal_object
    result[k] = marshal_schema_object(swagger_spec, prop_spec, v)
../../bravado_core/marshal.py:37: in marshal_schema_object
    return marshal_primitive(swagger_spec, schema_object_spec, value)
../../bravado_core/marshal.py:84: in marshal_primitive
    value = formatter.to_wire(swagger_spec, primitive_spec, value)
../../bravado_core/formatter.py:67: in to_wire
    return formatter.to_wire(value)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

d = '2017-09-03'

>   to_wire=lambda d: d.isoformat(),
    to_python=lambda d: dateutil.parser.parse(d).date(),
    validate=NO_OP,  # jsonschema validates date
    description='Converts [wire]string:date <=> python datetime.date'),
        # Python has no double. float is C's double in CPython
        'double': SwaggerFormat(
    format='double',
    to_wire=lambda d: d if isinstance(d, float) else float(d),
    to_python=lambda d: d if isinstance(d, float) else float(d),
    validate=NO_OP,  # jsonschema validates number
    description='Converts [wire]number:double <=> python float'),
        'date-time': SwaggerFormat(
    format='date-time',
    to_wire=lambda dt: (dt if dt.tzinfo else pytz.utc.localize(dt)).isoformat(),
    to_python=lambda dt: dateutil.parser.parse(dt),
    validate=NO_OP,  # jsonschema validates date-time
    description=(
        'Converts string:date-time <=> python datetime.datetime')),
        'float': SwaggerFormat(
    format='float',
    to_wire=lambda f: f if isinstance(f, float) else float(f),
    to_python=lambda f: f if isinstance(f, float) else float(f),
    validate=NO_OP,  # jsonschema validates number
    description='Converts [wire]number:float <=> python float'),
        'int32': SwaggerFormat(
    format='int32',
    to_wire=lambda i: i if isinstance(i, int) else int(i),
    to_python=lambda i: i if isinstance(i, int) else int(i),
    validate=NO_OP,  # jsonschema validates integer
    description='Converts [wire]integer:int32 <=> python int'),
        'int64': SwaggerFormat(
    format='int64',
    to_wire=lambda i: i if isinstance(i, long) else long(i),
    to_python=lambda i: i if isinstance(i, long) else long(i),
    validate=NO_OP,  # jsonschema validates integer
    description='Converts [wire]integer:int64 <=> python long'),
    }
E   AttributeError: 'str' object has no attribute 'isoformat'

../../bravado_core/formatter.py:119: AttributeError
```