### PR TITLE
Use yaml.safe_load, remove Python 3 specific test code

### DIFF
--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -423,14 +423,14 @@ def build_http_handlers(http_client):
         response = http_client.request(request_params).result()
         content_type = response.headers.get('content-type', '').lower()
         if is_yaml(uri, content_type):
-            return yaml.load(response.content)
+            return yaml.safe_load(response.content)
         else:
             return response.json()
 
     def read_file(uri):
         with closing(urlopen(uri)) as fp:
             if is_yaml(uri):
-                return yaml.load(fp)
+                return yaml.safe_load(fp)
             else:
                 return json.loads(fp.read().decode("utf-8"))
 

--- a/tests/formatter/to_python_test.py
+++ b/tests/formatter/to_python_test.py
@@ -9,6 +9,10 @@ from bravado_core.formatter import to_python
 from bravado_core.spec import Spec
 
 
+if not six.PY2:
+    long = int
+
+
 def test_none(minimal_swagger_spec):
     string_spec = {'type': 'string', 'format': 'date'}
     assert to_python(minimal_swagger_spec, string_spec, None) is None
@@ -42,28 +46,18 @@ def test_no_registered_format_returns_value_as_is_and_issues_warning(
 
 def test_int64_long(minimal_swagger_spec):
     integer_spec = {'type': 'integer', 'format': 'int64'}
-    if six.PY3:
-        result = to_python(minimal_swagger_spec, integer_spec, 999)
-        assert 999 == result
-    else:
-        result = to_python(minimal_swagger_spec, integer_spec, long(999))
-        assert long(999) == result
+    result = to_python(minimal_swagger_spec, integer_spec, long(999))
+    assert long(999) == result
 
 
 def test_int64_int(minimal_swagger_spec):
     integer_spec = {'type': 'integer', 'format': 'int64'}
     result = to_python(minimal_swagger_spec, integer_spec, 999)
-    if six.PY3:
-        assert 999 == result
-        assert isinstance(result, int)
-    else:
-        assert long(999) == result
-        assert isinstance(result, long)
+    assert long(999) == result
+    assert isinstance(result, long)
 
 
 def test_int32_long(minimal_swagger_spec):
-    if six.PY3:  # test irrelevant in py3
-        return
     integer_spec = {'type': 'integer', 'format': 'int32'}
     result = to_python(minimal_swagger_spec, integer_spec, long(999))
     assert 999 == result

--- a/tests/formatter/to_wire_test.py
+++ b/tests/formatter/to_wire_test.py
@@ -10,6 +10,10 @@ from bravado_core.formatter import to_wire
 from bravado_core.spec import Spec
 
 
+if not six.PY2:
+    long = int
+
+
 def test_none(minimal_swagger_spec):
     string_spec = {'type': 'string', 'format': 'date'}
     assert to_wire(minimal_swagger_spec, string_spec, None) is None
@@ -51,30 +55,19 @@ def test_no_registered_format_returns_value_as_is(
 
 def test_int64_long(minimal_swagger_spec):
     integer_spec = {'type': 'integer', 'format': 'int64'}
-    if six.PY3:
-        result = to_wire(minimal_swagger_spec, integer_spec, 999)
-        assert 999 == result
-        assert isinstance(result, int)
-    else:
-        result = to_wire(minimal_swagger_spec, integer_spec, long(999))
-        assert long(999) == result
-        assert isinstance(result, long)
+    result = to_wire(minimal_swagger_spec, integer_spec, long(999))
+    assert long(999) == result
+    assert isinstance(result, long)
 
 
 def test_int64_int(minimal_swagger_spec):
     integer_spec = {'type': 'integer', 'format': 'int64'}
     result = to_wire(minimal_swagger_spec, integer_spec, 999)
-    if six.PY3:
-        assert 999 == result
-        assert isinstance(result, int)
-    else:
-        assert long(999) == result
-        assert isinstance(result, long)
+    assert long(999) == result
+    assert isinstance(result, long)
 
 
 def test_int32_long(minimal_swagger_spec):
-    if six.PY3:  # test irrelevant in py3
-        return
     integer_spec = {'type': 'integer', 'format': 'int32'}
     result = to_wire(minimal_swagger_spec, integer_spec, long(999))
     assert 999 == result

--- a/tox.ini
+++ b/tox.ini
@@ -40,6 +40,7 @@ exclude = .svn,CVS,.bzr,.hg,.git,__pycache__,.tox,docs,virtualenv_run
 max_line_length = 120
 
 [testenv:pre-commit]
+basepython = /usr/bin/python2.7
 deps =
     pre-commit>0.12.0
 setenv =


### PR DESCRIPTION
Also, let's make sure pre-commit uses Python 2.7.