### PR TITLE
added default_type_to_object to default missing types to object

### DIFF
--- a/bravado_core/docstring.py
+++ b/bravado_core/docstring.py
@@ -174,4 +174,5 @@ def formatted_type(spec):
     elif obj_type:
         return obj_type
     else:  # not obj_type
+        # if 'default_type_to_object' config is True, then this is defaulted to object type
         return 'notype'

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -448,7 +448,8 @@ def is_object(swagger_spec, object_spec):
     :return: True if the spec describes an object, False otherwise.
     """
     deref = swagger_spec.deref
-    return deref(object_spec.get('type')) == 'object' or 'allOf' in object_spec
+    default_type = 'object' if swagger_spec.config['default_type_to_object'] else None
+    return deref(object_spec.get('type', default_type)) == 'object' or 'allOf' in object_spec
 
 
 def create_model_docstring(swagger_spec, model_spec):

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -61,6 +61,11 @@ CONFIG_DEFAULTS = {
 
     # Fill with None all the missing properties during object unmarshal-ing
     'include_missing_properties': True,
+
+    # What to do when a type is missing
+    # If True, set the type to object and validate
+    # If False, do no validation
+    'default_type_to_object': False,
 }
 
 

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -39,7 +39,10 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
         obj_type = 'object'
 
     if not obj_type:
-        return value
+        if swagger_spec.config['default_type_to_object']:
+            obj_type = 'object'
+        else:
+            return value
 
     if obj_type in SWAGGER_PRIMITIVES:
         return unmarshal_primitive(swagger_spec, schema_object_spec, value)

--- a/bravado_core/validate.py
+++ b/bravado_core/validate.py
@@ -21,7 +21,8 @@ def validate_schema_object(swagger_spec, schema_object_spec, value):
     """
     deref = swagger_spec.deref
     schema_object_spec = deref(schema_object_spec)
-    obj_type = deref(schema_object_spec.get('type'))
+    default_type = 'object' if swagger_spec.config['default_type_to_object'] else None
+    obj_type = deref(schema_object_spec.get('type', default_type))
 
     if not obj_type:
         pass

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -38,4 +38,9 @@ Config key                    Type            Default   Description
 ----------------------------- --------------- --------- ----------------------------------------------------
 *include_missing_properties*   boolean         True     | Create properties with the value ``None`` if they
                                                         | were not submitted during object unmarshalling
+----------------------------- --------------- --------- ----------------------------------------------------
+*default_type_to_object*      boolean         False     | When set to ``True``, missing types will default
+                                                        | to ``object`` and be validated as such.
+                                                        | When set to ``False``, missing types will not be
+                                                        | validated at all.
 ============================= =============== ========= ====================================================

--- a/tests/unmarshal/unmarshal_schema_object_test.py
+++ b/tests/unmarshal/unmarshal_schema_object_test.py
@@ -77,6 +77,33 @@ def test_missing_object_spec(petstore_dict):
     assert result == {'id': {'foo': 'bar'}, 'name': 'short-hair'}
 
 
+def test_missing_object_spec_defaulting_on(petstore_dict):
+    """When default_type_to_object config option is set to True,
+    then missing types default to object
+    """
+    petstore_spec = Spec.from_dict(petstore_dict, config={'use_models': False, 'default_type_to_object': True})
+    category_spec = copy.deepcopy(
+        petstore_spec.spec_dict['definitions']['Category']
+    )
+
+    # now a missing type will default to object type
+    category_spec['properties']['id'].pop('type')
+
+    result = unmarshal_schema_object(
+        petstore_spec,
+        category_spec,
+        {'id': {'foo': 'bar'}, 'name': 'short-hair'})
+
+    assert result == {'id': {'foo': 'bar'}, 'name': 'short-hair'}
+
+    # so a different type will fail
+    with pytest.raises(SwaggerMappingError):
+        result = unmarshal_schema_object(
+            petstore_spec,
+            category_spec,
+            {'id': 'blahblah', 'name': 'short-hair'})
+
+
 def test_invalid_type(petstore_dict):
     petstore_spec = Spec.from_dict(petstore_dict, config={'use_models': False})
     category_spec = copy.deepcopy(


### PR DESCRIPTION
In #183, we made it so that missing types will not be validated. This adds an option to validate missing types as objects.

Question: Do we want to have a third option that causes a hard failure when there is a missing type?


This addresses #192