### PR TITLE
Improve model name determination by using title information

### DIFF
--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -125,7 +125,10 @@ def bless_models(container, key, path, visited_models, swagger_spec):
 
     if (
         not is_dict_like(model_spec) or
-        not is_object(swagger_spec, model_spec, ignore_config=True) or
+        not is_object(swagger_spec, model_spec, no_default_type=True) or
+        # NOTE: determine_object_type uses a simple heuristic to determine if a model_spec has a SCHEMA type
+        # for this reason is important that model_spec is recognized as model in the most accurate way
+        # so we should not rely on default typing of a schema
         determine_object_type(model_spec) != ObjectType.SCHEMA or
         deref(model_spec.get(MODEL_MARKER)) is not None
     ):
@@ -547,19 +550,19 @@ def is_model(swagger_spec, schema_object_spec):
     return deref(schema_object_spec.get(MODEL_MARKER)) is not None
 
 
-def is_object(swagger_spec, object_spec, ignore_config=False):
+def is_object(swagger_spec, object_spec, no_default_type=False):
     """
     A schema definition is of type object if its type is object or if it uses
     model composition (i.e. it has an allOf property).
     :param swagger_spec: :class:`bravado_core.spec.Spec`
     :param object_spec: specification for a swagger object
     :type object_spec: dict
-    :param ignore_config: ignore bravado-core 'default_type_to_object' configuration
-    :type ignore_config: bool
+    :param no_default_type: ignore bravado-core 'default_type_to_object' configuration
+    :type no_default_type: bool
     :return: True if the spec describes an object, False otherwise.
     """
     deref = swagger_spec.deref
-    default_type = 'object' if not ignore_config and swagger_spec.config['default_type_to_object'] else None
+    default_type = 'object' if not no_default_type and swagger_spec.config['default_type_to_object'] else None
     return deref(object_spec.get('type', default_type)) == 'object' or 'allOf' in object_spec
 
 

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -7,8 +7,11 @@ import six
 from six import iteritems
 
 from bravado_core.schema import collapsed_properties
+from bravado_core.schema import is_dict_like
 from bravado_core.schema import is_list_like
 from bravado_core.schema import SWAGGER_PRIMITIVES
+from bravado_core.util import determine_object_type
+from bravado_core.util import ObjectType
 
 
 log = logging.getLogger(__name__)
@@ -16,6 +19,42 @@ log = logging.getLogger(__name__)
 # Models in #/definitions are tagged with this key so that they can be
 # differentiated from 'object' types.
 MODEL_MARKER = 'x-model'
+
+
+def _get_model_name(model_dict):
+    """Determine model name from model dictionary representation and Swagger Path"""
+    model_name = model_dict.get(MODEL_MARKER)
+    if not model_name:
+        model_name = model_dict.get('title')
+    return model_name
+
+
+def _register_visited_model(path, model_spec, model_name, visited_models, is_blessed):
+    """
+    Registers a model that has been tagged by a callback method.
+
+    :param path: list of path segments to the key
+    :type path: list
+    :param model_spec: swagger specification of the model
+    :type model_spec: dict
+    :param model_name: name of the model to register
+    :type model_name: str
+    :param visited_models: models that have already been identified
+    :type visited_models: dict (k,v) == (model_name, path)
+    :param is_blessed: flag that determines if the model name has been obtained by blessing
+    :type is_blessed: bool
+    """
+    log.debug('Found model: %s (is_blessed %s)', model_name, is_blessed)
+    if model_name in visited_models:
+        raise ValueError(
+            'Duplicate "{0}" model found at path {1}. '
+            'Original "{0}" model at path {2}'.format(
+                model_name, path, visited_models[model_name],
+            ),
+        )
+
+    model_spec[MODEL_MARKER] = model_name
+    visited_models[model_name] = path
 
 
 def tag_models(container, key, path, visited_models, swagger_spec):
@@ -45,7 +84,6 @@ def tag_models(container, key, path, visited_models, swagger_spec):
     if len(path) < 2 or path[-2] != 'definitions':
         return
     deref = swagger_spec.deref
-    model_name = key
     model_spec = deref(container.get(key))
 
     if not is_object(swagger_spec, model_spec):
@@ -54,12 +92,50 @@ def tag_models(container, key, path, visited_models, swagger_spec):
     if deref(model_spec.get(MODEL_MARKER)) is not None:
         return
 
-    log.debug('Found model: %s', model_name)
-    if model_name in visited_models:
-        raise ValueError(
-            'Duplicate "{0}" model found at path {1}. '
-            'Original "{0}" model at path {2}'
-            .format(model_name, path, visited_models[model_name]))
+    model_name = _get_model_name(model_spec) or key
+    _register_visited_model(path, model_spec, model_name, visited_models, is_blessed=False)
+
+
+def bless_models(container, key, path, visited_models, swagger_spec):
+    """
+    Callback used during the swagger spec ingestion process to add
+    ``x-model`` attribute to models which does not define it.
+
+    The callbacks is in charge of adding MODEL_MARKER in case a model
+    (identifies as an object of type SCHEMA) has enough information for
+    determining a model name (ie. has ``title`` attribute defined)
+
+    INFO: Implementation detail.
+    Respect ``collect_models`` this callback gets executed on the model_spec's parent container.
+    This is needed because this callback could modify (adding MODEL_MARKER) the model_spec;
+    performing this operation when the container represents model_spec will generate errors
+    because we're iterating over an object that gets mutated by the callback.
+
+    :param container: container being visited
+    :param key: attribute in container being visited as a string
+    :param path: list of path segments to the key
+    :type visited_models: dict (k,v) == (model_name, path)
+    :type swagger_spec: :class:`bravado_core.spec.Spec`
+    """
+    if not is_dict_like(container):
+        return
+
+    deref = swagger_spec.deref
+    model_spec = deref(container.get(key))
+
+    if (
+        not is_dict_like(model_spec) or
+        not is_object(swagger_spec, model_spec, ignore_config=True) or
+        determine_object_type(model_spec) != ObjectType.SCHEMA or
+        deref(model_spec.get(MODEL_MARKER)) is not None
+    ):
+        return
+
+    model_name = _get_model_name(model_spec)
+    if not model_name:
+        return
+
+    _register_visited_model(path, model_spec, model_name, visited_models, is_blessed=True)
 
 
 def collect_models(container, key, path, models, swagger_spec):
@@ -78,12 +154,11 @@ def collect_models(container, key, path, models, swagger_spec):
     :param models: created model types are placed here
     :type swagger_spec: :class:`bravado_core.spec.Spec`
     """
-    deref = swagger_spec.deref
     if key == MODEL_MARKER and is_object(swagger_spec, container):
-        model_spec = container
-        model_name = deref(model_spec.get(MODEL_MARKER))
-        models[model_name] = create_model_type(
-            swagger_spec, model_name, model_spec)
+        model_spec = swagger_spec.deref(container)
+        model_name = _get_model_name(container)
+        if model_name not in models:
+            models[model_name] = create_model_type(swagger_spec, model_name, model_spec)
 
 
 class ModelMeta(abc.ABCMeta):
@@ -472,17 +547,19 @@ def is_model(swagger_spec, schema_object_spec):
     return deref(schema_object_spec.get(MODEL_MARKER)) is not None
 
 
-def is_object(swagger_spec, object_spec):
+def is_object(swagger_spec, object_spec, ignore_config=False):
     """
     A schema definition is of type object if its type is object or if it uses
     model composition (i.e. it has an allOf property).
     :param swagger_spec: :class:`bravado_core.spec.Spec`
     :param object_spec: specification for a swagger object
     :type object_spec: dict
+    :param ignore_config: ignore bravado-core 'default_type_to_object' configuration
+    :type ignore_config: bool
     :return: True if the spec describes an object, False otherwise.
     """
     deref = swagger_spec.deref
-    default_type = 'object' if swagger_spec.config['default_type_to_object'] else None
+    default_type = 'object' if not ignore_config and swagger_spec.config['default_type_to_object'] else None
     return deref(object_spec.get('type', default_type)) == 'object' or 'allOf' in object_spec
 
 

--- a/bravado_core/response.py
+++ b/bravado_core/response.py
@@ -116,8 +116,7 @@ def unmarshal_response(response, op):
         if op.swagger_spec.config['validate_responses']:
             validate_schema_object(op.swagger_spec, content_spec, content_value)
 
-        return unmarshal_schema_object(
-            op.swagger_spec, content_spec, content_value)
+        return unmarshal_schema_object(op.swagger_spec, content_spec, content_value)
 
     # TODO: Non-json response contents
     return response.text

--- a/bravado_core/swagger20_validator.py
+++ b/bravado_core/swagger20_validator.py
@@ -8,6 +8,7 @@ from jsonschema.exceptions import ValidationError
 from jsonschema.validators import Draft4Validator
 from swagger_spec_validator.ref_validators import in_scope
 
+from bravado_core.model import MODEL_MARKER
 from bravado_core.schema import is_param_spec
 from bravado_core.schema import is_prop_nullable
 from bravado_core.schema import is_required
@@ -150,14 +151,14 @@ def discriminator_validator(swagger_spec, validator, discriminator_attribute, in
             message='\'{}\' is not a recognized schema'.format(discriminator_value)
         )
 
-    if discriminator_value == schema['x-model']:
+    if discriminator_value == schema[MODEL_MARKER]:
         return
 
     new_schema = deepcopy(swagger_spec.definitions[discriminator_value]._model_spec)
     if 'allOf' not in new_schema:
         raise ValidationError(
             message='discriminated schema \'{}\' must inherit from \'{}\''.format(
-                discriminator_value, schema['x-model']
+                discriminator_value, schema[MODEL_MARKER]
             )
         )
 
@@ -166,7 +167,7 @@ def discriminator_validator(swagger_spec, validator, discriminator_attribute, in
         # Not checking against len(schemas_to_remove) > 1 because it should be prevented by swagger spec validation
         raise ValidationError(
             message='discriminated schema \'{}\' must inherit from \'{}\''.format(
-                discriminator_value, schema['x-model']
+                discriminator_value, schema[MODEL_MARKER]
             )
         )
 

--- a/tests/model/bless_models_test.py
+++ b/tests/model/bless_models_test.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+import mock
+import pytest
+
+from bravado_core.model import bless_models
+from bravado_core.spec import Spec
+
+
+@mock.patch('bravado_core.model.is_dict_like', return_value=False)
+def test_bless_models_short_circuit_if_no_dict_like_container(mock_is_dict_like, minimal_swagger_dict):
+    minimal_swagger_dict['paths'] = {
+        '/endpoint': {
+            'post': {
+                'responses': {
+                    '200': 'not_valid',
+                },
+            },
+        },
+    }
+    swagger_spec = Spec(minimal_swagger_dict)
+    bless_models(
+        minimal_swagger_dict['paths']['/endpoint']['post']['responses']['200'],
+        'schema',
+        ['paths', '/endpoint', 'post', 'responses', '200'],
+        visited_models={},
+        swagger_spec=swagger_spec,
+    )
+    mock_is_dict_like.assert_called_once_with(minimal_swagger_dict['paths']['/endpoint']['post']['responses']['200'])
+
+
+@pytest.mark.parametrize(
+    'response_schema',
+    (
+        [1, 2, 3],  # is_dict_like(model_spec)
+        {'type': 'string'},  # is_object(model_spec)
+        {'in': 'body', 'name': 'body', 'type': 'string'},  # determine_object_type(model_spec)
+        {'x-model': 'string'},  # deref(model_spec.get('x-model'))
+    )
+)
+@mock.patch('bravado_core.model._get_model_name')
+def test_bless_models_gets_out_if_initial_pre_conditions_are_not_met(
+    mock__get_model_name, minimal_swagger_dict, response_schema,
+):
+    minimal_swagger_dict['paths'] = {
+        '/endpoint': {
+            'post': {
+                'responses': {
+                    '200': {
+                        'description': 'HTTP/200',
+                        'schema': response_schema,
+                    },
+                },
+            },
+        },
+    }
+    swagger_spec = Spec(minimal_swagger_dict)
+    bless_models(
+        minimal_swagger_dict['paths']['/endpoint']['post']['responses']['200'],
+        'schema',
+        ['paths', '/endpoint', 'post', 'responses', '200'],
+        visited_models={},
+        swagger_spec=swagger_spec,
+    )
+    assert mock__get_model_name.call_count == 0
+
+
+def test_bless_model_adds_model_marker(minimal_swagger_dict):
+    response_schema = {
+        'type': 'object',
+        'title': 'valid_response',
+    }
+    minimal_swagger_dict['paths'] = {
+        '/endpoint': {
+            'post': {
+                'responses': {
+                    '200': {
+                        'description': 'HTTP/200',
+                        'schema': response_schema,
+                    },
+                },
+            },
+        },
+    }
+    swagger_spec = Spec(minimal_swagger_dict)
+    bless_models(
+        minimal_swagger_dict['paths']['/endpoint']['post']['responses']['200'],
+        'schema',
+        ['paths', '/endpoint', 'post', 'responses', '200'],
+        visited_models={},
+        swagger_spec=swagger_spec,
+    )
+    assert response_schema.get('x-model') == response_schema['title']
+
+
+def test_bless_model_does_not_generate_model_tag_if_no_title_is_set(minimal_swagger_dict):
+    response_schema = {
+        'type': 'object',
+    }
+    minimal_swagger_dict['paths'] = {
+        '/endpoint': {
+            'post': {
+                'responses': {
+                    '200': {
+                        'description': 'HTTP/200',
+                        'schema': response_schema,
+                    },
+                },
+            },
+        },
+    }
+    swagger_spec = Spec(minimal_swagger_dict)
+    bless_models(
+        minimal_swagger_dict['paths']['/endpoint']['post']['responses']['200'],
+        'schema',
+        ['paths', '/endpoint', 'post', 'responses', '200'],
+        visited_models={},
+        swagger_spec=swagger_spec,
+    )
+    assert 'x-model' not in response_schema

--- a/tests/model/collect_models_test.py
+++ b/tests/model/collect_models_test.py
@@ -2,14 +2,13 @@
 import pytest
 
 from bravado_core.model import collect_models
-from bravado_core.model import MODEL_MARKER
 from bravado_core.spec import Spec
 
 
 @pytest.fixture
 def pet_model_spec():
     return {
-        MODEL_MARKER: 'Pet',
+        'x-model': 'Pet',
         'type': 'object',
         'properties': {
             'name': {
@@ -25,7 +24,7 @@ def test_simple(minimal_swagger_dict, pet_model_spec):
     models = {}
     collect_models(
         minimal_swagger_dict['definitions']['Pet'],
-        MODEL_MARKER,
+        'x-model',
         ['definitions', 'Pet', 'x-model'],
         models=models,
         swagger_spec=swagger_spec)
@@ -56,7 +55,7 @@ def test_no_model_type_generation_for_not_object_type(minimal_swagger_dict, pet_
     models = {}
     collect_models(
         minimal_swagger_dict['definitions']['Pets'],
-        MODEL_MARKER,
+        'x-model',
         ['definitions', 'Pets', 'x-model'],
         models=models,
         swagger_spec=swagger_spec)

--- a/tests/model/get_model_name_test.py
+++ b/tests/model/get_model_name_test.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+import mock
+import pytest
+
+from bravado_core.model import _get_model_name
+
+
+@pytest.mark.parametrize(
+    'model_dict, expected_name',
+    (
+        ({}, None),
+        ({'x-model': mock.sentinel.MODEL_MARKER}, mock.sentinel.MODEL_MARKER),
+        ({'title': mock.sentinel.TITLE}, mock.sentinel.TITLE),
+        ({'x-model': mock.sentinel.MODEL_MARKER, 'title': mock.sentinel.TITLE}, mock.sentinel.MODEL_MARKER),
+    )
+)
+def test__get_model_name(model_dict, expected_name):
+    assert _get_model_name(model_dict) == expected_name

--- a/tests/model/tag_models_test.py
+++ b/tests/model/tag_models_test.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import pytest
 
-from bravado_core.model import MODEL_MARKER
 from bravado_core.model import tag_models
 from bravado_core.spec import Spec
 
@@ -27,7 +26,7 @@ def test_tags_model(minimal_swagger_dict, pet_model_spec):
         ['definitions', 'Pet'],
         visited_models={},
         swagger_spec=swagger_spec)
-    assert pet_model_spec[MODEL_MARKER] == 'Pet'
+    assert pet_model_spec['x-model'] == 'Pet'
 
 
 def test_type_missing(minimal_swagger_dict, pet_model_spec):
@@ -40,7 +39,7 @@ def test_type_missing(minimal_swagger_dict, pet_model_spec):
         ['definitions', 'Pet'],
         visited_models={},
         swagger_spec=swagger_spec)
-    assert MODEL_MARKER not in pet_model_spec
+    assert 'x-model' not in pet_model_spec
 
 
 def test_model_not_object(minimal_swagger_dict):
@@ -57,7 +56,7 @@ def test_model_not_object(minimal_swagger_dict):
         ['definitions', 'Pet'],
         visited_models={},
         swagger_spec=swagger_spec)
-    assert MODEL_MARKER not in minimal_swagger_dict['definitions']['Pet']
+    assert 'x-model' not in minimal_swagger_dict['definitions']['Pet']
 
 
 def test_path_too_short(minimal_swagger_dict, pet_model_spec):
@@ -69,7 +68,7 @@ def test_path_too_short(minimal_swagger_dict, pet_model_spec):
         ['definitions'],
         visited_models={},
         swagger_spec=swagger_spec)
-    assert MODEL_MARKER not in pet_model_spec
+    assert 'x-model' not in pet_model_spec
 
 
 def test_duplicate_model(minimal_swagger_dict, pet_model_spec):
@@ -86,7 +85,7 @@ def test_duplicate_model(minimal_swagger_dict, pet_model_spec):
 
 
 def test_skip_already_tagged_models(minimal_swagger_dict, pet_model_spec):
-    pet_model_spec[MODEL_MARKER] = 'SpecialPet'
+    pet_model_spec['x-model'] = 'SpecialPet'
     minimal_swagger_dict['definitions']['Pet'] = pet_model_spec
     swagger_spec = Spec(minimal_swagger_dict)
     tag_models(
@@ -95,4 +94,4 @@ def test_skip_already_tagged_models(minimal_swagger_dict, pet_model_spec):
         ['definitions', 'Pet'],
         visited_models={},
         swagger_spec=swagger_spec)
-    assert pet_model_spec[MODEL_MARKER] == 'SpecialPet'
+    assert pet_model_spec['x-model'] == 'SpecialPet'

--- a/tests/spec/Spec/deref_flattened_spec_test.py
+++ b/tests/spec/Spec/deref_flattened_spec_test.py
@@ -4,7 +4,6 @@ from six import iterkeys
 from six import itervalues
 from six.moves.urllib_parse import urljoin
 
-from bravado_core.model import MODEL_MARKER
 from bravado_core.schema import is_dict_like
 from bravado_core.schema import is_list_like
 from bravado_core.spec import Spec
@@ -12,7 +11,7 @@ from bravado_core.spec import Spec
 
 def _get_model(spec_dict, model_name):
     for model_schema in itervalues(spec_dict['definitions']):
-        if model_schema.get(MODEL_MARKER) == model_name:
+        if model_schema.get('x-model') == model_name:
             return model_schema
 
 

--- a/tests/spec/from_dict_test.py
+++ b/tests/spec/from_dict_test.py
@@ -5,7 +5,6 @@ import simplejson as json
 import yaml
 from six.moves.urllib import parse as urlparse
 
-from bravado_core.model import MODEL_MARKER
 from bravado_core.response import get_response_spec
 from bravado_core.spec import Spec
 
@@ -111,7 +110,7 @@ def test_spec_with_dereffed_and_tagged_models_works(minimal_swagger_dict):
                 '200': {
                     'description': 'Returns a Pet',
                     'schema': {
-                        MODEL_MARKER: 'Pet',
+                        'x-model': 'Pet',
                         'type': 'object',
                         'properties': {
                             'name': {


### PR DESCRIPTION
This CR improves the model name determination strategy used during model discovery.

The original approach was:
 * use ``key`` for models in ``definition``
 * use ``x-model`` for models around the specs

The goal of this PR tries to unify this in a common approach.
The model name is determined as:
 1. use ``x-model``
 2. use ``title``
 3. if the model is in ``#/definitions`` use the ``key``

WARNING: this does CR not try to improve detection of duplicated models, but it should simplify future work on that direction