### PR TITLE
Return raw response

### DIFF
--- a/bravado_core/response.py
+++ b/bravado_core/response.py
@@ -115,6 +115,8 @@ def unmarshal_response(response, op):
             content_value = umsgpack.loads(response.raw_bytes)
         if op.swagger_spec.config['validate_responses']:
             validate_schema_object(op.swagger_spec, content_spec, content_value)
+        if op.swagger_spec.config['return_raw_response']:
+            return content_value
 
         return unmarshal_schema_object(
             op.swagger_spec, content_spec, content_value)

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -76,6 +76,9 @@ CONFIG_DEFAULTS = {
     # Completely dereference $refs to maximize marshaling and unmarshaling performances.
     # NOTE: this depends on validate_swagger_spec
     'internally_dereference_refs': False,
+
+    # Skip call to unmarshal_schema_object and return raw decoded response.
+    'return_raw_response': False,
 }
 
 

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -43,4 +43,9 @@ Config key                    Type            Default   Description
                                                         | to ``object`` and be validated as such.
                                                         | When set to ``False``, missing types will not be
                                                         | validated at all.
+----------------------------- --------------- --------- ----------------------------------------------------
+*return_raw_response*         boolean         False     | When set to ``True``, the raw decoded response
+                                                        | will be returned.
+                                                        | When set to ``False``, the response will be
+                                                        | unmarshalled according to the schema.
 ============================= =============== ========= ====================================================

--- a/tests/response/unmarshal_response_test.py
+++ b/tests/response/unmarshal_response_test.py
@@ -75,6 +75,24 @@ def test_text_content(empty_swagger_spec, response_spec):
         assert 'Monday' == unmarshal_response(response, op)
 
 
+def test_raw_response(empty_swagger_spec, response_spec):
+    empty_swagger_spec.config['validate_responses'] = False
+    empty_swagger_spec.config['return_raw_response'] = True
+    return_value = object()
+    response = Mock(
+        spec=IncomingResponse,
+        status_code=200,
+        headers={'content-type': APP_JSON},
+        json=Mock(return_value=return_value))
+
+    with patch('bravado_core.response.unmarshal_schema_object') as unmarshal_schem:
+        with patch('bravado_core.response.get_response_spec') as m:
+            m.return_value = response_spec
+            op = Mock(swagger_spec=empty_swagger_spec)
+            assert return_value == unmarshal_response(response, op)
+            assert unmarshal_schem.call_count == 0
+
+
 def test_skips_validation(empty_swagger_spec, response_spec):
     empty_swagger_spec.config['validate_responses'] = False
     response = Mock(


### PR DESCRIPTION
Adds a new config option "return_raw_response" that returns the raw decoded response (after json/msgpack decoding, skipping the call to unmarshal_schema_object).