### PR TITLE
Fix issue when marshalling a property without a spec and a value of None

### DIFF
--- a/bravado_core/marshal.py
+++ b/bravado_core/marshal.py
@@ -142,15 +142,16 @@ def marshal_object(swagger_spec, object_spec, object_value):
         prop_spec = get_spec_for_prop(
             swagger_spec, object_spec, object_value, k)
 
+        if not prop_spec:
+            # Don't marshal when a spec is not available - just pass through
+            result[k] = v
+            continue
+
         if v is None and k not in required_fields:
             if not is_prop_nullable(swagger_spec, prop_spec):
                 continue
 
-        if prop_spec:
-            result[k] = marshal_schema_object(swagger_spec, prop_spec, v)
-        else:
-            # Don't marshal when a spec is not available - just pass through
-            result[k] = v
+        result[k] = marshal_schema_object(swagger_spec, prop_spec, v)
 
     return result
 

--- a/tests/marshal/marshal_object_test.py
+++ b/tests/marshal/marshal_object_test.py
@@ -193,6 +193,8 @@ def test_pass_through_additionalProperties_with_no_spec(
 def test_pass_through_property_with_no_spec(
         empty_swagger_spec, address_spec, address):
     del address_spec['properties']['street_name']['type']
+    # add a field with a None value and no spec
+    address['none_field'] = None
     result = marshal_object(empty_swagger_spec, address_spec, address)
     assert address == result
 


### PR DESCRIPTION
This bug was introduced by PR #186, I'd like to make a release as soon as possible. I've rewritten the code to check for no spec being available first, which will hopefully remove this source of issues (we've had bugs like this before).