### PR TITLE
Make sure we use the real param name when unmarshalling

### DIFF
--- a/bravado_core/request.py
+++ b/bravado_core/request.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from six import iteritems
+from six import itervalues
 
 from bravado_core.operation import log
 from bravado_core.param import unmarshal_param
@@ -62,9 +62,9 @@ def unmarshal_request(request, op):
     :returns: dict where (key, value) = (param_name, param_value)
     """
     request_data = {}
-    for param_name, param in iteritems(op.params):
+    for param in itervalues(op.params):
         param_value = unmarshal_param(param, request)
-        request_data[param_name] = param_value
+        request_data[param.name] = param_value
 
     if op.swagger_spec.config['validate_requests']:
         validate_security_object(op, request_data)

--- a/test-data/2.0/petstore/swagger.json
+++ b/test-data/2.0/petstore/swagger.json
@@ -271,7 +271,7 @@
         },
         "security": [
           {
-            "api_key": []
+            "api-key": []
           }
         ]
       },
@@ -340,7 +340,7 @@
         ],
         "parameters": [
           {
-            "name": "api_key",
+            "name": "api-key",
             "in": "header",
             "required": false,
             "type": "string"
@@ -451,7 +451,7 @@
         },
         "security": [
           {
-            "api_key": []
+            "api-key": []
           }
         ]
       }
@@ -846,9 +846,9 @@
         "read:pets": "read your pets"
       }
     },
-    "api_key": {
+    "api-key": {
       "type": "apiKey",
-      "name": "api_key",
+      "name": "api-key",
       "in": "header"
     }
   },

--- a/tests/operation/security_object_test.py
+++ b/tests/operation/security_object_test.py
@@ -91,7 +91,7 @@ def test_correct_request_with_apiKey_security(petstore_spec):
     request = Mock(
         spec=IncomingRequest,
         path={'petId': '1234'},
-        headers={'api_key': 'key1'},
+        headers={'api-key': 'key1'},
     )
     op = petstore_spec.resources['pet'].operations['getPetById']
     unmarshal_request(request, op)

--- a/tests/request/unmarshal_request_test.py
+++ b/tests/request/unmarshal_request_test.py
@@ -11,13 +11,13 @@ def test_request_with_path_parameter(petstore_spec):
     request = Mock(
         spec=IncomingRequest,
         path={'petId': '1234'},
-        headers={'api_key': 'key1'},
+        headers={'api-key': 'key1'},
     )
     # /pet/{pet_id} fits the bill
     op = petstore_spec.resources['pet'].operations['getPetById']
     request_data = unmarshal_request(request, op)
     assert request_data['petId'] == 1234
-    assert request_data['api_key'] == 'key1'
+    assert request_data['api-key'] == 'key1'
 
 
 def test_request_with_no_parameters(petstore_spec):


### PR DESCRIPTION
Unfortunately, unmarshal_request uses the dict key of op.params as key in the request_data. This is incorrect with the changes made to sanitize param names. It should always use the real param name.