### PR TITLE
allow to specify Content-Disposition filename

### DIFF
--- a/bravado_core/param.py
+++ b/bravado_core/param.py
@@ -284,7 +284,12 @@ def add_file(param, value, request):
                     param.op.consumes
             ))
 
-    file_tuple = (param.name, (param.name, value))
+    if isinstance(value, tuple):
+        filename, val = value
+    else:
+        filename, val = param.name, value
+
+    file_tuple = (param.name, (filename, val))
     request['files'].append(file_tuple)
 
 


### PR DESCRIPTION
I'm missing the ability to specify the original filename when uploading files with bravado client.

In this PR I have made it possible to specify filename by using a tuple as the argument to methods that POST files.

E.g. it possible to use:

client.foo.post_bar(fooFile=("my-filename", "file content"))

The old style is also supported:

client.foo.post_bar(fooFile="file content")

Not sure if using tuples is the best way to go, please advice.
