### PR TITLE
Fix 235 allow override formats

### DIFF
--- a/bravado_core/param.py
+++ b/bravado_core/param.py
@@ -114,7 +114,7 @@ def marshal_param(param, value, request):
     location = param.location
 
     # Rely on unmarshalling behavior on the other side of the pipe to use
-    # the default value if one is availabe.
+    # the default value if one is available.
     if value is None and not schema.is_required(swagger_spec, param_spec):
         return
 

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -314,9 +314,10 @@ class Spec(object):
         :param name: Name of the format to retrieve
         :rtype: :class:`bravado_core.formatters.SwaggerFormat`
         """
-        if name in formatter.DEFAULT_FORMATS:
-            return formatter.DEFAULT_FORMATS[name]
         format = self.user_defined_formats.get(name)
+        if format is None:
+            format = formatter.DEFAULT_FORMATS.get(name)
+
         if format is None:
             warnings.warn(
                 message='{0} format is not registered with bravado-core!'.format(name),

--- a/docs/source/formats.rst
+++ b/docs/source/formats.rst
@@ -168,3 +168,51 @@ CIDR objects back from the response.
     # Verify cidrs are CIDR objects and not strings
     for cidr in cidrs:
         assert type(cidr) == CIDR
+
+Overriding built-in formats is also possible with a user-defined format
+-----------------------------------------------------------------------
+By default format 'double' is internally converted to a float in python.  This runs
+the risk of being imprecise due to the way floats are handled.  If you would
+like to instead use the decimal.Decimal() type for more precision, you can override
+this built-in format.
+
+ `Floating Point Precision <https://docs.python.org/tutorial/floatingpoint.html>`_.
+
+You'd define the type:
+
+.. code-block:: python
+    from decimal import Decimal
+    import re
+
+    is_decimal = re.compile(r'^\d+(?:\.\d+)?$')
+    def validate_decimaltype(x):
+      """Validate input is a str in valid decimal format"""
+      if not (isinstance(x, str) and is_decimal.match(x)):
+          raise bravado_core.exception.SwaggerValidationError()
+
+    mydouble = SwaggerFormat(
+      format='double',
+      to_wire=lambda x: str(x) if isinstance(x, Decimal) else str(Decimal(x)),
+      to_python=lambda x: x if isinstance(x, Decimal) else Decimal(x),
+      validate=validate_decimaltype,
+      description="model format double internally as Decimal()"
+    )
+
+Then in your config block you include this format:
+
+.. code-block:: python
+    config = {
+        'formats': [mydouble],
+	...
+    }
+
+    # Create a bravado_core.spec.Spec
+    swagger_spec = Spec.from_dict(spec_dict, config=config)
+
+.. topic::
+     Important Note: The above works when the openapi schema is written as
+    ``string(double)`` e.g. the spec passes the value as string on the wire and
+    format is double.  If the spec said it was a number(double), it is likely that
+    json will first convert the number from the wire to a float and then pass that
+    into Decimal() with unguaranteed precision.  The calls to json would need
+    ``use_decimals=True`` for that to work.

--- a/docs/source/formats.rst
+++ b/docs/source/formats.rst
@@ -174,13 +174,12 @@ Overriding built-in formats is also possible with a user-defined format
 By default format 'double' is internally converted to a float in python.  This runs
 the risk of being imprecise due to the way floats are handled.  If you would
 like to instead use the decimal.Decimal() type for more precision, you can override
-this built-in format.
-
- `Floating Point Precision <https://docs.python.org/tutorial/floatingpoint.html>`_.
+this built-in format.  See Also: `Floating Point Precision <https://docs.python.org/tutorial/floatingpoint.html>`_.
 
 You'd define the type:
 
 .. code-block:: python
+
     from decimal import Decimal
     import re
 
@@ -201,6 +200,7 @@ You'd define the type:
 Then in your config block you include this format:
 
 .. code-block:: python
+
     config = {
         'formats': [mydouble],
 	...
@@ -209,10 +209,12 @@ Then in your config block you include this format:
     # Create a bravado_core.spec.Spec
     swagger_spec = Spec.from_dict(spec_dict, config=config)
 
-.. topic::
-     Important Note: The above works when the openapi schema is written as
-    ``string(double)`` e.g. the spec passes the value as string on the wire and
-    format is double.  If the spec said it was a number(double), it is likely that
-    json will first convert the number from the wire to a float and then pass that
-    into Decimal() with unguaranteed precision.  The calls to json would need
-    ``use_decimals=True`` for that to work.
+Note about using precise Decimal format in Spec
+-----------------------------------------------
+
+The above works when the openapi schema is written as ``string(double)``
+e.g. the spec passes the value as string on the wire and format is double.  If
+the spec said it was a number(double), it is likely that json will first
+convert the number from the wire to a float and then pass that into Decimal()
+with unguaranteed precision.  The calls to json would need
+``use_decimals=True`` for that to work.

--- a/tests/formatter/to_python_test.py
+++ b/tests/formatter/to_python_test.py
@@ -117,15 +117,13 @@ def test_override(minimal_swagger_dict):
 
     byteformat = SwaggerFormat(
         format='byte',
-        to_wire=lambda x: x if isinstance(x, str) else str(x),
-        to_python=lambda x: x if type(x) is Byte else Byte(x),
-        validate=lambda x: True if isinstance(x, str) else False,
+        to_wire=lambda x: str(x),
+        to_python=lambda x: Byte(x),
+        validate=lambda x: isinstance(x, str),
         description=None
     )
 
-    number_spec = {
-        'type': 'string', 'format': 'byte'
-    }
+    number_spec = {'type': 'string', 'format': 'byte'}
 
     swagger_spec = Spec.from_dict(minimal_swagger_dict, config={'formats': [byteformat]})
     result = to_python(swagger_spec, number_spec, '8bits')

--- a/tests/formatter/to_python_test.py
+++ b/tests/formatter/to_python_test.py
@@ -5,6 +5,7 @@ from datetime import datetime
 import six
 from mock import patch
 
+from bravado_core.formatter import SwaggerFormat
 from bravado_core.formatter import to_python
 from bravado_core.spec import Spec
 
@@ -101,3 +102,34 @@ def test_ref(minimal_swagger_dict):
     result = to_python(swagger_spec, int_ref_spec, 999)
     assert 999 == result
     assert isinstance(result, int)
+
+
+def test_override(minimal_swagger_dict):
+    class Byte(object):
+        def __init__(self, x):
+            self.x = x
+
+        def __str__(self):
+            return str(self.x)
+
+        def __repr__(self):
+            return '%s(%r)' % (self.__class__, self.x)
+
+    byteformat = SwaggerFormat(
+        format='byte',
+        to_wire=lambda x: x if isinstance(x, str) else str(x),
+        to_python=lambda x: x if type(x) is Byte else Byte(x),
+        validate=lambda x: True if isinstance(x, str) else False,
+        description=None
+    )
+
+    number_spec = {
+        'type': 'string', 'format': 'byte'
+    }
+
+    swagger_spec = Spec.from_dict(minimal_swagger_dict, config={'formats': [byteformat]})
+    result = to_python(swagger_spec, number_spec, '8bits')
+
+    assert '8bits' == str(result)
+    assert repr(Byte('8bits')) == repr(result)
+    assert type(result) is Byte

--- a/tests/formatter/to_wire_test.py
+++ b/tests/formatter/to_wire_test.py
@@ -6,12 +6,16 @@ import six
 from mock import patch
 from pytz import timezone
 
+from bravado_core.formatter import SwaggerFormat
 from bravado_core.formatter import to_wire
 from bravado_core.spec import Spec
 
 
 if not six.PY2:
     long = int
+    StringType = str
+else:
+    from types import StringType
 
 
 def test_none(minimal_swagger_spec):
@@ -118,3 +122,34 @@ def test_ref(minimal_swagger_dict):
     result = to_wire(swagger_spec, int_ref_spec, 999)
     assert 999 == result
     assert isinstance(result, int)
+
+
+def test_override(minimal_swagger_dict):
+    class Byte(object):
+        def __init__(self, x):
+            self.x = x
+
+        def __str__(self):
+            return str(self.x)
+
+        def __repr__(self):
+            return '%s(%r)' % (self.__class__, self.x)
+
+    byteformat = SwaggerFormat(
+        format='byte',
+        to_wire=lambda x: x if isinstance(x, str) else str(x),
+        to_python=lambda x: x if type(x) is Byte else Byte(x),
+        validate=lambda x: True if isinstance(x, str) else False,
+        description=None
+    )
+
+    number_spec = {
+        'type': 'string', 'format': 'byte'
+    }
+
+    swagger_spec = Spec.from_dict(minimal_swagger_dict, config={'formats': [byteformat]})
+    result = to_wire(swagger_spec, number_spec, '8bits')
+
+    assert '8bits' == result
+    assert isinstance(result, str)
+    assert type(result) is StringType

--- a/tests/formatter/to_wire_test.py
+++ b/tests/formatter/to_wire_test.py
@@ -137,15 +137,13 @@ def test_override(minimal_swagger_dict):
 
     byteformat = SwaggerFormat(
         format='byte',
-        to_wire=lambda x: x if isinstance(x, str) else str(x),
-        to_python=lambda x: x if type(x) is Byte else Byte(x),
-        validate=lambda x: True if isinstance(x, str) else False,
+        to_wire=lambda x: str(x),
+        to_python=lambda x: Byte(x),
+        validate=lambda x: isinstance(x, str),
         description=None
     )
 
-    number_spec = {
-        'type': 'string', 'format': 'byte'
-    }
+    number_spec = {'type': 'string', 'format': 'byte'}
 
     swagger_spec = Spec.from_dict(minimal_swagger_dict, config={'formats': [byteformat]})
     result = to_wire(swagger_spec, number_spec, '8bits')


### PR DESCRIPTION
This PR is to fix the need for overriding DEFAULT_FORMATS

I welcome feedback, particularly on the example provided in docs as I am not 100% clear on the validate function in particular, I haven't quite figured out when this is called.

Closes #235 