### PR TITLE
Remove instance type check while marshaling models

### DIFF
--- a/bravado_core/marshal.py
+++ b/bravado_core/marshal.py
@@ -6,6 +6,7 @@ from bravado_core import schema
 from bravado_core.exception import SwaggerMappingError
 from bravado_core.model import is_model
 from bravado_core.model import is_object
+from bravado_core.model import Model
 from bravado_core.model import MODEL_MARKER
 from bravado_core.schema import collapsed_properties
 from bravado_core.schema import get_spec_for_prop
@@ -177,10 +178,10 @@ def marshal_model(swagger_spec, model_spec, model_value):
     if model_value is None:
         return handle_null_value(swagger_spec, model_spec)
 
-    if not isinstance(model_value, model_type):
+    if not isinstance(model_value, Model):
         raise SwaggerMappingError(
-            'Expected model of type {0} but got {1} for value {2}'.format(
-                model_name, model_value.__class__.__name__, model_value,
+            'Expected {0.__module__}.{0.__name__} object but got {1.__module__}.{1.__name__}'.format(
+                Model, type(model_value),
             ),
         )
 

--- a/tests/marshal/marshal_model_test.py
+++ b/tests/marshal/marshal_model_test.py
@@ -5,6 +5,7 @@ import pytest
 
 from bravado_core.exception import SwaggerMappingError
 from bravado_core.marshal import marshal_model
+from bravado_core.model import Model
 from bravado_core.spec import Spec
 
 
@@ -85,7 +86,7 @@ def test_value_is_not_dict_like_raises_error(petstore_dict):
     pet_spec = petstore_spec.spec_dict['definitions']['Pet']
     with pytest.raises(SwaggerMappingError) as excinfo:
         marshal_model(petstore_spec, pet_spec, 'i am not a dict')
-    assert 'Expected model of type' in str(excinfo.value)
+    assert 'Expected {0.__module__}.{0.__name__} object but got '.format(Model) in str(excinfo.value)
 
 
 def test_marshal_model_with_none_model_type(petstore_spec):
@@ -123,16 +124,3 @@ def test_marshal_model_with_with_different_specs(petstore_dict, petstore_spec):
     assert marshal_model(petstore_spec, pet_spec, model) == {
         'id': 1, 'name': 'Fido', 'photoUrls': ['wagtail.png', 'bark.png'],
     }
-
-
-def test_marshal_model_raises_exception_if_different_model(petstore_spec):
-    pet_spec = petstore_spec.spec_dict['definitions']['Pet']
-    order_spec = petstore_spec.definitions['Order']
-    model = order_spec()
-
-    with pytest.raises(SwaggerMappingError) as excinfo:
-        marshal_model(petstore_spec, pet_spec, model)
-
-    assert str(excinfo.value) == 'Expected model of type {0} but got {1} for value {2}'.format(
-        'Pet', 'Order', model,
-    )


### PR DESCRIPTION
Fixes: #222 
The goal of this PR is to remove model type check while marshaling models.
The "old" behavior adds a sort of type validation even if ``validate_response`` is set to false.

With this PR the only check that is made is that ``marshal_model`` is a ``bravado_core.model.Model`` instance, so we have guarantees that ``model_value._as_dict()`` will not raise an error.