### PR TITLE
Performance Improvements

### DIFF
--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -258,11 +258,6 @@ class Spec(object):
         # resolver doesn't have a traversal history (accumulated scope_stack)
         # when asked to resolve.
         with in_scope(self.resolver, ref_dict):
-            log.debug('Resolving {0} with scope {1}: {2}'.format(
-                ref_dict['$ref'],
-                len(self.resolver._scopes_stack),
-                self.resolver._scopes_stack))
-
             _, target = self.resolver.resolve(ref_dict['$ref'])
             return target
 

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -152,6 +152,11 @@ class Spec(object):
                 category=Warning,
             )
 
+        if self.config['internally_dereference_refs']:
+            # If internally_dereference_refs is enabled we do NOT need to resolve references anymore
+            # it's useless to evaluate is_ref every time
+            self.deref = lambda ref_dict: ref_dict
+
         return not are_config_changed
 
     @cached_property

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -272,7 +272,7 @@ class Spec(object):
         # If internally_dereference_refs is enabled we do NOT need to resolve references anymore
         # it's useless to evaluate is_ref every time
         return ref_dict if self.config['internally_dereference_refs'] else self._force_deref(ref_dict)
-    
+
     def deref(self, ref_dict):
         # This method is actually set in __init__
         pass

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -129,7 +129,7 @@ class Spec(object):
             # it's useless to evaluate is_ref every time
             self.deref = lambda ref_dict: ref_dict
         else:
-            self.deref = self._deref
+            self.deref = self._force_deref
 
     def _validate_config(self):
         """
@@ -267,11 +267,6 @@ class Spec(object):
         with in_scope(self.resolver, ref_dict):
             _, target = self.resolver.resolve(ref_dict['$ref'])
             return target
-
-    def _deref(self, ref_dict):
-        # If internally_dereference_refs is enabled we do NOT need to resolve references anymore
-        # it's useless to evaluate is_ref every time
-        return ref_dict if self.config['internally_dereference_refs'] else self._force_deref(ref_dict)
 
     def deref(self, ref_dict):
         # This method is actually set in __init__

--- a/tests/spec/Spec/build_test.py
+++ b/tests/spec/Spec/build_test.py
@@ -54,9 +54,9 @@ def test_build_with_custom_format(petstore_dict):
         False,
     ]
 )
-def assert_build_with_internally_dereference_refs_false(petstore_dict, internally_dereference_refs):
+def test_build_with_internally_dereference_refs(petstore_dict, internally_dereference_refs):
     spec = Spec(
         petstore_dict,
-        config={'internally_dereference_refs': False}
+        config={'internally_dereference_refs': internally_dereference_refs}
     )
     assert (spec.deref == spec._deref) == (not internally_dereference_refs)

--- a/tests/spec/Spec/build_test.py
+++ b/tests/spec/Spec/build_test.py
@@ -59,4 +59,4 @@ def test_build_with_internally_dereference_refs(petstore_dict, internally_derefe
         petstore_dict,
         config={'internally_dereference_refs': internally_dereference_refs}
     )
-    assert (spec.deref == spec._deref) == (not internally_dereference_refs)
+    assert (spec.deref == spec._force_deref) == (not internally_dereference_refs)

--- a/tests/spec/Spec/build_test.py
+++ b/tests/spec/Spec/build_test.py
@@ -45,3 +45,18 @@ def test_build_with_custom_format(petstore_dict):
         config={'formats': [email_address_format]},
         petstore_dict=petstore_dict,
     )
+
+
+@pytest.mark.parametrize(
+    'internally_dereference_refs',
+    [
+        True,
+        False,
+    ]
+)
+def assert_build_with_internally_dereference_refs_false(petstore_dict, internally_dereference_refs):
+    spec = Spec(
+        petstore_dict,
+        config={'internally_dereference_refs': False}
+    )
+    assert (spec.deref == spec._deref) == (not internally_dereference_refs)

--- a/tests/spec/Spec/deref_flattened_spec_test.py
+++ b/tests/spec/Spec/deref_flattened_spec_test.py
@@ -50,7 +50,7 @@ def test_deref_flattened_spec_not_recursive_specs(petstore_spec):
     assert pet_spec['properties']['category'] != deref_pet_spec['properties']['category']
 
     # dereferencing category the two parameter specs are equivalent
-    assert petstore_spec._deref(pet_spec['properties']['category']) == deref_pet_spec['properties']['category']
+    assert petstore_spec._force_deref(pet_spec['properties']['category']) == deref_pet_spec['properties']['category']
 
     assert _equivalent(petstore_spec, pet_spec, deref_pet_spec)
     assert _equivalent(petstore_spec, petstore_spec.spec_dict, petstore_spec.deref_flattened_spec)

--- a/tests/spec/Spec/deref_flattened_spec_test.py
+++ b/tests/spec/Spec/deref_flattened_spec_test.py
@@ -50,7 +50,7 @@ def test_deref_flattened_spec_not_recursive_specs(petstore_spec):
     assert pet_spec['properties']['category'] != deref_pet_spec['properties']['category']
 
     # dereferencing category the two parameter specs are equivalent
-    assert petstore_spec.deref(pet_spec['properties']['category']) == deref_pet_spec['properties']['category']
+    assert petstore_spec._deref(pet_spec['properties']['category']) == deref_pet_spec['properties']['category']
 
     assert _equivalent(petstore_spec, pet_spec, deref_pet_spec)
     assert _equivalent(petstore_spec, petstore_spec.spec_dict, petstore_spec.deref_flattened_spec)


### PR DESCRIPTION
This pull request includes two optimizations

### Removed a logging line
This log.debug causes 8000+ lines to be logged during my experiment as `deref` can be called thousands of times for one API call. With this removed, less than 10 lines were logged, so this probably should be removed.

Also, removing this causes a performance gain of almost 9%*

### Patches deref if internally_dereference_refs
Instead of checking if internally_dereference_refs is set every time in deref, it might be more efficient to just patch it.

This leads to a performance gain of 3.2%*

*In my custom benchmark tests with an very large spec with many refs

### Benchmark Results

#### Master

```
------------------------------------------------------------------------------------------ benchmark 'test_large_objects': 12 tests -----------------------------------------------------------------------------------------
Name (time in ms)                                      Min                   Max                  Mean             StdDev                Median                IQR            Outliers      OPS            Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
large_objects[not_validate-full-deref-100]         12.5268 (1.0)         24.4592 (1.0)         12.8176 (1.0)       1.3318 (1.83)        12.6414 (1.0)       0.1115 (1.0)           1;4  78.0180 (1.0)          79           1
large_objects[not_validate-with-refs-100]          22.0839 (1.76)        29.6021 (1.21)        22.4103 (1.75)      1.1547 (1.58)        22.1703 (1.75)      0.1187 (1.06)          2;3  44.6224 (0.57)         44           1
large_objects[validate-full-deref-100]             28.5821 (2.28)        36.3756 (1.49)        29.0308 (2.26)      1.4202 (1.95)        28.6702 (2.27)      0.1318 (1.18)          2;3  34.4461 (0.44)         35           1
large_objects[validate-with-refs-100]              44.9149 (3.59)        48.5357 (1.98)        45.3231 (3.54)      0.7290 (1.0)         45.1393 (3.57)      0.2657 (2.38)          1;2  22.0638 (0.28)         23           1
large_objects[not_validate-full-deref-1000]       126.8411 (10.13)      135.1093 (5.52)       128.6998 (10.04)     2.7678 (3.80)       127.3496 (10.07)     2.0033 (17.96)         2;2   7.7700 (0.10)         15           1
large_objects[not_validate-with-refs-1000]        223.5404 (17.85)      237.9027 (9.73)       226.4565 (17.67)     3.8393 (5.27)       225.2970 (17.82)     2.4544 (22.01)         2;2   4.4159 (0.06)         15           1
large_objects[validate-full-deref-1000]           285.1346 (22.76)      407.5041 (16.66)      297.5064 (23.21)    30.9258 (42.42)      287.6627 (22.76)     5.7088 (51.18)         1;2   3.3613 (0.04)         15           1
large_objects[validate-with-refs-1000]            452.7250 (36.14)      466.1344 (19.06)      457.7390 (35.71)     4.2074 (5.77)       457.1275 (36.16)     4.2630 (38.22)         4;1   2.1847 (0.03)         15           1
large_objects[not_validate-full-deref-5000]       658.2425 (52.55)      725.3440 (29.66)      668.6047 (52.16)    15.9983 (21.95)      665.5472 (52.65)     3.7841 (33.93)         1;1   1.4957 (0.02)         15           1
large_objects[not_validate-with-refs-5000]      1,138.9839 (90.92)    1,178.6613 (48.19)    1,157.6669 (90.32)     9.3933 (12.88)    1,158.5367 (91.65)     7.6275 (68.39)         4;2   0.8638 (0.01)         15           1
large_objects[validate-full-deref-5000]         1,449.0636 (115.68)   1,588.1233 (64.93)    1,472.3220 (114.87)   33.3209 (45.71)    1,465.5950 (115.94)   15.0831 (135.23)        1;1   0.6792 (0.01)         15           1
large_objects[validate-with-refs-5000]          2,296.4258 (183.32)   2,635.5504 (107.75)   2,366.3552 (184.62)   97.8768 (134.26)   2,318.4664 (183.40)   67.8774 (608.56)        2;2   0.4226 (0.01)         15           1
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------


Generated histogram: /nail/home/alston/bravado-core/.benchmarks/benchmark-test_large_objects.svg
-------------------------------------------------------------------------------------- benchmark 'test_small_objects': 12 tests --------------------------------------------------------------------------------------
Name (time in ms)                                    Min                 Max                Mean             StdDev              Median                IQR            Outliers       OPS            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
small_objects[not_validate-full-deref-100]        3.1819 (1.0)       11.0154 (1.0)        3.2487 (1.0)       0.4545 (1.35)       3.2220 (1.0)       0.0189 (1.0)           1;9  307.8108 (1.0)         295           1
small_objects[not_validate-with-refs-100]         6.9730 (2.19)      11.0245 (1.00)       7.0653 (2.17)      0.3356 (1.0)        7.0385 (2.18)      0.0384 (2.03)          1;1  141.5364 (0.46)        142           1
small_objects[validate-full-deref-100]            7.0688 (2.22)      15.1123 (1.37)       7.2027 (2.22)      0.7202 (2.15)       7.1296 (2.21)      0.0482 (2.55)          1;6  138.8374 (0.45)        123           1
small_objects[validate-with-refs-100]            12.5742 (3.95)      21.5999 (1.96)      12.8155 (3.94)      1.0088 (3.01)      12.6758 (3.93)      0.0823 (4.35)          1;7   78.0303 (0.25)         79           1
small_objects[not_validate-full-deref-1000]      32.0995 (10.09)     40.4167 (3.67)      32.6746 (10.06)     1.5991 (4.76)      32.2834 (10.02)     0.1943 (10.27)         2;3   30.6048 (0.10)         31           1
small_objects[not_validate-with-refs-1000]       70.6458 (22.20)    157.2426 (14.27)     79.8429 (24.58)    23.3471 (69.56)     71.2746 (22.12)     0.5931 (31.35)         2;3   12.5246 (0.04)         15           1
small_objects[validate-full-deref-1000]          70.7771 (22.24)     79.0129 (7.17)      71.6598 (22.06)     2.0483 (6.10)      71.0731 (22.06)     0.4071 (21.52)         1;1   13.9548 (0.05)         15           1
small_objects[validate-with-refs-1000]          125.5894 (39.47)    138.3042 (12.56)    127.6093 (39.28)     3.6584 (10.90)    126.0417 (39.12)     1.0842 (57.31)         2;3    7.8364 (0.03)         15           1
small_objects[not_validate-full-deref-5000]     163.0231 (51.23)    172.7724 (15.68)    166.4535 (51.24)     3.7428 (11.15)    165.0318 (51.22)     7.4715 (394.93)        4;0    6.0077 (0.02)         15           1
small_objects[not_validate-with-refs-5000]      355.1658 (111.62)   368.6471 (33.47)    360.2528 (110.89)    4.7679 (14.21)    357.2633 (110.88)    8.3435 (441.03)        5;0    2.7758 (0.01)         15           1
small_objects[validate-full-deref-5000]         355.6939 (111.78)   379.6088 (34.46)    365.2398 (112.42)    7.0391 (20.97)    365.0384 (113.29)    8.0162 (423.72)        6;1    2.7379 (0.01)         15           1
small_objects[validate-with-refs-5000]          637.9847 (200.50)   658.2013 (59.75)    647.2056 (199.22)    7.0759 (21.08)    646.9710 (200.80)   13.7518 (726.90)        8;0    1.5451 (0.01)         15           1
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------


Generated histogram: /nail/home/alston/bravado-core/.benchmarks/benchmark-test_small_objects.svg
Legend:
  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
  OPS: Operations Per Second, computed as 1 / Mean
```

#### This Branch

```
------------------------------------------------------------------------------------------ benchmark 'test_large_objects': 12 tests -----------------------------------------------------------------------------------------
Name (time in ms)                                      Min                   Max                  Mean             StdDev                Median                IQR            Outliers      OPS            Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
large_objects[not_validate-full-deref-100]         13.1332 (1.0)         23.8939 (1.0)         13.4340 (1.0)       1.3194 (1.0)         13.2179 (1.0)       0.0647 (1.0)           2;8  74.4379 (1.0)          75           1
large_objects[not_validate-with-refs-100]          19.6873 (1.50)        43.2166 (1.81)        22.1915 (1.65)      6.7995 (5.15)        19.8416 (1.50)      0.1202 (1.86)          5;6  45.0623 (0.61)         51           1
large_objects[validate-full-deref-100]             28.5398 (2.17)        39.0308 (1.63)        29.2193 (2.18)      2.1870 (1.66)        28.6657 (2.17)      0.1232 (1.90)          2;4  34.2240 (0.46)         35           1
large_objects[validate-with-refs-100]              42.0270 (3.20)        54.6238 (2.29)        42.8702 (3.19)      2.5323 (1.92)        42.2987 (3.20)      0.3015 (4.66)          1;2  23.3262 (0.31)         24           1
large_objects[not_validate-full-deref-1000]       131.6454 (10.02)      142.5448 (5.97)       135.0179 (10.05)     3.5391 (2.68)       132.6476 (10.04)     5.4130 (83.66)         3;0   7.4064 (0.10)         15           1
large_objects[not_validate-with-refs-1000]        196.7201 (14.98)      211.5347 (8.85)       200.9814 (14.96)     3.9087 (2.96)       199.7566 (15.11)     4.7439 (73.32)         3;1   4.9756 (0.07)         15           1
large_objects[validate-full-deref-1000]           285.6238 (21.75)      298.4806 (12.49)      291.0853 (21.67)     4.8426 (3.67)       288.9968 (21.86)     9.1809 (141.89)        6;0   3.4354 (0.05)         15           1
large_objects[validate-with-refs-1000]            423.7315 (32.26)      440.2225 (18.42)      429.1981 (31.95)     4.3428 (3.29)       428.1222 (32.39)     3.1455 (48.61)         3;2   2.3299 (0.03)         15           1
large_objects[not_validate-full-deref-5000]       676.9105 (51.54)      699.5420 (29.28)      687.6646 (51.19)     6.5392 (4.96)       685.4251 (51.86)     5.7847 (89.40)         4;1   1.4542 (0.02)         15           1
large_objects[not_validate-with-refs-5000]      1,008.5955 (76.80)    1,213.0288 (50.77)    1,031.8799 (76.81)    50.5193 (38.29)    1,018.0003 (77.02)     8.0585 (124.54)        1;1   0.9691 (0.01)         15           1
large_objects[validate-full-deref-5000]         1,470.1559 (111.94)   1,492.0250 (62.44)    1,479.8690 (110.16)    6.4513 (4.89)     1,478.3208 (111.84)    8.3019 (128.30)        6;0   0.6757 (0.01)         15           1
large_objects[validate-with-refs-5000]          2,141.8758 (163.09)   2,180.8412 (91.27)    2,162.2417 (160.95)   11.1292 (8.44)     2,164.6063 (163.76)   12.1008 (187.01)        5;0   0.4625 (0.01)         15           1
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------


Generated histogram: /nail/home/alston/bravado-core/.benchmarks/benchmark-test_large_objects.svg
-------------------------------------------------------------------------------------- benchmark 'test_small_objects': 12 tests -------------------------------------------------------------------------------------
Name (time in ms)                                    Min                 Max                Mean            StdDev              Median                IQR            Outliers       OPS            Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
small_objects[not_validate-full-deref-100]        3.2726 (1.0)        6.6810 (1.0)        3.4249 (1.0)      0.2075 (1.29)       3.4251 (1.0)       0.0821 (1.69)          3;4  291.9757 (1.0)         279           1
small_objects[not_validate-with-refs-100]         5.9064 (1.80)       7.8471 (1.17)       5.9836 (1.75)     0.1607 (1.0)        5.9601 (1.74)      0.0487 (1.0)           3;5  167.1238 (0.57)        167           1
small_objects[validate-full-deref-100]            7.0582 (2.16)      10.5060 (1.57)       7.1850 (2.10)     0.3228 (2.01)       7.1344 (2.08)      0.0966 (1.98)          2;5  139.1789 (0.48)        115           1
small_objects[validate-with-refs-100]            11.3397 (3.47)      14.9296 (2.23)      11.5625 (3.38)     0.4448 (2.77)      11.4545 (3.34)      0.1216 (2.50)          3;8   86.4864 (0.30)         87           1
small_objects[not_validate-full-deref-1000]      32.8302 (10.03)     42.3585 (6.34)      33.7281 (9.85)     1.8657 (11.61)     33.1433 (9.68)      0.5810 (11.93)         3;3   29.6489 (0.10)         30           1
small_objects[not_validate-with-refs-1000]       59.3277 (18.13)     62.9195 (9.42)      59.9013 (17.49)    0.9202 (5.73)      59.5298 (17.38)     0.5257 (10.79)         3;3   16.6941 (0.06)         17           1
small_objects[validate-full-deref-1000]          70.2772 (21.47)     75.0500 (11.23)     70.9416 (20.71)    1.1545 (7.19)      70.6219 (20.62)     0.3366 (6.91)          1;1   14.0961 (0.05)         15           1
small_objects[validate-with-refs-1000]          114.2885 (34.92)    127.4448 (19.08)    118.1229 (34.49)    3.3560 (20.89)    116.8700 (34.12)     3.7668 (77.32)         4;1    8.4658 (0.03)         15           1
small_objects[not_validate-full-deref-5000]     166.3628 (50.84)    178.1454 (26.66)    169.4850 (49.49)    4.1921 (26.09)    167.1756 (48.81)     3.6346 (74.60)         3;2    5.9002 (0.02)         15           1
small_objects[not_validate-with-refs-5000]      298.6854 (91.27)    318.2586 (47.64)    304.8728 (89.02)    6.4023 (39.85)    302.7785 (88.40)     8.5196 (174.87)        3;0    3.2801 (0.01)         15           1
small_objects[validate-full-deref-5000]         355.1987 (108.54)   382.5925 (57.27)    362.3307 (105.79)   7.5961 (47.28)    358.5935 (104.69)    8.5741 (175.99)        2;1    2.7599 (0.01)         15           1
small_objects[validate-with-refs-5000]          573.4849 (175.24)   612.7903 (91.72)    585.2388 (170.88)   9.9673 (62.04)    582.6132 (170.10)   10.2757 (210.92)        4;1    1.7087 (0.01)         15           1
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------


Generated histogram: /nail/home/alston/bravado-core/.benchmarks/benchmark-test_small_objects.svg
Legend:
  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
  OPS: Operations Per Second, computed as 1 / Mean
```

If we look a the the largest object with derefs (benchmark for `large_objects[validate-with-refs-5000]`), we now have a median of `2,164.6063` compared to `2,318.4664` on master, which is a 6.6% performance gain. The performance gains seem to increase based on the object size, which would explain why larger gains were recorded during my custom tests.