### PR TITLE
Percent encode params that will be put into the url

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+4.11.4 (2018-01-16)
+-------------------
+- Percent encode params that will be put into the url
+
 4.11.3 (2018-01-16)
 -------------------
 - Remove strict isinstance check when marshalling models - PR #236.

--- a/tests/param/marshal_param_test.py
+++ b/tests/param/marshal_param_test.py
@@ -53,20 +53,33 @@ def param_spec():
     }
 
 
-def test_query_string(empty_swagger_spec, string_param_spec, request_dict):
+@pytest.mark.parametrize(
+    'query_string_param, exected_param',
+    [
+        ('darwin', 'darwin'),
+        ('da%?=rwin', 'da%25%3F%3Drwin'),
+    ]
+)
+def test_query_string(empty_swagger_spec, string_param_spec, request_dict, query_string_param, exected_param):
     param = Param(empty_swagger_spec, Mock(spec=Operation), string_param_spec)
     expected = copy.deepcopy(request_dict)
-    expected['params']['username'] = 'darwin'
-    marshal_param(param, 'darwin', request_dict)
+    expected['params']['username'] = exected_param
+    marshal_param(param, query_string_param, request_dict)
     assert expected == request_dict
 
 
-def test_query_array(empty_swagger_spec, array_param_spec, request_dict):
+@pytest.mark.parametrize(
+    'query_array_param, exected_param',
+    [
+        (['cat', 'dog', 'bird'], 'cat,dog,bird'),
+        (['c?at', 'd=og', 'b%ird'], 'c%3Fat,d%3Dog,b%25ird'),
+    ]
+)
+def test_query_array(empty_swagger_spec, array_param_spec, request_dict, query_array_param, exected_param):
     param = Param(empty_swagger_spec, Mock(spec=Operation), array_param_spec)
-    value = ['cat', 'dog', 'bird']
     expected = copy.deepcopy(request_dict)
-    expected['params']['animals'] = ','.join(value)
-    marshal_param(param, value, request_dict)
+    expected['params']['animals'] = exected_param
+    marshal_param(param, query_array_param, request_dict)
     assert expected == request_dict
 
 
@@ -97,25 +110,22 @@ def test_path_integer(empty_swagger_spec, param_spec):
     assert '/pet/34' == request['url']
 
 
-def test_path_string(empty_swagger_spec, param_spec):
+@pytest.mark.parametrize(
+    'string_param, expected_path',
+    [
+        ('34', '/pet/34'),
+        (u'Ümlaut', '/pet/%C3%9Cmlaut'),
+        ('/\%?=', '/pet/%2F%5C%25%3F%3D'),
+    ]
+)
+def test_path_string(empty_swagger_spec, param_spec, string_param, expected_path):
     param_spec['in'] = 'path'
     param_spec['type'] = 'string'
     del param_spec['format']
     param = Param(empty_swagger_spec, Mock(spec=Operation), param_spec)
     request = {'url': '/pet/{petId}'}
-    marshal_param(param, '34', request)
-    assert '/pet/34' == request['url']
-
-
-def test_path_unicode_string(empty_swagger_spec, param_spec):
-    param_spec['in'] = 'path'
-    param_spec['type'] = 'string'
-    del param_spec['format']
-    param = Param(empty_swagger_spec, Mock(spec=Operation), param_spec)
-    request = {'url': '/pet/{petId}'}
-    marshal_param(param, u'Ümlaut', request)
-    # verify no escaping/encoding takes place on URL
-    assert u'/pet/Ümlaut' == request['url']
+    marshal_param(param, string_param, request)
+    assert expected_path == request['url']
 
 
 def test_header_string(empty_swagger_spec, param_spec):


### PR DESCRIPTION
Before, we did not percent escape params being put into the url, so invalid urls would be created (most commonly with '%' or '?' characters).  When these invalid urls hit Apache, a 400 was returned, and bravado raised an exception when trying to parse the 400 (resulting in a 500 for the user).