### PR TITLE
Fully dereference specs for performance improvements

### DIFF
--- a/bravado_core/operation.py
+++ b/bravado_core/operation.py
@@ -75,14 +75,14 @@ class Operation(object):
         deref = self.swagger_spec.deref
         result = deref(self.op_spec.get('consumes'))
         if result is None:
-            result = deref(self.swagger_spec.spec_dict.get('consumes', []))
+            result = deref(self.swagger_spec._internal_spec_dict.get('consumes', []))
         return result
 
     @cached_property
     def security_specs(self):
         deref = self.swagger_spec.deref
         op_spec = deref(self.op_spec)
-        spec_dict = deref(self.swagger_spec.spec_dict)
+        spec_dict = deref(self.swagger_spec._internal_spec_dict)
         if 'security' in op_spec:
             return deref(op_spec['security'])
         else:
@@ -119,7 +119,7 @@ class Operation(object):
         deref = self.swagger_spec.deref
         result = deref(self.op_spec.get('produces'))
         if result is None:
-            return deref(self.swagger_spec.spec_dict.get('produces', []))
+            return deref(self.swagger_spec._internal_spec_dict.get('produces', []))
         return result
 
     @classmethod
@@ -167,7 +167,7 @@ def build_params(op):
     deref = swagger_spec.deref
     op_spec = deref(op.op_spec)
     op_params_spec = deref(op_spec.get('parameters', []))
-    spec_dict = deref(swagger_spec.spec_dict)
+    spec_dict = deref(swagger_spec._internal_spec_dict)
     paths_spec = deref(spec_dict.get('paths', {}))
     path_spec = deref(paths_spec.get(op.path_name))
     path_params_spec = deref(path_spec.get('parameters', []))

--- a/bravado_core/resource.py
+++ b/bravado_core/resource.py
@@ -48,7 +48,7 @@ def build_resources(swagger_spec):
     # key = tag_name   value = { operation_id : Operation }
     tag_to_ops = defaultdict(dict)
     deref = swagger_spec.deref
-    spec_dict = deref(swagger_spec.spec_dict)
+    spec_dict = deref(swagger_spec._internal_spec_dict)
     paths_spec = deref(spec_dict.get('paths', {}))
     for path_name, path_spec in iteritems(paths_spec):
         path_spec = deref(path_spec)

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -163,7 +163,7 @@ class Spec(object):
         spec.build()
         return spec
 
-    def build(self):
+    def _validate_spec(self):
         if self.config['validate_swagger_spec']:
             self.resolver = validator20.validate_spec(
                 spec_dict=self.spec_dict,
@@ -171,6 +171,8 @@ class Spec(object):
                 http_handlers=build_http_handlers(self.http_client),
             )
 
+    def build(self):
+        self._validate_spec()
         post_process_spec(
             self,
             on_container_callbacks=[
@@ -282,9 +284,12 @@ class Spec(object):
         :return:
         """
 
-        # self.resources is None if the specs are not built
-        if self.resources is None or not self.config['validate_swagger_spec']:
-            raise RuntimeError('Swagger Specs have to be built and validated before flattening.')
+        if not self.config['validate_swagger_spec']:
+            raise RuntimeError('Swagger Specs have to be validated before flattening.')
+
+        # If resources are defined it means that Spec has been built and so swagger specs have been validated
+        if self.resources is None:
+            self._validate_spec()
 
         return strip_xscope(
             spec_dict=flattened_spec(

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os.path
 import warnings
+from contextlib import closing
 
 import yaml
 from jsonref import JsonRef
@@ -422,11 +423,11 @@ def build_http_handlers(http_client):
             return response.json()
 
     def read_file(uri):
-        fp = urlopen(uri)
-        if is_yaml(uri):
-            return yaml.load(fp)
-        else:
-            return json.loads(fp.read().decode("utf-8"))
+        with closing(urlopen(uri)) as fp:
+            if is_yaml(uri):
+                return yaml.load(fp)
+            else:
+                return json.loads(fp.read().decode("utf-8"))
 
     return {
         'http': download,

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -148,7 +148,7 @@ class Spec(object):
             are_config_changed = True
             self.config['internally_dereference_refs'] = False
             warnings.warn(
-                message='config disabled internally_dereference_refs because validate_swagger_spec has to be enabled',
+                message='internally_dereference_refs config disabled because validate_swagger_spec has to be enabled',
                 category=Warning,
             )
 
@@ -374,6 +374,9 @@ class Spec(object):
                 for index in range(len(obj)):
                     obj[index] = descend(obj[index])
             return obj
+
+        # Make sure that all memory allocated for cache could be released
+        descend.cache.clear()
 
         return descend(deref_spec_dict)
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 # Unit test dependencies
-mock<1.1.0
+mock
 pre-commit
 pytest
 pytest-benchmark[histogram]

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ import bravado_core
 
 
 install_requires = [
+    "jsonref",
     "jsonschema[format]>=2.5.1",
     "python-dateutil",
     "pyyaml",

--- a/test-data/2.0/multi-file-recursive/flattened-multi-file-recursive-spec.json
+++ b/test-data/2.0/multi-file-recursive/flattened-multi-file-recursive-spec.json
@@ -19,6 +19,25 @@
       "type": "object",
       "x-model": "ping"
     },
+    "lfile:swagger.json|..definitions..model_with_allOf_recursive": {
+      "allOf": [
+        {
+          "properties": {
+            "pong": {
+              "$ref": "#/definitions/lfile:swagger.json|..definitions..pong"
+            }
+          }
+        },
+        {
+          "properties": {
+            "ping": {
+              "$ref": "#/definitions/lfile:aux.json|..definitions..ping"
+            }
+          }
+        }
+      ],
+      "x-model": "model_with_allOf_recursive"
+    },
     "lfile:swagger.json|..definitions..not_used": {
       "properties": {
         "not_used_remote_reference": {

--- a/test-data/2.0/multi-file-recursive/swagger.json
+++ b/test-data/2.0/multi-file-recursive/swagger.json
@@ -1,5 +1,24 @@
 {
     "definitions": {
+        "model_with_allOf_recursive": {
+            "allOf": [
+                {
+                    "properties": {
+                        "pong": {
+                            "$ref": "#/definitions/pong"
+                        }
+                    }
+                },
+                {
+                    "properties": {
+                        "ping": {
+                            "$ref": "aux.json#/definitions/ping"
+                        }
+                    }
+                }
+            ],
+            "x-model": "model_with_allOf_recursive"
+        },
         "not_used": {
             "type": "object",
             "properties": {

--- a/tests/profiling/conftest.py
+++ b/tests/profiling/conftest.py
@@ -51,12 +51,15 @@ def large_pets(number_of_objects):
     return pets
 
 
-@pytest.fixture
+@pytest.fixture(
+    params=[True, False],
+    ids=['full-deref', 'with-refs'],
+)
 def perf_petstore_spec(request, petstore_spec):
     return Spec.from_dict(
         spec_dict=petstore_spec.spec_dict,
         origin_url=petstore_spec.origin_url,
-        config=dict(petstore_spec.config),
+        config=dict(petstore_spec.config, internally_dereference_refs=request.param),
     )
 
 

--- a/tests/resource/build_resources_test.py
+++ b/tests/resource/build_resources_test.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import pytest
+
 from bravado_core.param import Param
 from bravado_core.resource import build_resources
 from bravado_core.spec import Spec
@@ -67,16 +69,13 @@ def test_resource_with_vendor_extension(paths_spec):
     assert resources['pet'].findPetsByStatus
 
 
-def test_refs(minimal_swagger_dict, paths_spec):
-    minimal_swagger_dict['real_paths'] = paths_spec
-    minimal_swagger_dict['real_op'] = paths_spec['/pet/findByStatus']['get']
-    minimal_swagger_dict['real_tags'] = \
-        paths_spec['/pet/findByStatus']['get']['tags']
-
-    paths_spec['/pet/findByStatus']['get']['tags'] = {'$ref': '#/real_tags'}
-    paths_spec['/pet/findByStatus']['get'] = {'$ref': '#/real_op'}
-    minimal_swagger_dict['paths'] = {'$ref': '#/real_paths'}
-    swagger_spec = Spec(minimal_swagger_dict)
+@pytest.mark.parametrize(
+    'internally_dereference_refs', [True, False],
+)
+def test_refs(minimal_swagger_dict, paths_spec, pet_spec, internally_dereference_refs):
+    minimal_swagger_dict['paths'] = paths_spec
+    minimal_swagger_dict['definitions'] = {'Pet': pet_spec}
+    swagger_spec = Spec(minimal_swagger_dict, config={'internally_dereference_refs': internally_dereference_refs})
     resources = build_resources(swagger_spec)
     assert len(resources) == 1
     assert 'pet' in resources

--- a/tests/resource/conftest.py
+++ b/tests/resource/conftest.py
@@ -3,6 +3,22 @@ import pytest
 
 
 @pytest.fixture
+def pet_spec():
+    # The '#/definitions' dict from spec
+    return {
+        'properties': {
+            'name': {
+                'type': 'string'
+            },
+        },
+        'required': [
+            'name'
+        ],
+        'type': 'object',
+    }
+
+
+@pytest.fixture
 def paths_spec():
     # The '#/paths' dict from a spec
     return {

--- a/tests/spec/Spec/deref_flattened_spec_test.py
+++ b/tests/spec/Spec/deref_flattened_spec_test.py
@@ -14,7 +14,7 @@ def _get_model(spec_dict, model_name):
 
 
 def _equivalent(spec, obj1, obj2):
-    if bool(is_dict_like(obj1)) != bool(is_dict_like(obj2)) or bool(is_list_like(obj1)) != bool(is_list_like(obj2)):
+    if is_dict_like(obj1) != is_dict_like(obj2) or is_list_like(obj1) != is_list_like(obj2):
         return False
 
     if is_dict_like(obj1):
@@ -57,7 +57,6 @@ def test_deref_flattened_spec_not_recursive_specs(petstore_spec):
 def test_deref_flattened_spec_recursive_specs(multi_file_recursive_spec):
     deref_spec_dict = multi_file_recursive_spec.deref_flattened_spec
 
-    # NOTE:
     ping = _get_model(deref_spec_dict, 'ping')
     assert id(ping) == id(ping['properties']['pong']['properties']['ping'])
     assert id(ping['properties']['pong']) == id(ping['properties']['pong']['properties']['ping']['properties']['pong'])

--- a/tests/spec/Spec/deref_flattened_spec_test.py
+++ b/tests/spec/Spec/deref_flattened_spec_test.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+from six import iterkeys
+from six import itervalues
+
+from bravado_core.model import MODEL_MARKER
+from bravado_core.schema import is_dict_like
+from bravado_core.schema import is_list_like
+
+
+def _get_model(spec_dict, model_name):
+    for model_schema in itervalues(spec_dict['definitions']):
+        if model_schema.get(MODEL_MARKER) == model_name:
+            return model_schema
+
+
+def _equivalent(spec, obj1, obj2):
+    if bool(is_dict_like(obj1)) != bool(is_dict_like(obj2)) or bool(is_list_like(obj1)) != bool(is_list_like(obj2)):
+        return False
+
+    if is_dict_like(obj1):
+        if len(obj1) != len(obj2):
+            return False
+
+        for key in iterkeys(obj1):
+            if key not in obj2:
+                return False
+            return _equivalent(spec, spec.deref(obj1[key]), spec.deref(obj2[key]))
+
+    elif is_list_like(obj1):
+        if len(obj1) != len(obj2):
+            return False
+
+        for key in range(len(obj1)):
+            return _equivalent(spec, spec.deref(obj1[key]), spec.deref(obj2[key]))
+    else:
+        return obj1 == obj2
+
+
+def test_deref_flattened_spec_not_recursive_specs(petstore_spec):
+    spec_dict = petstore_spec.spec_dict
+    deref_spec_dict = petstore_spec.deref_flattened_spec
+
+    # NOTE: Pet spec is not recursive
+    pet_spec = _get_model(spec_dict, 'Pet')
+    deref_pet_spec = _get_model(deref_spec_dict, 'Pet')
+
+    # property 'category' is different because it is a reference
+    assert pet_spec['properties']['category'] != deref_pet_spec['properties']['category']
+
+    # dereferencing category the two parameter specs are equivalent
+    assert petstore_spec.deref(pet_spec['properties']['category']) == deref_pet_spec['properties']['category']
+
+    assert _equivalent(petstore_spec, pet_spec, deref_pet_spec)
+    assert _equivalent(petstore_spec, petstore_spec.spec_dict, petstore_spec.deref_flattened_spec)
+
+
+def test_deref_flattened_spec_recursive_specs(multi_file_recursive_spec):
+    deref_spec_dict = multi_file_recursive_spec.deref_flattened_spec
+
+    # NOTE:
+    ping = _get_model(deref_spec_dict, 'ping')
+    assert id(ping) == id(ping['properties']['pong']['properties']['ping'])
+    assert id(ping['properties']['pong']) == id(ping['properties']['pong']['properties']['ping']['properties']['pong'])
+
+    pong = _get_model(deref_spec_dict, 'pong')
+    assert id(pong) == id(pong['properties']['ping']['properties']['pong'])
+    assert id(pong['properties']['ping']) == id(pong['properties']['ping']['properties']['pong']['properties']['ping'])

--- a/tests/spec/Spec/flattened_spec_test.py
+++ b/tests/spec/Spec/flattened_spec_test.py
@@ -105,21 +105,15 @@ def test_marshal_url(target, expected_marshaled_uri):
     assert marshaled_uri == expected_marshaled_uri
 
 
-@pytest.mark.parametrize(
-    'build_spec_object', [True, False]
-)
 @mock.patch('bravado_core.spec.build_api_serving_url')
 @mock.patch('bravado_core.spec.flattened_spec')
-def test_flattened_spec_raises_if_specs_are_not_built_and_validated(
-    mock_flattened_dict, mock_build_api_serving_url, petstore_spec, build_spec_object,
+def test_flattened_spec_raises_if_configured_to_not_validate_swagger_specs(
+    mock_flattened_dict, mock_build_api_serving_url, petstore_spec,
 ):
-    petstore_spec = Spec(mock_flattened_dict, config=dict(CONFIG_DEFAULTS, validate_swagger_spec=not build_spec_object))
-    if build_spec_object:
-        petstore_spec.build()
-
+    petstore_spec = Spec(mock_flattened_dict, config=dict(CONFIG_DEFAULTS, validate_swagger_spec=False))
     with pytest.raises(RuntimeError) as excinfo:
         petstore_spec.flattened_spec
-    assert 'Swagger Specs have to be built and validated before flattening.' == str(excinfo.value)
+    assert 'Swagger Specs have to be validated before flattening.' == str(excinfo.value)
 
 
 @pytest.mark.parametrize(

--- a/tests/spec/validate_config_test.py
+++ b/tests/spec/validate_config_test.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+import mock
+import pytest
+
+from bravado_core.spec import CONFIG_DEFAULTS
+from bravado_core.spec import Spec
+from tests.conftest import get_url
+
+
+@pytest.mark.parametrize(
+    'config',
+    [
+        {},
+        CONFIG_DEFAULTS,
+        dict(CONFIG_DEFAULTS, validate_swagger_spec=True),
+    ]
+)
+def test_validate_config_succeed(minimal_swagger_dict, minimal_swagger_abspath, config):
+    spec = Spec.from_dict(minimal_swagger_dict, origin_url=get_url(minimal_swagger_abspath), config=config)
+    assert spec.config == dict(CONFIG_DEFAULTS, **config)
+
+
+@pytest.mark.parametrize(
+    'config, expected_warnings_call',
+    [
+        (
+            {'this_is_an_extra_key': True},
+            'config this_is_an_extra_key is been removed because is not a recognized config key',
+        ),
+        (
+            {'validate_swagger_spec': False, 'internally_dereference_refs': True},
+            'config disabled internally_dereference_refs because validate_swagger_spec has to be enabled',
+        ),
+    ]
+)
+@mock.patch('bravado_core.spec.warnings')
+def test_validate_config_fail(
+    mock_warnings, minimal_swagger_dict, minimal_swagger_abspath, config, expected_warnings_call,
+):
+    spec = Spec.from_dict(minimal_swagger_dict, origin_url=get_url(minimal_swagger_abspath), config=config)
+    assert spec.config != dict(CONFIG_DEFAULTS, **config)
+    mock_warnings.warn.assert_called_once_with(message=expected_warnings_call, category=Warning)

--- a/tests/spec/validate_config_test.py
+++ b/tests/spec/validate_config_test.py
@@ -29,7 +29,7 @@ def test_validate_config_succeed(minimal_swagger_dict, minimal_swagger_abspath, 
         ),
         (
             {'validate_swagger_spec': False, 'internally_dereference_refs': True},
-            'config disabled internally_dereference_refs because validate_swagger_spec has to be enabled',
+            'internally_dereference_refs config disabled because validate_swagger_spec has to be enabled',
         ),
     ]
 )

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -55,12 +55,11 @@ def test_memoize_by_id_decorator():
     assert decorated_function.cache == {
         (('a', id(1)), ('b', id(None))): id(1) + id(None),
         (('a', id(2)), ('b', id(3))): id(2) + id(3),
-        (('a', id(2)), ('b', id(3))): id(2) + id(3),
     }
     assert calls == [[1, None], [2, 3]]
 
-    for key in list(decorated_function.cache):
-        del decorated_function.cache[key]
+    decorated_function.cache.clear()
+
     assert decorated_function(1) == id(1) + id(None)
     assert decorated_function.cache == {
         (('a', id(1)), ('b', id(None))): id(1) + id(None)

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from bravado_core.util import cached_property
+from bravado_core.util import memoize_by_id
 
 
 def test_cached_property():
@@ -26,3 +27,42 @@ def test_cached_property():
     del class_instance.property_1
     assert class_instance.property_1 == 2
     assert class_instance.calls == 2
+
+
+def test_memoize_by_id_decorator():
+    calls = []
+
+    def function(a, b=None):
+        calls.append([a, b])
+        return id(a) + id(b)
+    decorated_function = memoize_by_id(function)
+
+    assert decorated_function(1) == id(1) + id(None)
+    assert decorated_function.cache == {
+        (('a', id(1)), ('b', id(None))): id(1) + id(None)
+    }
+    assert calls == [[1, None]]
+
+    assert decorated_function(2, 3) == id(2) + id(3)
+    assert decorated_function.cache == {
+        (('a', id(1)), ('b', id(None))): id(1) + id(None),
+        (('a', id(2)), ('b', id(3))): id(2) + id(3),
+    }
+    assert calls == [[1, None], [2, 3]]
+
+    # Calling the decorated method with known arguments will not call the inner method
+    assert decorated_function(1) == id(1) + id(None)
+    assert decorated_function.cache == {
+        (('a', id(1)), ('b', id(None))): id(1) + id(None),
+        (('a', id(2)), ('b', id(3))): id(2) + id(3),
+        (('a', id(2)), ('b', id(3))): id(2) + id(3),
+    }
+    assert calls == [[1, None], [2, 3]]
+
+    for key in list(decorated_function.cache):
+        del decorated_function.cache[key]
+    assert decorated_function(1) == id(1) + id(None)
+    assert decorated_function.cache == {
+        (('a', id(1)), ('b', id(None))): id(1) + id(None)
+    }
+    assert calls == [[1, None], [2, 3], [1, None]]

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ deps =
     -rrequirements-dev.txt
     coverage
 commands =
-    coverage run --source=bravado_core/ --omit=bravado_core/__init__.py -m pytest --capture=no --strict {posargs:tests/}
+    coverage run --source=bravado_core/ --omit=bravado_core/__init__.py -m pytest --benchmark-skip --capture=no --strict {posargs:tests/}
     coverage report --omit=.tox/*,tests/*,/usr/share/pyshared/*,/usr/lib/pymodules/* -m
 
 [testenv:docs]


### PR DESCRIPTION
The goal of this PR is to enhance bravado-core performances by using fully dereferenced specs for marshaling and unmarshaling operations.

According to how bravado-core is structured all the decisions made during marsharling and unmarshaling are made on top of ``spec.client_dict`` object which could contain references (``{"$ref": ...}`` objects). In order to make the spec traversing as transparent as possible we take advantage of ``spec.deref`` method which:
 - checks if the object is a potential reference object
 - eventually dereference the reference

Dereferencing the reference is _expensive_ especially considering that this will be done for all the unmarshaling (no specific caches are used).
A possible solution is to completely dereference the spec at build time, doing so ``deref`` method will always return the input object since no reference objects are possible at that point.

ℹ️  ``internally_dereference_refs`` is defaulted to ``False`` and a warning is rendered in case this config is used. I don't think that this will be needed so I'm fine to remove it 😄 

⚠️  currently are not present tests for checking ``deref_flattened_spec`` -> I'll write the test soon ... in the mean time any type of feedback is welcome

The performance improvements (based on ``tests/profiling/unmarshal_response_profiler_test.py``) are estimated around 35-40%.

```
------------------------------------------------------------------------------------- benchmark 'number_of_objects=100': 8 tests ------------------------------------------------------------------------------------
Name (time in ms)                                       Min                Max               Mean            StdDev             Median                IQR            Outliers       OPS            Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_small_objects[not_validate-full-deref-100]      3.4703 (1.0)       7.4356 (1.0)       6.6310 (1.0)      0.4756 (1.63)      6.5699 (1.0)       0.2250 (1.0)         47;49  150.8076 (1.0)         209           1
test_small_objects[validate-full-deref-100]          7.4766 (2.15)     14.2583 (1.92)     12.5795 (1.90)     1.6259 (5.58)     12.8922 (1.96)      2.3475 (10.44)        15;2   79.4944 (0.53)         72           1
test_small_objects[not_validate-with-refs-100]       9.5869 (2.76)     16.3894 (2.20)     14.8315 (2.24)     1.0073 (3.46)     15.0546 (2.29)      0.2467 (1.10)        15;27   67.4241 (0.45)        105           1
test_small_objects[validate-with-refs-100]          13.8252 (3.98)     29.0968 (3.91)     22.9156 (3.46)     4.6131 (15.83)    24.1939 (3.68)      7.1594 (31.83)        25;0   43.6385 (0.29)         71           1
test_large_objects[not_validate-full-deref-100]     13.8267 (3.98)     30.0045 (4.04)     23.8832 (3.60)     5.7839 (19.84)    26.2189 (3.99)      8.0483 (35.78)        22;0   41.8704 (0.28)         70           1
test_large_objects[validate-full-deref-100]         30.7165 (8.85)     57.6890 (7.76)     49.6596 (7.49)     9.8793 (33.90)    56.9023 (8.66)     17.2251 (76.57)         5;0   20.1371 (0.13)         21           1
test_large_objects[not_validate-with-refs-100]      36.3909 (10.49)    47.1335 (6.34)     44.7468 (6.75)     2.9153 (10.00)    45.9373 (6.99)      1.7825 (7.92)          3;3   22.3479 (0.15)         23           1
test_large_objects[validate-with-refs-100]          89.4499 (25.78)    90.5934 (12.18)    89.8360 (13.55)    0.2915 (1.0)      89.7698 (13.66)     0.2583 (1.15)          4;1   11.1314 (0.07)         15           1
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--------------------------------------------------------------------------------------- benchmark 'number_of_objects=1000': 8 tests ---------------------------------------------------------------------------------------
Name (time in ms)                                         Min                 Max                Mean             StdDev              Median                 IQR            Outliers      OPS            Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_small_objects[not_validate-full-deref-1000]      37.1008 (1.0)       69.6430 (1.0)       54.7790 (1.0)      12.1528 (1.59)      58.8435 (1.0)       23.9882 (3.13)          8;0  18.2552 (1.0)          22           1
test_small_objects[not_validate-with-refs-1000]       90.7017 (2.44)     147.8807 (2.12)     129.6385 (2.37)     17.3670 (2.28)     136.8842 (2.33)      19.5690 (2.55)          4;1   7.7138 (0.42)         15           1
test_small_objects[validate-full-deref-1000]         122.0972 (3.29)     153.7875 (2.21)     134.3517 (2.45)      8.5451 (1.12)     136.8268 (2.33)      13.3731 (1.74)          6;0   7.4432 (0.41)         15           1
test_large_objects[not_validate-full-deref-1000]     141.6785 (3.82)     285.5863 (4.10)     193.7177 (3.54)     59.2193 (7.76)     150.1474 (2.55)     108.7358 (14.18)         3;0   5.1622 (0.28)         15           1
test_small_objects[validate-with-refs-1000]          165.5165 (4.46)     280.5730 (4.03)     240.0495 (4.38)     29.8277 (3.91)     252.5970 (4.29)      27.5218 (3.59)          3;1   4.1658 (0.23)         15           1
test_large_objects[not_validate-with-refs-1000]      250.5242 (6.75)     493.6451 (7.09)     404.0562 (7.38)     81.4143 (10.67)    441.5763 (7.50)     112.2616 (14.64)         4;0   2.4749 (0.14)         15           1
test_large_objects[validate-full-deref-1000]         381.5170 (10.28)    614.5810 (8.82)     499.9089 (9.13)     60.4586 (7.93)     517.4497 (8.79)      94.4330 (12.31)         4;0   2.0004 (0.11)         15           1
test_large_objects[validate-with-refs-1000]          892.6406 (24.06)    920.9084 (13.22)    900.7493 (16.44)     7.6282 (1.0)      897.8168 (15.26)      7.6697 (1.0)           3;1   1.1102 (0.06)         15           1
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

------------------------------------------------------------------------------------------- benchmark 'number_of_objects=5000': 8 tests -------------------------------------------------------------------------------------------
Name (time in ms)                                           Min                   Max                  Mean              StdDev                Median                 IQR            Outliers     OPS            Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_small_objects[not_validate-full-deref-5000]       272.9713 (1.0)        353.6942 (1.0)        316.7180 (1.0)       23.8559 (1.0)        315.4705 (1.0)       23.5055 (1.0)           5;0  3.1574 (1.0)          15           1
test_small_objects[not_validate-with-refs-5000]        606.8064 (2.22)       769.9987 (2.18)       720.1087 (2.27)      53.5498 (2.24)       740.1593 (2.35)      65.4244 (2.78)          3;0  1.3887 (0.44)         15           1
test_small_objects[validate-full-deref-5000]           666.4790 (2.44)       823.9281 (2.33)       751.2675 (2.37)      45.2545 (1.90)       754.9685 (2.39)      56.1773 (2.39)          6;0  1.3311 (0.42)         15           1
test_large_objects[not_validate-full-deref-5000]       874.6289 (3.20)     1,351.8986 (3.82)     1,142.3961 (3.61)     180.2666 (7.56)     1,208.8945 (3.83)     346.9499 (14.76)         7;0  0.8754 (0.28)         15           1
test_small_objects[validate-with-refs-5000]          1,076.6074 (3.94)     1,309.4840 (3.70)     1,220.1635 (3.85)      67.1624 (2.82)     1,232.1623 (3.91)     100.0812 (4.26)          6;0  0.8196 (0.26)         15           1
test_large_objects[not_validate-with-refs-5000]      1,377.1945 (5.05)     2,424.9644 (6.86)     2,087.5990 (6.59)     345.1350 (14.47)    2,188.3172 (6.94)     485.6563 (20.66)         2;0  0.4790 (0.15)         15           1
test_large_objects[validate-full-deref-5000]         2,213.3820 (8.11)     2,991.5740 (8.46)     2,784.6868 (8.79)     171.5568 (7.19)     2,811.5405 (8.91)      47.8394 (2.04)          2;3  0.3591 (0.11)         15           1
test_large_objects[validate-with-refs-5000]          3,892.5828 (14.26)    5,103.6798 (14.43)    4,542.3739 (14.34)    281.6887 (11.81)    4,527.4716 (14.35)    168.0378 (7.15)          3;3  0.2201 (0.07)         15           1
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```