### PR TITLE
Change model repr() to return additionalProperties

### DIFF
--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -268,9 +268,10 @@ class Model(object):
         return sorted(self.__dict.keys())
 
     def __repr__(self):
+        """Return properties (including additional)."""
         s = [
             "{0}={1!r}".format(attr_name, self[attr_name])
-            for attr_name in sorted(self._properties.keys())
+            for attr_name in sorted(self.__dict.keys())
             if attr_name in self
         ]
         return "{0}({1})".format(self.__class__.__name__, ', '.join(s))


### PR DESCRIPTION
I had a case where I was using `additionalProperties: true` (actually that's the default I think) and I noticed that the repr() on the response did not include them in the object.  It includes them in the dict when `use_models: false` or _as_dict() is called.

Should it include them in the repr(Model) ?

