### PR TITLE
Don't remove extraneous configurations, only warn about their presence

### DIFF
--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -140,10 +140,9 @@ class Spec(object):
             are_config_changed = True
             for key in extraneous_keys:
                 warnings.warn(
-                    message='config {} is been removed because is not a recognized config key'.format(key),
+                    message='config {} is not a recognized config key'.format(key),
                     category=Warning,
                 )
-                del self.config[key]
 
         if self.config['internally_dereference_refs'] and not self.config['validate_swagger_spec']:
             are_config_changed = True

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -243,7 +243,7 @@ class Spec(object):
         else:
             return self.spec_dict
 
-    def deref(self, ref_dict):
+    def _force_deref(self, ref_dict):
         """Dereference ref_dict (if it is indeed a ref) and return what the
         ref points to.
 
@@ -251,9 +251,7 @@ class Spec(object):
         :return: dereferenced value of ref_dict
         :rtype: scalar, list, dict
         """
-        # If internally_dereference_refs is enabled we do NOT need to resolve references anymore
-        # it's useless to evaluate is_ref every time
-        if self.config['internally_dereference_refs'] or ref_dict is None or not is_ref(ref_dict):
+        if ref_dict is None or not is_ref(ref_dict):
             return ref_dict
 
         # Restore attached resolution scope before resolving since the
@@ -267,6 +265,11 @@ class Spec(object):
 
             _, target = self.resolver.resolve(ref_dict['$ref'])
             return target
+
+    def deref(self, ref_dict):
+        # If internally_dereference_refs is enabled we do NOT need to resolve references anymore
+        # it's useless to evaluate is_ref every time
+        return ref_dict if self.config['internally_dereference_refs'] else self._force_deref(ref_dict)
 
     def get_op_for_request(self, http_method, path_pattern):
         """Return the Swagger operation for the passed in request http method

--- a/tests/spec/Spec/deref_flattened_spec_test.py
+++ b/tests/spec/Spec/deref_flattened_spec_test.py
@@ -24,14 +24,14 @@ def _equivalent(spec, obj1, obj2):
         for key in iterkeys(obj1):
             if key not in obj2:
                 return False
-            return _equivalent(spec, spec.deref(obj1[key]), spec.deref(obj2[key]))
+            return _equivalent(spec, spec._force_deref(obj1[key]), spec._force_deref(obj2[key]))
 
     elif is_list_like(obj1):
         if len(obj1) != len(obj2):
             return False
 
         for key in range(len(obj1)):
-            return _equivalent(spec, spec.deref(obj1[key]), spec.deref(obj2[key]))
+            return _equivalent(spec, spec._force_deref(obj1[key]), spec._force_deref(obj2[key]))
     else:
         return obj1 == obj2
 

--- a/tests/spec/validate_config_test.py
+++ b/tests/spec/validate_config_test.py
@@ -21,22 +21,25 @@ def test_validate_config_succeed(minimal_swagger_dict, minimal_swagger_abspath, 
 
 
 @pytest.mark.parametrize(
-    'config, expected_warnings_call',
+    'config, expected_different_config, expected_warnings_call',
     [
         (
             {'this_is_an_extra_key': True},
-            'config this_is_an_extra_key is been removed because is not a recognized config key',
+            False,
+            'config this_is_an_extra_key is not a recognized config key',
         ),
         (
             {'validate_swagger_spec': False, 'internally_dereference_refs': True},
+            True,
             'internally_dereference_refs config disabled because validate_swagger_spec has to be enabled',
         ),
     ]
 )
 @mock.patch('bravado_core.spec.warnings')
 def test_validate_config_fail(
-    mock_warnings, minimal_swagger_dict, minimal_swagger_abspath, config, expected_warnings_call,
+    mock_warnings, minimal_swagger_dict, minimal_swagger_abspath,
+    config, expected_different_config, expected_warnings_call,
 ):
     spec = Spec.from_dict(minimal_swagger_dict, origin_url=get_url(minimal_swagger_abspath), config=config)
-    assert spec.config != dict(CONFIG_DEFAULTS, **config)
+    assert (spec.config != dict(CONFIG_DEFAULTS, **config)) is expected_different_config
     mock_warnings.warn.assert_called_once_with(message=expected_warnings_call, category=Warning)

--- a/tests/validate/validate_object_test.py
+++ b/tests/validate/validate_object_test.py
@@ -254,7 +254,7 @@ def test_nullable_required_no_value(empty_swagger_spec, nullable):
 
     with pytest.raises(ValidationError) as excinfo:
         validate_object(empty_swagger_spec, content_spec, value)
-    assert excinfo.value.message == "'x' is a required property"
+    assert "'x' is a required property" in str(excinfo.value.message)
 
 
 @pytest.mark.parametrize('nullable', [True, False])
@@ -330,7 +330,7 @@ def test_allOf_complex_failure(composition_spec):
 
     with pytest.raises(ValidationError) as excinfo:
         validate_object(composition_spec, pongclone_spec, value)
-    assert excinfo.value.message == "'gameSystem' is a required property"
+    assert "'gameSystem' is a required property" in str(excinfo.value.message)
 
 
 def test_validate_valid_polymorphic_object(polymorphic_spec):
@@ -422,4 +422,4 @@ def test_validate_invalid_polymorphic_object(polymorphic_spec, schema_dict, expe
             object_spec=polymorphic_spec.spec_dict['definitions']['PetList'],
             value=schema_dict,
         )
-    assert e.value.message == expected_validation_error
+    assert expected_validation_error in str(e.value.message)


### PR DESCRIPTION
Fixes #217 .

The goal of this PR is to fix the current [``Yelp/bravado``](https://github.com/Yelp/bravado) [build failure](https://travis-ci.org/Yelp/bravado/builds/297225901).

``bravado`` is failing because it used to inject ``also_return_response`` configuration into ``bravado-core`` configs, which is not using that config.

Since ``bravado-core`` is not using this config, I'm not adding it into ``CONFIG_DEFAULTS``, but removing the logic that strips out extraneous configurations.

This PR exposes also ``_deref`` method in order to force dereferencing of objects even if ``internaly_dereference_ref`` in order to reduce ``test_deref_flattened_spec_not_recursive_specs`` flakyness.