### PR TITLE
Ensure proper polymorphic objects handling in case of fully dereferenced specs

### DIFF
--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -570,6 +570,13 @@ def post_process_spec(swagger_spec, on_container_callbacks):
                 descend(fragment[index], path + [str(index)], visited_refs)
 
     descend(swagger_spec.spec_dict)
+    if swagger_spec.config['internally_dereference_refs']:
+        # While building models we need to rebuild them by using fully dereference specs in order
+        # to get proper validation of polymorphic objects
+        # NOTE: It cannot be a replacement of ``descend(swagger_spec.spec_dict)`` because
+        # swagger_specs.deref_flattened_spec needs already built models in order to add not used
+        # models in the discovered models/definitions
+        descend(swagger_spec.deref_flattened_spec)
 
 
 def strip_xscope(spec_dict):

--- a/bravado_core/swagger20_validator.py
+++ b/bravado_core/swagger20_validator.py
@@ -10,7 +10,6 @@ from swagger_spec_validator.ref_validators import in_scope
 
 from bravado_core.schema import is_param_spec
 from bravado_core.schema import is_prop_nullable
-from bravado_core.schema import is_ref
 from bravado_core.schema import is_required
 
 """Draft4Validator is not completely compatible with Swagger 2.0 schema
@@ -146,7 +145,7 @@ def discriminator_validator(swagger_spec, validator, discriminator_attribute, in
     """
 
     discriminator_value = instance[discriminator_attribute]
-    if discriminator_value not in swagger_spec.spec_dict['definitions']:
+    if discriminator_value not in swagger_spec.definitions:
         raise ValidationError(
             message='\'{}\' is not a recognized schema'.format(discriminator_value)
         )
@@ -154,7 +153,7 @@ def discriminator_validator(swagger_spec, validator, discriminator_attribute, in
     if discriminator_value == schema['x-model']:
         return
 
-    new_schema = deepcopy(swagger_spec.deref(swagger_spec.spec_dict['definitions'][discriminator_value]))
+    new_schema = deepcopy(swagger_spec.definitions[discriminator_value]._model_spec)
     if 'allOf' not in new_schema:
         raise ValidationError(
             message='discriminated schema \'{}\' must inherit from \'{}\''.format(
@@ -162,7 +161,7 @@ def discriminator_validator(swagger_spec, validator, discriminator_attribute, in
             )
         )
 
-    schemas_to_remove = [s for s in new_schema['allOf'] if is_ref(s) and swagger_spec.deref(s) == schema]
+    schemas_to_remove = [s for s in new_schema['allOf'] if swagger_spec.deref(s) == schema]
     if not schemas_to_remove:
         # Not checking against len(schemas_to_remove) > 1 because it should be prevented by swagger spec validation
         raise ValidationError(

--- a/test-data/2.0/polymorphic_specs/swagger.json
+++ b/test-data/2.0/polymorphic_specs/swagger.json
@@ -13,7 +13,13 @@
         "operationId": "get_pets",
         "responses": {
           "200": {
-            "description": "Pet List"
+            "description": "Pet List",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/GenericPet"
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
Fixes #210 

The issue reported is caused by two concurrent factors:
1. in case of fully dereferenced specs polymorphic checks are performed on specs that have references (but ``deref`` will not resolve them) -> ensure that Spec is built using fully dereferenced specs
2. in case of fully dereferenced specs (since the specs are obtained after spec flattening) we should not use ``spec.client_dict``, but using ``spec._internal_client_dict`` will not give us any guarantee to get the required definition. -> use spec.definitions instead

I've added ``test_ensure_polymorphic_objects_are_correctly_build_in_case_of_fully_dereferenced_specs`` to ensure that we're correctly covering this case.

@gstarnberger : FYI