### PR TITLE
Workaourd to fix internal build

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,8 @@ envlist = py27, py35, py36, pre-commit
 [testenv]
 deps =
     -rrequirements-dev.txt
+    # prevent Yelp internal build failure
+    webcolors!=1.8
 commands =
     python -m pytest --capture=no --benchmark-skip {posargs:tests}
 
@@ -23,6 +25,8 @@ basepython = /usr/bin/python2.7
 deps =
     -rrequirements-dev.txt
     coverage
+    # prevent Yelp internal build failure
+    webcolors!=1.8
 commands =
     coverage run --source=bravado_core/ --omit=bravado_core/__init__.py -m pytest --benchmark-skip --capture=no --strict {posargs:tests/}
     coverage report --omit=.tox/*,tests/*,/usr/share/pyshared/*,/usr/lib/pymodules/* -m


### PR DESCRIPTION
Our internal build is failing on master 😢 

I tried to inspect the error and seems that setuptools is complaining when trying to install ``webcolors==1.8``.
I'm proposing this in order to fix our internal build.

NOTE: ``webcolor`` is not a direct dependency (it is added from ``jsonschema[format]``, so I'm not to concerned in not using the latest version as I assume it is already tested there.