### PR TITLE
deref is overridden after building Spec

### DIFF
--- a/tests/profiling/unmarshal_response_profiler_test.py
+++ b/tests/profiling/unmarshal_response_profiler_test.py
@@ -23,11 +23,11 @@ class FakeJsonResponse(IncomingResponse):
         return self.text
 
 
-def test_small_objects(petstore_op, benchmark, small_pets):
+def test_small_objects(benchmark, petstore_op, small_pets):
     resp = FakeJsonResponse(small_pets)
     benchmark(unmarshal_response, resp, petstore_op)
 
 
-def test_large_objects(petstore_op, benchmark, large_pets):
+def test_large_objects(benchmark, petstore_op, large_pets):
     resp = FakeJsonResponse(large_pets)
     benchmark(unmarshal_response, resp, petstore_op)

--- a/tests/spec/Spec/build_test.py
+++ b/tests/spec/Spec/build_test.py
@@ -59,6 +59,8 @@ def test_build_with_internally_dereference_refs(petstore_dict, internally_derefe
         petstore_dict,
         config={'internally_dereference_refs': internally_dereference_refs}
     )
+    assert spec.deref == spec._force_deref
+    spec.build()
     assert (spec.deref == spec._force_deref) == (not internally_dereference_refs)
 
 


### PR DESCRIPTION
In order to optimize dereferencing process, we're dynamically defining ``deref`` method according to ``internally_dereference_refs`` value.
This implies that during spec post-processing the no-op deref will be used if ``internally_dereference_refs`` is enabled.

This CR fixes this issue by:
 * forcing ``deref`` to be an alias of ``_force_deref``
 * overriding ``deref`` (to be a _no-op_) only after spec post-processing (model discovery) runs over the specs

An additional change provided by this CR is related to how models are saved in case of ``internally_dereference_refs``.

Before this change, we were running ``descend`` (on ``post_process_spec``) twice to guarantee that the models get's overridden; but I noticed that this was not happening for models that are not directly referenced (ie. models defined for polymorphism)

After this change, we build a new temporary ``Spec`` object which guarantees that model discovery is performed on fully dereferenced objects.

I don't expect this change to be a breaking change and to add additional time penalties in building ``Spec`` objects.

NOTE: I've also updated ``tests/profiling/unmarshal_response_profiler_test.py`` so that executions gets faster if benchmark tests are disabled.