### PR TITLE
Small tests refactory to ensure high testing coverage

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import base64
 import os
 
 import pytest
@@ -7,7 +6,6 @@ import simplejson as json
 import yaml
 from six.moves.urllib import parse as urlparse
 
-import bravado_core.formatter
 from bravado_core.spec import Spec
 
 
@@ -167,27 +165,6 @@ def flattened_multi_file_with_no_xmodel_abspath(my_dir):
 @pytest.fixture
 def flattened_multi_file_with_no_xmodel_dict(flattened_multi_file_with_no_xmodel_abspath):
     return _read_json(flattened_multi_file_with_no_xmodel_abspath)
-
-
-def del_base64():
-    del bravado_core.formatter.DEFAULT_FORMATS['base64']
-
-
-@pytest.fixture
-def base64_format():
-    return bravado_core.formatter.SwaggerFormat(
-        format='base64',
-        to_wire=base64.b64encode,
-        to_python=base64.b64decode,
-        validate=base64.b64decode,
-        description='Base64',
-    )
-
-
-@pytest.fixture(scope='function')
-def register_base64_format(base64_format, request):
-    request.addfinalizer(del_base64)
-    bravado_core.formatter.register_format(base64_format)
 
 
 @pytest.fixture

--- a/tests/operation/conftest.py
+++ b/tests/operation/conftest.py
@@ -34,10 +34,6 @@ SECURITY_OBJECTS = {
 }
 
 
-def test_security_object_and_definition_constants():
-    assert SECURITY_OBJECTS.keys() == SECURITY_DEFINITIONS.keys()
-
-
 @pytest.fixture
 def definitions_spec():
     return {

--- a/tests/operation/security_object_test.py
+++ b/tests/operation/security_object_test.py
@@ -9,6 +9,13 @@ from bravado_core.request import IncomingRequest
 from bravado_core.request import unmarshal_request
 from bravado_core.resource import build_resources
 from bravado_core.spec import Spec
+from tests.operation.conftest import SECURITY_DEFINITIONS
+from tests.operation.conftest import SECURITY_OBJECTS
+
+
+def test_security_object_and_definition_constants():
+    """Test that ensures that constant in tests/operation/conftest.py are reasonable"""
+    assert SECURITY_OBJECTS.keys() == SECURITY_DEFINITIONS.keys()
 
 
 def test_op_with_security_in_op_without_security_defs(

--- a/tests/param/unmarshal_param_test.py
+++ b/tests/param/unmarshal_param_test.py
@@ -11,13 +11,6 @@ from bravado_core.spec import Spec
 
 
 @pytest.fixture
-def request_dict():
-    return {
-        'params': {}
-    }
-
-
-@pytest.fixture
 def string_param_spec():
     return {
         'name': 'username',

--- a/tests/resource/conftest.py
+++ b/tests/resource/conftest.py
@@ -65,8 +65,3 @@ def paths_spec():
             }
         },
     }
-
-
-@pytest.fixture
-def find_by_status_path_spec(paths_spec):
-    return paths_spec['/pet/findByStatus']


### PR DESCRIPTION
This PR removes not used fixtures and makes sure that all the tests get executed.
I've noticed this while checking coverage of the test related code.

ℹ️ : I've moved ``test_security_object_and_definition_constants`` to ensure its execution (it was in conftest and seemed that pytest was not running the test)