### PR TITLE
Reintroduce instance check while marshaling models

### DIFF
--- a/bravado_core/marshal.py
+++ b/bravado_core/marshal.py
@@ -176,10 +176,11 @@ def marshal_model(swagger_spec, model_spec, model_value):
         return handle_null_value(swagger_spec, model_spec)
     model_type._isinstance(model_value)
     if not isinstance(model_value, model_type):
-        # if not model_type._isinstance(model_value):
         raise SwaggerMappingError(
-            'Expected model of type {0} for {1}:{2}'
-            .format(model_name, model_value.__class__.__name__, model_value))
+            'Expected model of type {0} but got {1} for value {2}'.format(
+                model_name, model_value.__class__.__name__, model_value,
+            ),
+        )
 
     # just convert the model to a dict and feed into `marshal_object` because
     # models are essentially 'type':'object' when marshaled

--- a/bravado_core/marshal.py
+++ b/bravado_core/marshal.py
@@ -174,11 +174,12 @@ def marshal_model(swagger_spec, model_spec, model_value):
 
     if model_value is None:
         return handle_null_value(swagger_spec, model_spec)
-
-    if not hasattr(model_value, '_as_dict'):
+    model_type._isinstance(model_value)
+    if not isinstance(model_value, model_type):
+        # if not model_type._isinstance(model_value):
         raise SwaggerMappingError(
             'Expected model of type {0} for {1}:{2}'
-            .format(model_name, type(model_value), model_value))
+            .format(model_name, model_value.__class__.__name__, model_value))
 
     # just convert the model to a dict and feed into `marshal_object` because
     # models are essentially 'type':'object' when marshaled

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
+import abc
 import logging
 from warnings import warn
 
+import six
 from six import iteritems
 
 from bravado_core.schema import collapsed_properties
@@ -69,6 +71,30 @@ def collect_models(container, key, path, models, swagger_spec):
             swagger_spec, model_name, model_spec)
 
 
+class ModelMeta(abc.ABCMeta):
+    def __instancecheck__(self, instance):
+        """
+        An object is instance of a specific model class if:
+        - model class and instance share the same model Swagger Specs
+        - instance inherits from model class (in case of multiple inheritance, ie. allOff)
+        """
+        if not isinstance(type(instance), type(self)):
+            return False
+
+        if not hasattr(self, '_model_spec'):
+            # This is a generic Model
+            return True
+
+        if not hasattr(instance, '_model_spec'):
+            return False
+
+        if self._model_spec == instance._model_spec:
+            return True
+
+        return self.__name__ in type(instance)._inherits_from
+
+
+@six.add_metaclass(ModelMeta)
 class Model(object):
     """Base class for Swagger models.
 
@@ -353,19 +379,11 @@ class Model(object):
 
     @classmethod
     def _isinstance(cls, obj):
-        """Check if an object is an instance of this model or a model inheriting
-        from it.
-
-        :param obj: Object to check.
-        :rtype: bool
-        """
-        if isinstance(obj, cls):
-            return True
-
-        if isinstance(obj, Model):
-            return cls.__name__ in type(obj)._inherits_from
-
-        return False
+        warn(
+            "_isinstance is deprecated. Please use isinstance(obj, cls) instead..",
+            DeprecationWarning,
+        )
+        return isinstance(obj, cls)
 
 
 class ModelDocstring(object):

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -82,7 +82,7 @@ class ModelMeta(abc.ABCMeta):
             return False
 
         if not hasattr(self, '_model_spec'):
-            # This is a generic Model
+            # This is the base Model class
             return True
 
         if not hasattr(instance, '_model_spec'):

--- a/tests/marshal/marshal_model_test.py
+++ b/tests/marshal/marshal_model_test.py
@@ -123,3 +123,16 @@ def test_marshal_model_with_with_different_specs(petstore_dict, petstore_spec):
     assert marshal_model(petstore_spec, pet_spec, model) == {
         'id': 1, 'name': 'Fido', 'photoUrls': ['wagtail.png', 'bark.png'],
     }
+
+
+def test_marshal_model_raises_exception_if_different_model(petstore_spec):
+    pet_spec = petstore_spec.spec_dict['definitions']['Pet']
+    order_spec = petstore_spec.definitions['Order']
+    model = order_spec()
+
+    with pytest.raises(SwaggerMappingError) as excinfo:
+        marshal_model(petstore_spec, pet_spec, model)
+
+    assert str(excinfo.value) == 'Expected model of type {0} for {1}:{2}'.format(
+        'Pet', 'Order', model,
+    )

--- a/tests/marshal/marshal_model_test.py
+++ b/tests/marshal/marshal_model_test.py
@@ -133,6 +133,6 @@ def test_marshal_model_raises_exception_if_different_model(petstore_spec):
     with pytest.raises(SwaggerMappingError) as excinfo:
         marshal_model(petstore_spec, pet_spec, model)
 
-    assert str(excinfo.value) == 'Expected model of type {0} for {1}:{2}'.format(
+    assert str(excinfo.value) == 'Expected model of type {0} but got {1} for value {2}'.format(
         'Pet', 'Order', model,
     )

--- a/tests/model/model_test.py
+++ b/tests/model/model_test.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import pytest
 
+from bravado_core.model import create_model_type
 from bravado_core.model import Model
 from bravado_core.schema import collapsed_properties
 from bravado_core.unmarshal import unmarshal_model
@@ -78,11 +79,16 @@ def test_model_as_dict(definitions_spec, user_type, user_kwargs):
 def test_model_is_instance_same_class(user_type, user_kwargs):
     user = user_type(**user_kwargs)
     assert user_type._isinstance(user)
+    assert isinstance(user, user_type)
 
 
-def test_model_is_instance_inherits_from(pet_type, cat_type, cat_kwargs):
+def test_model_is_instance_inherits_from(cat_swagger_spec, pet_type, pet_spec, cat_type, cat_kwargs):
     cat = cat_type(**cat_kwargs)
+    new_pet_type = create_model_type(cat_swagger_spec, 'Pet', pet_spec)
     assert pet_type._isinstance(cat)
+    assert isinstance(cat, cat_type)
+    assert isinstance(cat, pet_type)
+    assert isinstance(cat, new_pet_type)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
#194 removed the check around Model class while marshaling a model.

This PR:
 * reintroduces the check
 * makes sure that a model instance will be recognized as a valid model class even if the model type is originated by a different ``bravado_core.spec.Spec`` object build on top of the same swagger specs.
 * deprecates usage of ``_isinstance`` instance method suggesting the use of the *standard* ``isinstance`` python method