### PR TITLE
Properly quote path params

### DIFF
--- a/bravado_core/param.py
+++ b/bravado_core/param.py
@@ -4,6 +4,7 @@ from functools import partial
 
 import simplejson as json
 import six
+from six.moves.urllib.parse import quote_plus
 
 from bravado_core import schema
 from bravado_core.content_type import APP_JSON
@@ -128,8 +129,8 @@ def marshal_param(param, value, request):
 
     if location == 'path':
         token = u'{%s}' % param.name
-        # Don't do any escaping/encoding - http_client will take care of it
-        request['url'] = request['url'].replace(token, six.text_type(value))
+        quoted_value = quote_plus(six.text_type(value).encode('utf8'), safe=',')
+        request['url'] = request['url'].replace(token, quoted_value)
     elif location == 'query':
         request['params'][param.name] = value
     elif location == 'header':

--- a/tests/param/marshal_param_test.py
+++ b/tests/param/marshal_param_test.py
@@ -97,25 +97,22 @@ def test_path_integer(empty_swagger_spec, param_spec):
     assert '/pet/34' == request['url']
 
 
-def test_path_string(empty_swagger_spec, param_spec):
+@pytest.mark.parametrize(
+    'string_param, expected_path',
+    [
+        ('34', '/pet/34'),
+        (u'Ümlaut', '/pet/%C3%9Cmlaut'),
+        ('/\%?=', '/pet/%2F%5C%25%3F%3D'),
+    ]
+)
+def test_path_string(empty_swagger_spec, param_spec, string_param, expected_path):
     param_spec['in'] = 'path'
     param_spec['type'] = 'string'
     del param_spec['format']
     param = Param(empty_swagger_spec, Mock(spec=Operation), param_spec)
     request = {'url': '/pet/{petId}'}
-    marshal_param(param, '34', request)
-    assert '/pet/34' == request['url']
-
-
-def test_path_unicode_string(empty_swagger_spec, param_spec):
-    param_spec['in'] = 'path'
-    param_spec['type'] = 'string'
-    del param_spec['format']
-    param = Param(empty_swagger_spec, Mock(spec=Operation), param_spec)
-    request = {'url': '/pet/{petId}'}
-    marshal_param(param, u'Ümlaut', request)
-    # verify no escaping/encoding takes place on URL
-    assert u'/pet/Ümlaut' == request['url']
+    marshal_param(param, string_param, request)
+    assert expected_path == request['url']
 
 
 def test_header_string(empty_swagger_spec, param_spec):


### PR DESCRIPTION
This is an updated version of #237. Long story short: bravado is handling quoting of query and formData params correctly, #237 would have broken that. On the other hand, we do not properly handle path params that need quoting. I'm assuming this hasn't surfaced earlier because people typically only have numeric IDs or ASCII strings as values for params that are passed in the URL.

I have integration tests for bravado and bravado-asyncio that show that query argument escaping works, I'll publish PRs once this change is merged in (I need this fix so that the integration tests for it that I wrote don't fail).