### PR TITLE
Add _asdict() method to model objects, just like namedtuples have

### DIFF
--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -82,7 +82,7 @@ class Model(object):
     making up the public API of this class prefixed by a single underscore
     (this is done with the :func:`collections.namedtuple` type factory, which
     also uses property values with arbitrary names). There may still be name
-    conflicts but only if the property name also begins with an undersecore,
+    conflicts but only if the property name also begins with an underscore,
     which is uncommon. Truly private attributes are prefixed with double
     underscores in the source code (and thus by "_Model__" after
     `name-mangling`_).
@@ -289,6 +289,9 @@ class Model(object):
             dct[attr_name] = attr_val
 
         return dct
+
+    # provide the same interface as a namedtuple
+    _asdict = _as_dict
 
     @classmethod
     def _from_dict(cls, dct):

--- a/tests/model/model_test.py
+++ b/tests/model/model_test.py
@@ -70,7 +70,9 @@ def test_model_delete_additional_property(definitions_spec, user_type, user_kwar
 
 def test_model_as_dict(definitions_spec, user_type, user_kwargs):
     user = user_type(**user_kwargs)
-    assert {k: user_kwargs.get(k) for k in definitions_spec['User']['properties'].keys()} == user._as_dict()
+    user_dict = user._as_dict()
+    assert {k: user_kwargs.get(k) for k in definitions_spec['User']['properties'].keys()} == user_dict
+    assert user._asdict() == user_dict
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Frankly I think models should be more similar to namedtuples in terms of duck-typing. This will help internally as well with our typed model stubs (which are NamedTuples).