### PR TITLE
Fixes #214 - Added msgpack support

### DIFF
--- a/bravado_core/content_type.py
+++ b/bravado_core/content_type.py
@@ -1,2 +1,3 @@
 # -*- coding: utf-8 -*-
 APP_JSON = 'application/json'
+APP_MSGPACK = 'application/msgpack'

--- a/bravado_core/response.py
+++ b/bravado_core/response.py
@@ -112,7 +112,7 @@ def unmarshal_response(response, op):
         if content_type.startswith(APP_JSON):
             content_value = response.json()
         else:
-            content_value = umsgpack.unpackb(response.raw_bytes)
+            content_value = umsgpack.loads(response.raw_bytes)
         if op.swagger_spec.config['validate_responses']:
             validate_schema_object(op.swagger_spec, content_spec, content_value)
 
@@ -203,7 +203,7 @@ def validate_response_body(op, response_spec, response):
         if response.content_type == APP_JSON:
             response_value = response.json()
         else:
-            response_value = umsgpack.unpackb(response.raw_bytes)
+            response_value = umsgpack.loads(response.raw_bytes)
         validate_schema_object(
             op.swagger_spec, response_body_spec, response_value)
     elif response.content_type.startswith("text/"):

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ install_requires = [
     "six",
     "swagger-spec-validator>=2.0.1",
     "pytz",
-    "u-msgpack-python>=2.4.1",
+    "u-msgpack-python>=2",
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ install_requires = [
     "six",
     "swagger-spec-validator>=2.0.1",
     "pytz",
+    "u-msgpack-python>=2.4.1",
 ]
 
 

--- a/tests/response/IncomingResponse_test.py
+++ b/tests/response/IncomingResponse_test.py
@@ -12,6 +12,7 @@ def test_required_attr_returned():
             self.status_code = 404
             self.reason = 'Object not found'
             self.text = 'Error - not found'
+            self.raw_bytes = b'Error - not found'
             self.headers = {}
 
     r = CompliantIncomingResponse()

--- a/tests/response/unmarshal_response_test.py
+++ b/tests/response/unmarshal_response_test.py
@@ -54,8 +54,10 @@ def test_msgpack_content(empty_swagger_spec, response_spec):
         headers={'content-type': APP_MSGPACK},
         raw_bytes=umsgpack.packb(message))
 
-    with patch('bravado_core.response.get_response_spec') as m:
-        m.return_value = response_spec
+    with patch(
+        'bravado_core.response.get_response_spec',
+        return_value=response_spec,
+    ):
         op = Mock(swagger_spec=empty_swagger_spec)
         assert message == unmarshal_response(response, op)
 

--- a/tests/response/unmarshal_response_test.py
+++ b/tests/response/unmarshal_response_test.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 import pytest
+import umsgpack
 from mock import Mock
 from mock import patch
 
 from bravado_core.content_type import APP_JSON
+from bravado_core.content_type import APP_MSGPACK
 from bravado_core.response import IncomingResponse
 from bravado_core.response import unmarshal_response
 
@@ -42,6 +44,20 @@ def test_json_content(empty_swagger_spec, response_spec):
         m.return_value = response_spec
         op = Mock(swagger_spec=empty_swagger_spec)
         assert 'Monday' == unmarshal_response(response, op)
+
+
+def test_msgpack_content(empty_swagger_spec, response_spec):
+    message = 'Monday'
+    response = Mock(
+        spec=IncomingResponse,
+        status_code=200,
+        headers={'content-type': APP_MSGPACK},
+        raw_bytes=umsgpack.packb(message))
+
+    with patch('bravado_core.response.get_response_spec') as m:
+        m.return_value = response_spec
+        op = Mock(swagger_spec=empty_swagger_spec)
+        assert message == unmarshal_response(response, op)
 
 
 def test_text_content(empty_swagger_spec, response_spec):

--- a/tests/response/validate_response_body_test.py
+++ b/tests/response/validate_response_body_test.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 import pytest
+import umsgpack
 from mock import Mock
 
+from bravado_core.content_type import APP_MSGPACK
 from bravado_core.exception import SwaggerMappingError
 from bravado_core.operation import Operation
 from bravado_core.response import EMPTY_BODIES
@@ -47,6 +49,34 @@ def test_success_json_response(minimal_swagger_spec):
                 'last_name': 'niwrad'
             }
         )
+    )
+    validate_response_body(op, response_spec, response)
+
+
+def test_success_msgpack_response(minimal_swagger_spec):
+    response_spec = {
+        'description': 'Address',
+        'schema': {
+            'type': 'object',
+            'properties': {
+                'first_name': {
+                    'type': 'string',
+                },
+                'last_name': {
+                    'type': 'string',
+                }
+            }
+        }
+    }
+    op = Operation(minimal_swagger_spec, '/foo', 'get',
+                   op_spec={'produces': [APP_MSGPACK]})
+    response = Mock(
+        spec=OutgoingResponse,
+        content_type=APP_MSGPACK,
+        raw_bytes=umsgpack.packb({
+            'first_name': 'darwin',
+            'last_name': 'niwrad'
+        }),
     )
     validate_response_body(op, response_spec, response)
 


### PR DESCRIPTION
### Test Plan
(1) `make test` with added unit tests
(2) Manually tested the client side by calling a mocked endpoint that responds with a application/msgpack content type and data, and verified the final response from Bravado was properly deserialized
(3) Manually tested the server side response validation by requesting an endpoint which responds with a application/msgpack content type that uses pyramid_swagger

### Related PRs
https://github.com/striglia/pyramid_swagger/pull/223
https://github.com/Yelp/bravado/pull/324

##### This should be released as a major version bump