### PR TITLE
Ensure that models are converted to dictionaries if coming from two bravado_core.spec.Spec instances

### DIFF
--- a/bravado_core/marshal.py
+++ b/bravado_core/marshal.py
@@ -175,7 +175,7 @@ def marshal_model(swagger_spec, model_spec, model_value):
     if model_value is None:
         return handle_null_value(swagger_spec, model_spec)
 
-    if not model_type._isinstance(model_value):
+    if not hasattr(model_value, '_as_dict'):
         raise SwaggerMappingError(
             'Expected model of type {0} for {1}:{2}'
             .format(model_name, type(model_value), model_value))

--- a/tests/marshal/marshal_model_test.py
+++ b/tests/marshal/marshal_model_test.py
@@ -106,3 +106,20 @@ def test_marshal_non_nullable_model(petstore_spec):
     with pytest.raises(SwaggerMappingError) as excinfo:
         marshal_model(petstore_spec, pet_spec, None)
     assert 'is a required value' in str(excinfo.value)
+
+
+def test_marshal_model_with_with_different_specs(petstore_dict, petstore_spec):
+    pet_spec = petstore_spec.spec_dict['definitions']['Pet']
+    new_petstore_spec = Spec.from_dict(petstore_dict)
+    model = new_petstore_spec.definitions['Pet'](
+        id=1,
+        name='Fido',
+        status=None,
+        photoUrls=['wagtail.png', 'bark.png'],
+        category=None,
+        tags=None
+    )
+
+    assert marshal_model(petstore_spec, pet_spec, model) == {
+        'id': 1, 'name': 'Fido', 'photoUrls': ['wagtail.png', 'bark.png'],
+    }

--- a/tests/model/conftest.py
+++ b/tests/model/conftest.py
@@ -152,6 +152,11 @@ def pet_spec(definitions_spec):
 
 
 @pytest.fixture
+def pet_type(cat_swagger_spec, pet_spec):
+    return create_model_type(cat_swagger_spec, 'Pet', pet_spec)
+
+
+@pytest.fixture
 def cat_spec(definitions_spec):
     return definitions_spec['Cat']
 

--- a/tests/model/model_test.py
+++ b/tests/model/model_test.py
@@ -75,6 +75,16 @@ def test_model_as_dict(definitions_spec, user_type, user_kwargs):
     assert user._asdict() == user_dict
 
 
+def test_model_is_instance_same_class(user_type, user_kwargs):
+    user = user_type(**user_kwargs)
+    assert user_type._isinstance(user)
+
+
+def test_model_is_instance_inherits_from(pet_type, cat_type, cat_kwargs):
+    cat = cat_type(**cat_kwargs)
+    assert pet_type._isinstance(cat)
+
+
 @pytest.mark.parametrize(
     'recursive',
     [


### PR DESCRIPTION
before converting a model to its dictionary representation, ``marshal_model`` checks that ``model_value`` is an instance of ``model_type``. The check will fail if the model is extracted from a different ``bravado_core.spec.Spec`` instance (even if built from the same Swagger Specs).

This PR updates the check in order to ensure that ``model_value`` has ``_as_dict`` method before running the conversion.

The added tests is failing with the old code and succeeding with the new one.

@sjaensch  could you have a look to this?