### PR TITLE
Sanitize param and resource names

### DIFF
--- a/bravado_core/operation.py
+++ b/bravado_core/operation.py
@@ -1,31 +1,26 @@
 # -*- coding: utf-8 -*-
 import logging
-import re
+
+from six import iteritems
 
 from bravado_core.exception import SwaggerSchemaError
 from bravado_core.param import Param
 from bravado_core.security_requirement import SecurityRequirement
+from bravado_core.util import AliasKeyDict
 from bravado_core.util import cached_property
+from bravado_core.util import sanitize_name
 
 log = logging.getLogger(__name__)
 
 
 def _sanitize_operation_id(operation_id, http_method, path_name):
-    def _replace_patterns(op_id):
-        for regex, replacement in (
-                ('[^A-Za-z0-9_]', '_'),  # valid chars for method names
-                ('_+', '_'),  # collapse consecutive _'s
-                ('^_|_$', '')):  # trim leading/trailing _'s
-            op_id = re.compile(regex).sub(replacement, op_id)
-        return op_id
-
-    sanitized_operation_id = _replace_patterns(operation_id or '')
+    sanitized_operation_id = sanitize_name(operation_id or '')
 
     # Handle crazy corner cases where someone explictily sets operation
     # id a value that gets sanitized down to an empty string
     if len(sanitized_operation_id) == 0:
         # build based on the http method and request path
-        sanitized_operation_id = _replace_patterns(http_method + '_' + path_name)
+        sanitized_operation_id = sanitize_name(http_method + '_' + path_name)
 
     # Handle super crazy corner case where even ``http_method + '_' + path_name``
     # gets sanitized down to an empty string
@@ -177,15 +172,19 @@ def build_params(op):
     # same name when the final params dict is constructed in the loop below.
     params_spec = path_params_spec + op_params_spec
 
-    params = {}
+    params = AliasKeyDict()
     for param_spec in params_spec:
         param = Param(swagger_spec, op, deref(param_spec))
-        params[param.name] = param
+        sanitized_name = sanitize_name(param.name)
+        params[sanitized_name] = param
+        params.add_alias(param.name, sanitized_name)
 
     # Security parameters cannot override and been overridden by operation or path objects
     new_params = {}
+    new_param_aliases = {}
     for parameter in op.security_parameters:
-        if parameter.name in params:
+        param_name = sanitize_name(parameter.name)
+        if param_name in params:
             raise SwaggerSchemaError(
                 "'{0}' security parameter is overriding a parameter defined in operation or path object".format(
                     parameter.name,
@@ -193,7 +192,10 @@ def build_params(op):
             )
         else:
             # not directly in params because different security requirements could share parameters
-            new_params[parameter.name] = parameter
+            new_params[param_name] = parameter
+            new_param_aliases[parameter.name] = param_name
 
     params.update(new_params)
+    for alias, name in iteritems(new_param_aliases):
+        params.add_alias(alias, name)
     return params

--- a/bravado_core/resource.py
+++ b/bravado_core/resource.py
@@ -6,6 +6,8 @@ from six import iteritems
 
 from bravado_core.exception import SwaggerMappingError
 from bravado_core.operation import Operation
+from bravado_core.util import AliasKeyDict
+from bravado_core.util import sanitize_name
 
 log = logging.getLogger(__name__)
 
@@ -70,9 +72,11 @@ def build_resources(swagger_spec):
             for tag in tags:
                 tag_to_ops[deref(tag)][op.operation_id] = op
 
-    resources = {}
+    resources = AliasKeyDict()
     for tag, ops in iteritems(tag_to_ops):
-        resources[tag] = Resource(tag, ops)
+        sanitized_tag = sanitize_name(tag)
+        resources[sanitized_tag] = Resource(sanitized_tag, ops)
+        resources.add_alias(tag, sanitized_tag)
     return resources
 
 

--- a/bravado_core/util.py
+++ b/bravado_core/util.py
@@ -1,8 +1,19 @@
 # -*- coding: utf-8 -*-
 import inspect
+import re
 from functools import wraps
 
 from six import iteritems
+
+
+SANITIZE_RULES = [
+    (re.compile(regex), replacement)
+    for regex, replacement in [
+        ('[^A-Za-z0-9_]', '_'),  # valid chars for method names
+        ('__+', '_'),  # collapse consecutive _
+        ('^[0-9_]|_$', ''),  # trim leading/trailing _ and leading digits
+    ]
+]
 
 
 class cached_property(object):
@@ -41,3 +52,53 @@ def memoize_by_id(func):
             cache[cache_key] = cached_value
         return cached_value
     return wrapper
+
+
+def sanitize_name(name):
+    """Convert a given name so that it is a valid python identifier."""
+    for regex, replacement in SANITIZE_RULES:
+        name = regex.sub(replacement, name)
+
+    return name
+
+
+class AliasKeyDict(dict):
+    """Dictionary class that allows you to set additional key names for existing keys. Retrieving
+    values using these aliased keys works, but when iterating over the dictionary, only the main
+    keys are returned."""
+
+    def __init__(self, *args, **kwargs):
+        super(AliasKeyDict, self).__init__(*args, **kwargs)
+        self.alias_to_key = {}
+
+    def add_alias(self, alias, key):
+        if alias != key:
+            self.alias_to_key[alias] = key
+
+    def determine_key(self, key):
+        if key in self.alias_to_key:  # this will normally be False, optimize for it
+            key = self.alias_to_key[key]
+        return key
+
+    def get(self, key, *args, **kwargs):
+        return super(AliasKeyDict, self).get(self.determine_key(key), *args, **kwargs)
+
+    def pop(self, key, *args, **kwargs):
+        return super(AliasKeyDict, self).pop(self.determine_key(key), *args, **kwargs)
+
+    def __getitem__(self, key):
+        return super(AliasKeyDict, self).__getitem__(self.determine_key(key))
+
+    def __delitem__(self, key):
+        final_key = self.alias_to_key.get(key, key)
+        if final_key != key:
+            del self.alias_to_key[key]
+        return super(AliasKeyDict, self).__delitem__(final_key)
+
+    def __contains__(self, key):
+        return super(AliasKeyDict, self).__contains__(self.determine_key(key))
+
+    def copy(self):
+        copied_dict = type(self)(self)
+        copied_dict.alias_to_key = self.alias_to_key.copy()
+        return copied_dict

--- a/tests/operation/build_params_test.py
+++ b/tests/operation/build_params_test.py
@@ -194,3 +194,33 @@ def test_path_param_and_op_param_refs(minimal_swagger_dict):
     assert len(params) == 2
     assert 'pet_id' in params
     assert 'sort_key' in params
+
+
+def test_sanitized_param(minimal_swagger_dict):
+    op_spec = {
+        'operationId': 'get_pet_by_id',
+        # op params would go here
+        'responses': {
+            '200': {
+            }
+        }
+    }
+    path_spec = {
+        'get': op_spec,
+        'parameters': [
+            {
+                'name': 'pet-id',
+                'in': 'headers',
+                'required': 'true',
+                'type': 'integer',
+            }
+        ],
+    }
+    minimal_swagger_dict['paths']['/pets'] = path_spec
+    swagger_spec = Spec(minimal_swagger_dict)
+    op = Operation(swagger_spec, '/pets', 'get', op_spec)
+    params = build_params(op)
+    assert len(params) == 1
+    assert [p for p in params] == ['pet_id']
+    assert 'pet-id' in params
+    assert params['pet_id'] is params['pet-id']

--- a/tests/resource/build_resources_test.py
+++ b/tests/resource/build_resources_test.py
@@ -19,6 +19,16 @@ def test_resource_with_a_single_operation_associated_by_tag(paths_spec):
     assert resources['pet'].findPetsByStatus
 
 
+def test_resource_with_sanitized_tag(paths_spec):
+    paths_spec['/pet/findByStatus']['get']['tags'][0] = 'Pets & Animals'
+    spec_dict = {'paths': paths_spec}
+    resources = build_resources(Spec(spec_dict))
+    assert 1 == len(resources)
+    assert 'Pets & Animals' in resources
+    assert 'Pets_Animals' in resources
+    assert resources['Pets_Animals'] is resources['Pets & Animals']
+
+
 def test_resource_with_a_single_operation_associated_by_path_name(paths_spec):
     # rename path so we know resource name will not be 'pet'
     paths_spec['/foo/findByStatus'] = paths_spec['/pet/findByStatus']
@@ -31,6 +41,22 @@ def test_resource_with_a_single_operation_associated_by_path_name(paths_spec):
     resources = build_resources(Spec(spec_dict))
     assert 1 == len(resources)
     assert resources['foo'].findPetsByStatus
+
+
+def test_resource__associated_by_sanitized_path_name(paths_spec):
+    # rename path so we know resource name will not be 'pet'
+    paths_spec['/foo-bar/findByStatus'] = paths_spec['/pet/findByStatus']
+    del paths_spec['/pet/findByStatus']
+
+    # remove tags on operation so path name is used to assoc with a resource
+    del paths_spec['/foo/findByStatus']['get']['tags']
+
+    spec_dict = {'paths': paths_spec}
+    resources = build_resources(Spec(spec_dict))
+    assert 1 == len(resources)
+    assert 'foo-bar' in resources
+    assert 'foo_bar' in resources
+    assert resources['foo_bar'] is resources['foo-bar']
 
 
 def test_many_resources_with_the_same_operation_cuz_multiple_tags(paths_spec):

--- a/tests/resource/build_resources_test.py
+++ b/tests/resource/build_resources_test.py
@@ -49,7 +49,7 @@ def test_resource__associated_by_sanitized_path_name(paths_spec):
     del paths_spec['/pet/findByStatus']
 
     # remove tags on operation so path name is used to assoc with a resource
-    del paths_spec['/foo/findByStatus']['get']['tags']
+    del paths_spec['/foo-bar/findByStatus']['get']['tags']
 
     spec_dict = {'paths': paths_spec}
     resources = build_resources(Spec(spec_dict))

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -85,7 +85,7 @@ def test_AliasKeyDict():
     alias_dict = AliasKeyDict({'a': 'b', 'c': 'd'})
     alias_dict.add_alias('alias_a', 'a')
     assert len(alias_dict) == 2
-    assert set(alias_dict.items()) == set(('a', 'b'), ('c', 'd'))
+    assert set(alias_dict.items()) == set([('a', 'b'), ('c', 'd')])
     assert 'alias_a' in alias_dict
     assert alias_dict['alias_a'] is alias_dict['a']
     assert alias_dict.get('alias_a') is alias_dict.get('a')
@@ -98,7 +98,7 @@ def test_AliasKeyDict():
 
 
 def test_AliasKeyDict_copy():
-    alias_dict = AliasKeyDict(('foo', 'bar'))
+    alias_dict = AliasKeyDict([('foo', 'bar')])
     alias_dict.add_alias('baz', 'bar')
     dict_copy = alias_dict.copy()
     assert set(dict_copy.items()) == set(alias_dict.items())

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -99,7 +99,16 @@ def test_AliasKeyDict():
 
 def test_AliasKeyDict_copy():
     alias_dict = AliasKeyDict([('foo', 'bar')])
-    alias_dict.add_alias('baz', 'bar')
+    alias_dict.add_alias('baz', 'foo')
     dict_copy = alias_dict.copy()
     assert set(dict_copy.items()) == set(alias_dict.items())
     assert dict_copy.alias_to_key == alias_dict.alias_to_key
+
+
+def test_AliasKeyDict_del():
+    alias_dict = AliasKeyDict([('foo', 'bar')])
+    alias_dict.add_alias('baz', 'foo')
+    del alias_dict['baz']
+    assert len(alias_dict) == 0
+    assert 'baz' not in alias_dict
+    assert 'foo' not in alias_dict

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
+import pytest
+
+from bravado_core.util import AliasKeyDict
 from bravado_core.util import cached_property
 from bravado_core.util import memoize_by_id
+from bravado_core.util import sanitize_name
 
 
 def test_cached_property():
@@ -65,3 +69,37 @@ def test_memoize_by_id_decorator():
         (('a', id(1)), ('b', id(None))): id(1) + id(None)
     }
     assert calls == [[1, None], [2, 3], [1, None]]
+
+
+@pytest.mark.parametrize(('input', 'expected'), [
+    ('pet.getBy Id', 'pet_getBy_Id'),      # simple case
+    ('_getPetById_', 'getPetById'),        # leading/trailing underscore
+    ('get__Pet_By__Id', 'get_Pet_By_Id'),  # double underscores
+    ('^&#@!$foo%+++:;"<>?/', 'foo'),       # bunch of illegal chars
+])
+def test_sanitize_name(input, expected):
+    assert sanitize_name(input) == expected
+
+
+def test_AliasKeyDict():
+    alias_dict = AliasKeyDict({'a': 'b', 'c': 'd'})
+    alias_dict.add_alias('alias_a', 'a')
+    assert len(alias_dict) == 2
+    assert set(alias_dict.items()) == set(('a', 'b'), ('c', 'd'))
+    assert 'alias_a' in alias_dict
+    assert alias_dict['alias_a'] is alias_dict['a']
+    assert alias_dict.get('alias_a') is alias_dict.get('a')
+    assert alias_dict.get('f', 'not there') == 'not there'
+
+    assert alias_dict.pop('alias_a') == 'b'
+    assert len(alias_dict) == 1
+    assert 'a' not in alias_dict
+    assert 'alias_a' not in alias_dict
+
+
+def test_AliasKeyDict_copy():
+    alias_dict = AliasKeyDict(('foo', 'bar'))
+    alias_dict.add_alias('baz', 'bar')
+    dict_copy = alias_dict.copy()
+    assert set(dict_copy.items()) == set(alias_dict.items())
+    assert dict_copy.alias_to_key == alias_dict.alias_to_key

--- a/tox.ini
+++ b/tox.ini
@@ -46,4 +46,4 @@ deps =
 setenv =
     LC_CTYPE=en_US.UTF-8
 commands =
-    pre-commit run --all-files
+    pre-commit {posargs:run --all-files}


### PR DESCRIPTION
Currently, bravado-core only makes sure the operationId is a valid Python identifier. Let's do the same for resources and params. My primary concern was backwards compatibility; I've ran bravado tests with this bravado-core branch and they all passed, including a few new integration tests that test the new behavior. I've used this branch with the bravado-asyncio test suite as well, all tests pass.

The second concern was discoverability. The names shown when using dir(client) or dir(resource) in bravado need to be the sanitized names. That's why the real name is only added as an alias.

Closes #200, #215.