### PR TITLE
Fixes #227 - Use msgpack-python instead of umsgpack

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,6 @@
 Changelog
 =========
+- Use msgpack-python instead of u-msgpack-python for performance improvements - Issue #227, PR #228.
 
 4.11.0 (2017-11-09)
 -------------------

--- a/bravado_core/response.py
+++ b/bravado_core/response.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import umsgpack
+import msgpack
 from six import iteritems
 
 from bravado_core.content_type import APP_JSON
@@ -112,7 +112,7 @@ def unmarshal_response(response, op):
         if content_type.startswith(APP_JSON):
             content_value = response.json()
         else:
-            content_value = umsgpack.loads(response.raw_bytes)
+            content_value = msgpack.loads(response.raw_bytes, encoding='utf-8')
         if op.swagger_spec.config['validate_responses']:
             validate_schema_object(op.swagger_spec, content_spec, content_value)
 
@@ -203,7 +203,7 @@ def validate_response_body(op, response_spec, response):
         if response.content_type == APP_JSON:
             response_value = response.json()
         else:
-            response_value = umsgpack.loads(response.raw_bytes)
+            response_value = msgpack.loads(response.raw_bytes, encoding='utf-8')
         validate_schema_object(
             op.swagger_spec, response_body_spec, response_value)
     elif response.content_type.startswith("text/"):

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ install_requires = [
     "six",
     "swagger-spec-validator>=2.0.1",
     "pytz",
-    "u-msgpack-python>=2",
+    "msgpack-python",
 ]
 
 

--- a/tests/response/unmarshal_response_test.py
+++ b/tests/response/unmarshal_response_test.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
+import msgpack
 import pytest
-import umsgpack
 from mock import Mock
 from mock import patch
 
@@ -52,7 +52,7 @@ def test_msgpack_content(empty_swagger_spec, response_spec):
         spec=IncomingResponse,
         status_code=200,
         headers={'content-type': APP_MSGPACK},
-        raw_bytes=umsgpack.packb(message))
+        raw_bytes=msgpack.packb(message))
 
     with patch(
         'bravado_core.response.get_response_spec',

--- a/tests/response/unmarshal_response_test.py
+++ b/tests/response/unmarshal_response_test.py
@@ -52,7 +52,7 @@ def test_msgpack_content(empty_swagger_spec, response_spec):
         spec=IncomingResponse,
         status_code=200,
         headers={'content-type': APP_MSGPACK},
-        raw_bytes=msgpack.packb(message))
+        raw_bytes=msgpack.dumps(message))
 
     with patch(
         'bravado_core.response.get_response_spec',

--- a/tests/response/validate_response_body_test.py
+++ b/tests/response/validate_response_body_test.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
+import msgpack
 import pytest
-import umsgpack
 from mock import Mock
 
 from bravado_core.content_type import APP_MSGPACK
@@ -73,7 +73,7 @@ def test_success_msgpack_response(minimal_swagger_spec):
     response = Mock(
         spec=OutgoingResponse,
         content_type=APP_MSGPACK,
-        raw_bytes=umsgpack.packb({
+        raw_bytes=msgpack.packb({
             'first_name': 'darwin',
             'last_name': 'niwrad'
         }),

--- a/tests/response/validate_response_body_test.py
+++ b/tests/response/validate_response_body_test.py
@@ -73,7 +73,7 @@ def test_success_msgpack_response(minimal_swagger_spec):
     response = Mock(
         spec=OutgoingResponse,
         content_type=APP_MSGPACK,
-        raw_bytes=msgpack.packb({
+        raw_bytes=msgpack.dumps({
             'first_name': 'darwin',
             'last_name': 'niwrad'
         }),


### PR DESCRIPTION
Fixes #227 

### Testing Plan
- Updated unit tests and ran `make test`
- Tested server side response by using an API endpoint that renders `application/msgpack` responses and checked that the server side Swagger response validation worked properly
- Tested client side by using a `bravado` client which used a version of `bravado-core` with these changes to request an API endpoint that renders only `application/msgpack`. First, check that requesting without the `Accept: application/msgpack` results in a 500 response status. Then, check that requesting with the `Accept: application/msgpack` results in the desired response.
