### PR TITLE
fix default array param

### DIFF
--- a/bravado_core/param.py
+++ b/bravado_core/param.py
@@ -345,9 +345,11 @@ def unmarshal_collection_format(swagger_spec, param_spec, value):
             return None
         return schema.handle_null_value(swagger_spec, param_spec)
 
-    if collection_format == 'multi':
-        # http client lib should have already unmarshaled to an array
-        value_array = value if isinstance(value, list) else [value]
+    if isinstance(value, list):
+        value_array = value
+    elif collection_format == 'multi':
+        # http client lib should have already unmarshaled the value
+        value_array = [value]
     else:
         sep = COLLECTION_FORMATS[collection_format]
         if value == '':

--- a/bravado_core/param.py
+++ b/bravado_core/param.py
@@ -345,7 +345,7 @@ def unmarshal_collection_format(swagger_spec, param_spec, value):
             return None
         return schema.handle_null_value(swagger_spec, param_spec)
 
-    if isinstance(value, list):
+    if schema.is_list_like(value):
         value_array = value
     elif collection_format == 'multi':
         # http client lib should have already unmarshaled the value

--- a/tests/param/unmarshal_param_test.py
+++ b/tests/param/unmarshal_param_test.py
@@ -138,9 +138,20 @@ def test_optional_query_array_with_default(
         empty_swagger_spec, array_param_spec):
     array_param_spec['required'] = False
     array_param_spec['default'] = ['bird', 'fish']
+    array_param_spec.pop('collectionFormat')
     param = Param(empty_swagger_spec, Mock(spec=Operation), array_param_spec)
     request = Mock(spec=IncomingRequest, query={})
     assert ['bird', 'fish'] == unmarshal_param(param, request)
+
+
+def test_optional_query_array_with_default_empty(
+        empty_swagger_spec, array_param_spec):
+    array_param_spec['required'] = False
+    array_param_spec['default'] = []
+    array_param_spec.pop('collectionFormat')
+    param = Param(empty_swagger_spec, Mock(spec=Operation), array_param_spec)
+    request = Mock(spec=IncomingRequest, query={})
+    assert [] == unmarshal_param(param, request)
 
 
 @pytest.mark.parametrize("test_input,expected", [


### PR DESCRIPTION
This fixes #198

I'm not 100% sure of the implications of the code path that I changed. I've never directly used the `multi` `collectionFormat`. But the tests pass so...