### PR TITLE
Fixes #335 - Added support for validating compressed responses

### DIFF
--- a/bravado_core/content_encoding.py
+++ b/bravado_core/content_encoding.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+DEFLATE = 'deflate'


### PR DESCRIPTION
## Testing Plan
- Added unit tests and ran `make test`

### Manual Testing
Using bravado-core for Swagger validation and an API endpoint that produces the following:
- `Content-Type: application/msgpack` + `Content-Encoding: deflate` when `Accept: application/msgpack` and `Accept-Encoding: deflate` is specified
- `Content-Type: application/msgpack` when `Accept: application/msgpack` and is specified
- `Content-Type: application/json` + `Content-Encoding: deflate` when `Accept-Encoding: deflate` is specified
- `Content-Type: application/json` for any other request header combinations

The following was tested and verified, using a curl (to avoid any automatically added headers)
- `curl <URK> -i`
- `curl <URL> -H "Accept: application/msgpack" -i`
- `curl <URL> -H "Accept: application/msgpack" -H "Accept-Encoding: deflate" -i`
- `curl <URL> -H "Accept-Encoding: deflate" -i`