### PR TITLE
Fixed validate_schema_object to handle None types

### DIFF
--- a/bravado_core/validate.py
+++ b/bravado_core/validate.py
@@ -25,7 +25,7 @@ def validate_schema_object(swagger_spec, schema_object_spec, value):
     obj_type = deref(schema_object_spec.get('type', default_type))
 
     if not obj_type:
-        pass
+        return
 
     if obj_type in SWAGGER_PRIMITIVES:
         validate_primitive(swagger_spec, schema_object_spec, value)

--- a/tests/validate/validate_schema_object_test.py
+++ b/tests/validate/validate_schema_object_test.py
@@ -20,3 +20,7 @@ def test_allOf_with_ref(composition_spec):
         'releaseDate': 'October',
     }
     validate_schema_object(composition_spec, pongclone_spec, value)
+
+
+def test_no_validation_when_no_type(minimal_swagger_spec):
+    validate_schema_object(minimal_swagger_spec, {}, None)


### PR DESCRIPTION
Fixed a small bug would cause swagger validation errors when the obj_type is None.