### PR TITLE
Ensure model discovery runs for flattened specs

### DIFF
--- a/bravado_core/spec_flattening.py
+++ b/bravado_core/spec_flattening.py
@@ -317,9 +317,11 @@ def flattened_spec(
         )
 
         flatten_models = {
-            definition[MODEL_MARKER]
+            # Needed because schema objects could not contain "type" property and so they won't be tagged as models
+            definition.get(MODEL_MARKER)
             for definition in itervalues(known_mappings['definitions'])
         }
+
         for model_name, model_type in iteritems(spec_definitions):
             if model_name in flatten_models:
                 continue

--- a/bravado_core/spec_flattening.py
+++ b/bravado_core/spec_flattening.py
@@ -15,6 +15,7 @@ from six.moves.urllib.parse import urlunparse
 from six.moves.urllib_parse import ParseResult
 from swagger_spec_validator.ref_validators import in_scope
 
+from bravado_core.model import MODEL_MARKER
 from bravado_core.schema import is_dict_like
 from bravado_core.schema import is_list_like
 from bravado_core.schema import is_ref
@@ -300,8 +301,23 @@ def flattened_spec(
     resolved_spec = descend(value=spec_dict)
 
     if spec_definitions is not None:
+        from bravado_core.spec import Spec  # local import due to circular dependency
+        # Creating the bravado_core.spec.Spec object will trigger models discovery and tagging.
+        # The process will add x-model key to ``known_mappings['definitions']`` items
+        Spec.from_dict(
+            # Minimalistic swagger spec like object
+            # it's not a valid spec due to lack of info and paths, but it's good enough to trigger model discovery
+            spec_dict={
+                'definitions': {
+                    marshal_uri(uri): value
+                    for uri, value in iteritems(known_mappings['definitions'])
+                }
+            },
+            config={'validate_swagger_spec': False},  # Not validate specs, which are known to not be valid
+        )
+
         flatten_models = {
-            definition['x-model']
+            definition[MODEL_MARKER]
             for definition in itervalues(known_mappings['definitions'])
         }
         for model_name, model_type in iteritems(spec_definitions):

--- a/bravado_core/spec_flattening.py
+++ b/bravado_core/spec_flattening.py
@@ -317,7 +317,7 @@ def flattened_spec(
         )
 
         flatten_models = {
-            # Needed because schema objects could not contain "type" property and so they won't be tagged as models
+            # schema objects might not have a "type" set so they won't be tagged as models
             definition.get(MODEL_MARKER)
             for definition in itervalues(known_mappings['definitions'])
         }

--- a/test-data/2.0/multi-file-specs-with-no-x-model/aux.json
+++ b/test-data/2.0/multi-file-specs-with-no-x-model/aux.json
@@ -1,0 +1,7 @@
+{
+    "definitions": {
+        "referenced_object": {
+            "type": "object"
+        }
+    }
+}

--- a/test-data/2.0/multi-file-specs-with-no-x-model/flattened-multi-file-with-no-xmodel.json
+++ b/test-data/2.0/multi-file-specs-with-no-x-model/flattened-multi-file-with-no-xmodel.json
@@ -1,0 +1,27 @@
+{
+  "definitions": {
+    "lfile:aux.json|..definitions..referenced_object": {
+      "type": "object",
+      "x-model": "lfile:aux.json|..definitions..referenced_object"
+    },
+    "lfile:swagger.json|..definitions..not_used": {
+      "type": "object",
+      "x-model": "not_used"
+    },
+    "lfile:swagger.json|..definitions..object": {
+      "properties": {
+        "property": {
+          "$ref": "#/definitions/lfile:aux.json|..definitions..referenced_object"
+        }
+      },
+      "type": "object",
+      "x-model": "object"
+    }
+  },
+  "info": {
+    "title": "Test",
+    "version": "1.0"
+  },
+  "paths": {},
+  "swagger": "2.0"
+}

--- a/test-data/2.0/multi-file-specs-with-no-x-model/flattened-multi-file-with-no-xmodel.json
+++ b/test-data/2.0/multi-file-specs-with-no-x-model/flattened-multi-file-with-no-xmodel.json
@@ -4,9 +4,12 @@
       "type": "object",
       "x-model": "lfile:aux.json|..definitions..referenced_object"
     },
-    "lfile:swagger.json|..definitions..not_used": {
-      "type": "object",
-      "x-model": "not_used"
+    "lfile:swagger.json|..definitions..not_used_referenced": {
+      "properties": {
+        "key": {
+          "type": "object"
+        }
+      }
     },
     "lfile:swagger.json|..definitions..object": {
       "properties": {

--- a/test-data/2.0/multi-file-specs-with-no-x-model/swagger.json
+++ b/test-data/2.0/multi-file-specs-with-no-x-model/swagger.json
@@ -7,7 +7,18 @@
   "paths": {},
   "definitions": {
     "not_used": {
-      "type": "object"
+      "properties": {
+        "any": {
+          "$ref": "#/definitions/not_used_referenced"
+        }
+      }
+    },
+    "not_used_referenced": {
+      "properties": {
+        "key": {
+          "type": "object"
+        }
+      }
     },
     "object": {
       "properties": {

--- a/test-data/2.0/multi-file-specs-with-no-x-model/swagger.json
+++ b/test-data/2.0/multi-file-specs-with-no-x-model/swagger.json
@@ -1,0 +1,21 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Test",
+    "version": "1.0"
+  },
+  "paths": {},
+  "definitions": {
+    "not_used": {
+      "type": "object"
+    },
+    "object": {
+      "properties": {
+        "property": {
+          "$ref": "aux.json#/definitions/referenced_object"
+        }
+      },
+      "type": "object"
+    }
+  }
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -141,6 +141,34 @@ def security_spec(security_dict):
     return Spec.from_dict(security_dict)
 
 
+@pytest.fixture
+def multi_file_with_no_xmodel_abspath(my_dir):
+    return os.path.join(my_dir, '../test-data/2.0/multi-file-specs-with-no-x-model/swagger.json')
+
+
+@pytest.fixture
+def multi_file_with_no_xmodel_dict(multi_file_with_no_xmodel_abspath):
+    return _read_json(multi_file_with_no_xmodel_abspath)
+
+
+@pytest.fixture
+def multi_file_with_no_xmodel_spec(multi_file_with_no_xmodel_dict, multi_file_with_no_xmodel_abspath):
+    return Spec.from_dict(multi_file_with_no_xmodel_dict, origin_url=get_url(multi_file_with_no_xmodel_abspath))
+
+
+@pytest.fixture
+def flattened_multi_file_with_no_xmodel_abspath(my_dir):
+    return os.path.join(
+        my_dir,
+        '../test-data/2.0/multi-file-specs-with-no-x-model/flattened-multi-file-with-no-xmodel.json',
+    )
+
+
+@pytest.fixture
+def flattened_multi_file_with_no_xmodel_dict(flattened_multi_file_with_no_xmodel_abspath):
+    return _read_json(flattened_multi_file_with_no_xmodel_abspath)
+
+
 def del_base64():
     del bravado_core.formatter.DEFAULT_FORMATS['base64']
 

--- a/tests/spec/Spec/flattened_spec_test.py
+++ b/tests/spec/Spec/flattened_spec_test.py
@@ -203,3 +203,14 @@ def test_flattened_spec_provide_valid_specs(
         http_handlers={},
     )
     assert flattened_spec == flattened_multi_file_recursive_dict
+
+
+def test_flattened_specs_with_no_xmodel_tags(multi_file_with_no_xmodel_spec, flattened_multi_file_with_no_xmodel_dict):
+    flattened_spec = multi_file_with_no_xmodel_spec.flattened_spec
+    validator20.validate_spec(
+        # Deep copy needed because validate_spec adds x-scope information
+        spec_dict=copy.deepcopy(flattened_spec),
+        spec_url='',
+        http_handlers={},
+    )
+    assert flattened_spec == flattened_multi_file_with_no_xmodel_dict


### PR DESCRIPTION
This PR is meant to fix #190.

The main difference introduced in the discovery of the missing models that needs to be injected in the flattened specs.

Basically running ``Spec.from_dict`` will trigger the model discovery and tagging process ([Code](https://github.com/Yelp/bravado-core/blob/v4.8.3/bravado_core/spec.py#L170)) which will modify the injected swagger specs dictionary, and so it will add ``x-model`` into ``known_mappings['definitions']`` objects.

In order to reduce as much as possible the overhead of this operation I'm passing to ``Spec.from_dict`` an object that looks like swagger specs (it won't be valid since ``info`` and ``paths`` are missing) and I'm preventing spec validation.
I know that this could not be 100% clear so I hope that the comments will help 😄 