### PR TITLE
Improve security definitions tests

### DIFF
--- a/test-data/2.0/security/swagger.json
+++ b/test-data/2.0/security/swagger.json
@@ -20,6 +20,11 @@
       "name": "apiKey3",
       "in": "query"
     },
+    "apiKey4": {
+      "type": "apiKey",
+      "name": "apiKey4",
+      "in": "query"
+    },
     "oauth2": {
       "type": "oauth2",
       "authorizationUrl": "http://domain/oauth/dialog",
@@ -66,14 +71,14 @@
     },
     "/example3": {
       "get": {
-        "description": "Endpoint requires (apiKey1,apiKey2) or (apiKey2) header parameters",
+        "description": "Endpoint requires (apiKey1,apiKey2) or (apiKey3) header parameters",
         "security": [
           {
             "apiKey1": [],
             "apiKey2": []
           },
           {
-            "apiKey2": []
+            "apiKey3": []
           }
         ],
         "responses": {

--- a/tests/security_test.py
+++ b/tests/security_test.py
@@ -16,7 +16,7 @@ def test_security_definition_property_extraction(security_dict, security_spec):
     [
         ('example1', 'get_example1', [{'apiKey1': []}, {'apiKey2': []}]),
         ('example2', 'get_example2', [{'apiKey3': []}]),
-        ('example3', 'get_example3', [{'apiKey1': [], 'apiKey2': []}, {'apiKey2': []}]),
+        ('example3', 'get_example3', [{'apiKey1': [], 'apiKey2': []}, {'apiKey3': []}]),
         ('example4', 'get_example4', [{'oauth2': ['write:resource']}]),
         ('example5', 'get_example5', []),
     ]

--- a/tests/validate/validate_security_object_test.py
+++ b/tests/validate/validate_security_object_test.py
@@ -12,7 +12,7 @@ from bravado_core.validate import validate_security_object
         ('example1', 'get_example1', {'apiKey2': 'key'}),
         ('example2', 'get_example2', {'apiKey3': 'key'}),
         ('example3', 'get_example3', {'apiKey1': 'key', 'apiKey2': 'key'}),
-        ('example3', 'get_example3', {'apiKey2': 'key'}),
+        ('example3', 'get_example3', {'apiKey3': 'key'}),
         ('example4', 'get_example4', {}),
         ('example5', 'get_example5', {}),
     ]
@@ -27,7 +27,7 @@ def test_validate_correct_security_objects(security_spec, resource, operation, r
     [
         ('example1', 'get_example1', {}),
         ('example1', 'get_example1', {'apiKey1': 'key', 'apiKey2': 'key'}),
-        ('example3', 'get_example3', {'apiKey1': 'key', 'apiKey3': 'key'}),
+        ('example3', 'get_example3', {'apiKey1': 'key', 'apiKey4': 'key'}),
     ]
 )
 def test_validate_incorrect_security_objects(security_spec, resource, operation, request_data):


### PR DESCRIPTION
The goal of this PR is to fix [travis tests failure](https://travis-ci.org/Yelp/bravado-core/jobs/291577938#L416).
While fixing the ``flake8`` failure I noticed that ``test_only_one_security_definition_in_use_at_time`` needed to be refactored a bit and that was not actually testing the different cases of exceptions.