### PR TITLE
Make sure we don't unnecessarily call collapsed_properties

### DIFF
--- a/bravado_core/marshal.py
+++ b/bravado_core/marshal.py
@@ -7,6 +7,7 @@ from bravado_core.exception import SwaggerMappingError
 from bravado_core.model import is_model
 from bravado_core.model import is_object
 from bravado_core.model import MODEL_MARKER
+from bravado_core.schema import collapsed_properties
 from bravado_core.schema import get_spec_for_prop
 from bravado_core.schema import handle_null_value
 from bravado_core.schema import is_dict_like
@@ -135,12 +136,13 @@ def marshal_object(swagger_spec, object_spec, object_value):
 
     object_spec = deref(object_spec)
     required_fields = object_spec.get('required', [])
+    properties = collapsed_properties(object_spec, swagger_spec)
 
     result = {}
     for k, v in iteritems(object_value):
 
         prop_spec = get_spec_for_prop(
-            swagger_spec, object_spec, object_value, k)
+            swagger_spec, object_spec, object_value, k, properties)
 
         if not prop_spec:
             # Don't marshal when a spec is not available - just pass through

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -82,7 +82,7 @@ def is_list_like(spec):
     return isinstance(spec, (list, tuple))
 
 
-def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name):
+def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, properties=None):
     """Given a jsonschema object spec and value, retrieve the spec for the
      given property taking 'additionalProperties' into consideration.
 
@@ -90,13 +90,15 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name):
     :param object_value: jsonschema object containing the given property. Only
         used in error message.
     :param prop_name: name of the property to retrieve the spec for
+    :param properties: collapsed properties of the object
 
     :return: spec for the given property or None if no spec found
     :rtype: dict or None
     """
     deref = swagger_spec.deref
 
-    properties = collapsed_properties(deref(object_spec), swagger_spec)
+    if properties is None:
+        properties = collapsed_properties(deref(object_spec), swagger_spec)
     prop_spec = properties.get(prop_name)
 
     if prop_spec is not None:

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -129,11 +129,12 @@ def unmarshal_object(swagger_spec, object_spec, object_value):
 
     object_spec = deref(object_spec)
     required_fields = object_spec.get('required', [])
+    properties = collapsed_properties(object_spec, swagger_spec)
 
     result = {}
     for k, v in iteritems(object_value):
         prop_spec = get_spec_for_prop(
-            swagger_spec, object_spec, object_value, k)
+            swagger_spec, object_spec, object_value, k, properties)
         if v is None and k not in required_fields and prop_spec:
             if schema.has_default(swagger_spec, prop_spec):
                 result[k] = schema.get_default(swagger_spec, prop_spec)
@@ -145,7 +146,6 @@ def unmarshal_object(swagger_spec, object_spec, object_value):
             # Don't marshal when a spec is not available - just pass through
             result[k] = v
 
-    properties = collapsed_properties(deref(object_spec), swagger_spec)
     for prop_name, prop_spec in iteritems(properties):
         if prop_name not in result and swagger_spec.config['include_missing_properties']:
             result[prop_name] = None


### PR DESCRIPTION
A comment made internally by @gstarnberger made me look into why we're calling ``collapsed_properties`` so often. It turns out we call ``get_spec_for_prop`` for every property of an object, both when marshalling and unmarshalling. That method fetches the collapsed properties of the parent object - every time! This PR changes marshalling and unmarshalling to compute the properties once and then pass them into ``get_spec_for_prop`` (and saves one more additional call to it when unmarshalling).

These are the timing reductions I observed locally when running our benchmark suite:

| Name | Mean time reduction |
| -- | -- |
 | large_objects[not_validate-full-deref-100]  | 21.62% | 
 | large_objects[not_validate-with-refs-100]   | 19.90% | 
 | large_objects[validate-full-deref-100]      | 8.99% | 
 | large_objects[validate-with-refs-100]       | 10.83% | 
 | large_objects[not_validate-full-deref-1000] | 23.91% | 
 | large_objects[not_validate-with-refs-1000]  | 19.55% | 
 | large_objects[validate-full-deref-1000]     | 11.89% | 
 | large_objects[validate-with-refs-1000]      | 11.40% | 
 | large_objects[not_validate-full-deref-5000] | 21.38% | 
 | large_objects[not_validate-with-refs-5000]  | 17.41% | 
 | large_objects[validate-full-deref-5000]     | 9.90% | 
 | large_objects[validate-with-refs-5000]      | 14.34% | 
 | small_objects[not_validate-full-deref-100]  | 12.17% | 
 | small_objects[not_validate-with-refs-100]   | 12.35% | 
 | small_objects[validate-full-deref-100]      | 8.72% | 
 | small_objects[validate-with-refs-100]       | 8.34% | 
 | small_objects[not_validate-full-deref-1000] | 12.31% | 
 | small_objects[not_validate-with-refs-1000]  | 12.33% | 
 | small_objects[validate-full-deref-1000]     | 7.55% | 
 | small_objects[validate-with-refs-1000]      | 7.08% | 
 | small_objects[not_validate-full-deref-5000] | 13.26% | 
 | small_objects[not_validate-with-refs-5000]  | 13.14% | 
 | small_objects[validate-full-deref-5000]     | 2.76% | 
 | small_objects[validate-with-refs-5000]      | 8.20% | 

As you can see, there is a ~20% reduction in timings for large objects, and ~13% for small objects.