### PR TITLE
Collect models will not create models for not models objects

### DIFF
--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -64,7 +64,7 @@ def collect_models(container, key, path, models, swagger_spec):
     :type swagger_spec: :class:`bravado_core.spec.Spec`
     """
     deref = swagger_spec.deref
-    if key == MODEL_MARKER:
+    if key == MODEL_MARKER and is_object(swagger_spec, container):
         model_spec = container
         model_name = deref(model_spec.get(MODEL_MARKER))
         models[model_name] = create_model_type(

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -131,7 +131,7 @@ Model Discovery
 Keep in mind that bravado-core has to do some extra legwork to figure out which
 parts of your spec represent Swagger models and which parts don't to make this
 feature work automagically. With a single-file Swagger spec, this is pretty
-straight forward - everything under ``#/definitions`` is a model. However, with
+straight forward - almost everything under ``#/definitions`` is a model. However, with
 more complicated specs that span multiple files and use external refs, it
 becomes a bit more involved. For this reason, the discovery process for
 models is best effort with a fallback to explicit annotations as follows:
@@ -202,9 +202,12 @@ models is best effort with a fallback to explicit annotations as follows:
        {
            "models": {
                "Pet": {
-                    "x-model": "Pet"
+                   "x-model": "Pet"
                    ...
                }
            }
        }
 
+.. note::
+
+    Models will be generated only for object types (``"type": "object"``).

--- a/tests/model/collect_models_test.py
+++ b/tests/model/collect_models_test.py
@@ -30,3 +30,23 @@ def test_simple(minimal_swagger_dict, pet_model_spec):
         models=models,
         swagger_spec=swagger_spec)
     assert 'Pet' in models
+
+
+def test_not_model(minimal_swagger_dict, pet_model_spec):
+    minimal_swagger_dict['definitions']['Pet'] = pet_model_spec
+    minimal_swagger_dict['definitions']['Pets'] = {
+        'type': 'array',
+        'items': {
+            '$ref': '#/definitions/Pet'
+        },
+        'x-model': 'Pets'
+    }
+    swagger_spec = Spec(minimal_swagger_dict)
+    models = {}
+    collect_models(
+        minimal_swagger_dict['definitions']['Pet'],
+        MODEL_MARKER,
+        ['definitions', 'Pet', 'x-model'],
+        models=models,
+        swagger_spec=swagger_spec)
+    assert 'Pets' not in models

--- a/tests/model/collect_models_test.py
+++ b/tests/model/collect_models_test.py
@@ -32,7 +32,18 @@ def test_simple(minimal_swagger_dict, pet_model_spec):
     assert 'Pet' in models
 
 
-def test_not_model(minimal_swagger_dict, pet_model_spec):
+def test_no_model_type_generation_for_not_object_type(minimal_swagger_dict, pet_model_spec):
+    """
+    Ensure that models types are generated only for swagger objects (type: object)
+
+    This is needed because even if "x-model" is present it could be related to a not object type
+    (ie. array or string) and for those cases it does not make sense to generate a python model type.
+    Additionally, even if this type has been generated it won't be used by bravado-core during
+    marshaling/unmarshaling process.
+
+    Ensuring that for those cases a model type is not generated simplifies type checking.
+    """
+
     minimal_swagger_dict['definitions']['Pet'] = pet_model_spec
     minimal_swagger_dict['definitions']['Pets'] = {
         'type': 'array',
@@ -44,9 +55,9 @@ def test_not_model(minimal_swagger_dict, pet_model_spec):
     swagger_spec = Spec(minimal_swagger_dict)
     models = {}
     collect_models(
-        minimal_swagger_dict['definitions']['Pet'],
+        minimal_swagger_dict['definitions']['Pets'],
         MODEL_MARKER,
-        ['definitions', 'Pet', 'x-model'],
+        ['definitions', 'Pets', 'x-model'],
         models=models,
         swagger_spec=swagger_spec)
     assert 'Pets' not in models

--- a/tests/spec/Spec/build_test.py
+++ b/tests/spec/Spec/build_test.py
@@ -60,3 +60,16 @@ def test_build_with_internally_dereference_refs(petstore_dict, internally_derefe
         config={'internally_dereference_refs': internally_dereference_refs}
     )
     assert (spec.deref == spec._force_deref) == (not internally_dereference_refs)
+
+
+def test_not_object_x_models_are_not_generating_models(minimal_swagger_dict):
+    minimal_swagger_dict['definitions']['Pets'] = {
+        'type': 'array',
+        'items': {
+            'type': 'string'
+        },
+        'x-model': 'Pets'
+    }
+    swagger_spec = Spec(minimal_swagger_dict)
+    swagger_spec.build()
+    assert not swagger_spec.definitions


### PR DESCRIPTION
Current model discovery generates models also for _not models_ object specs.
This PR aims to solve this issue.

Assuming that the following is a snippet of the swagger specs
```json
{
    "definitions": {
        "list": {
            "type": "array",
            "items": {"type": "string"},
            "x-model": "list"
        }
    }
    ...
}
```
Before this PR this generates a ``list`` model (``assert Swagger.from_url(...).definitions == {'list': mock.ANY}``)
After this PR ``assert Swagger.from_url(...).definitions == {}``