### PR TITLE
feat/Sanitise resource names to ensure they are valid Python identifiers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,8 @@
 Changelog
 =========
 
+- Sanitise resource names to ensure they are valid Python identifiers
+
 4.9.1 (2017-09-19)
 ------------------
 - Properly marshal a model even if it's not created from the same ``Spec`` instance - PR #194.

--- a/bravado_core/resource.py
+++ b/bravado_core/resource.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
+import re
 from collections import defaultdict
 
 from six import iteritems
@@ -50,6 +51,17 @@ def build_resources(swagger_spec):
     deref = swagger_spec.deref
     spec_dict = deref(swagger_spec.spec_dict)
     paths_spec = deref(spec_dict.get('paths', {}))
+
+    def sanitize(tag):
+        for regex, replacement in (
+                ('[^A-Za-z0-9_]', '_'),  # valid chars for method names
+                ('_+', '_'),             # collapse consecutive _'s
+                ('^_|_$', ''),           # trim leading/trailing _'s
+                ('^([0-9])', r'_\1')):          # no leading digits
+            tag = re.compile(regex).sub(replacement, tag)
+
+        return tag
+
     for path_name, path_spec in iteritems(paths_spec):
         path_spec = deref(path_spec)
         for http_method, op_spec in iteritems(path_spec):
@@ -68,7 +80,13 @@ def build_resources(swagger_spec):
                 tags.append(convert_path_to_resource(path_name))
 
             for tag in tags:
-                tag_to_ops[deref(tag)][op.operation_id] = op
+                sanitized_tag = sanitize(deref(tag))
+                if not sanitized_tag:
+                    # Edge case where users have explicitly chosen a tag name
+                    # which is empty after sanitization
+                    sanitized_tag = convert_path_to_resource(path_name)
+
+                tag_to_ops[sanitized_tag][op.operation_id] = op
 
     resources = {}
     for tag, ops in iteritems(tag_to_ops):

--- a/tests/resource/build_resources_test.py
+++ b/tests/resource/build_resources_test.py
@@ -80,3 +80,18 @@ def test_refs(minimal_swagger_dict, paths_spec):
     resources = build_resources(swagger_spec)
     assert len(resources) == 1
     assert 'pet' in resources
+
+
+def test_resource_with_a_tag_with_spaces(paths_spec_with_tags_with_spaces):
+    spec_dict = {'paths': paths_spec_with_tags_with_spaces}
+    resources = build_resources(Spec(spec_dict))
+    print(resources.keys())
+    assert 8 == len(resources)
+    assert resources['Some_Tag'].findPetsByStatus
+    assert resources['Tag_with_lots_of_words'].findPetsByStatus
+    assert resources['Tag_with_double_space'].findPetsByStatus
+    assert resources['Leading_space'].findPetsByStatus
+    assert resources['Trailing_space'].findPetsByStatus
+    assert resources['pet'].findPetsByStatus  # this was the tag that was only a space
+    assert resources['_0_starts_with_a_number'].findPetsByStatus
+    assert resources['_012_starts_with_a_number'].findPetsByStatus

--- a/tests/resource/conftest.py
+++ b/tests/resource/conftest.py
@@ -54,3 +54,24 @@ def paths_spec():
 @pytest.fixture
 def find_by_status_path_spec(paths_spec):
     return paths_spec['/pet/findByStatus']
+
+
+@pytest.fixture
+def paths_spec_with_tags_with_spaces():
+    return {
+        "/pet/findByStatus": {
+            "get": {
+                "tags": [
+                    "Some Tag",
+                    "Tag with lots of words",
+                    "Tag with        double space",
+                    " ",  # Tag with only a space
+                    " Leading space",
+                    "Trailing space ",
+                    "0 starts with a number",
+                    "012 starts with a number",
+                ],
+                "operationId": "findPetsByStatus",
+            }
+        },
+    }


### PR DESCRIPTION
Clean resource names to ensure they:

* can be used as valid Python identifiers, and
* match the naming style guide for the operation sanitisation

This is a breaking change, becuase resources which are currently called `My Tag` will now be called `My_Tag`. For users of `bravado` it will mean workarounds like `getattr(client, 'My Tag').api_method().result()` will need to be replaced with `client.My_Tag.api_method().result()`. I'm not sure what the impact of that change will be on any other libraries which depend on `bravado-core`.

Fixes https://github.com/Yelp/bravado/issues/307. I have also proposed a different fix for the same problem in https://github.com/Yelp/bravado/pull/320. I'm not sure if it's better to fix this in `bravado-core` or `bravado` (or both).