### PR TITLE
Optimize is_dict_like performance when called with a dict instance

### DIFF
--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -67,7 +67,11 @@ def is_dict_like(spec):
     :param spec: swagger object specification in dict form
     :rtype: boolean
     """
-    return isinstance(spec, Mapping)
+    # Calling isinstance(spec, Mapping) is relatively slow. As this function
+    # gets usually called with a dict type argument we optimize for that case
+    # by executing a much cheaper isinstance(spec, dict) check before the more
+    # expensive isinstance(spec, Mapping) check.
+    return isinstance(spec, (dict, Mapping))
 
 
 def is_list_like(spec):


### PR DESCRIPTION
isinstance(something, Mapping) is very slow in Python (see https://stackoverflow.com/questions/42378726/why-is-checking-isinstancesomething-mapping-so-slow) and most of the time is_dict_like in schema.py is called with an actual dict instance instead of some other type of mapping.

This change optimizes for that common use-case by doing a cheap dict is_instance check and by only executing the more expensive check if it's not a dictionary. This yields an approx 25% performance improvement for some of my test cases that use very large (around 400 kb) JSON responses.