### PR TITLE
Duplicate models should not raise if not use models

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Changelog
 - Models are generated only for objects - PR #246
 - Fix: ensure that models does not have references if ``internally_dereference_refs`` is used - PR # 247
 - Model name detection uses title attribute too - PR #249
+- Duplicated models do not raise exception if ``use_models`` is not used - PR #253
 
 4.12.1 (2018-02-07)
 -------------------

--- a/tests/model/tag_models_test.py
+++ b/tests/model/tag_models_test.py
@@ -81,6 +81,8 @@ def test_duplicate_model(mock_log, minimal_swagger_dict, pet_model_spec, use_mod
 
     duplicate_message = 'Duplicate "Pet" model found at path [\'definitions\', \'Pet\']. ' \
                         'Original "Pet" model at path [\'definitions\', \'Pet\']'
+
+    raised_exception = None
     try:
         tag_models(
             minimal_swagger_dict['definitions'],
@@ -90,9 +92,13 @@ def test_duplicate_model(mock_log, minimal_swagger_dict, pet_model_spec, use_mod
             swagger_spec=swagger_spec,
         )
     except ValueError as e:
-        assert str(e) == duplicate_message
+        raised_exception = e
+
+    if use_models:
+        assert str(raised_exception) == duplicate_message
         assert not mock_log.warning.called
     else:
+        assert raised_exception is None
         mock_log.warning.assert_called_once_with(duplicate_message)
 
 

--- a/tests/model/tag_models_test.py
+++ b/tests/model/tag_models_test.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
+import mock
 import pytest
 
+from bravado_core import model
 from bravado_core.model import tag_models
 from bravado_core.spec import Spec
 
@@ -71,17 +73,27 @@ def test_path_too_short(minimal_swagger_dict, pet_model_spec):
     assert 'x-model' not in pet_model_spec
 
 
-def test_duplicate_model(minimal_swagger_dict, pet_model_spec):
+@pytest.mark.parametrize('use_models', [True, False])
+@mock.patch.object(model, 'log', autospec=True)
+def test_duplicate_model(mock_log, minimal_swagger_dict, pet_model_spec, use_models):
     minimal_swagger_dict['definitions']['Pet'] = pet_model_spec
-    swagger_spec = Spec(minimal_swagger_dict)
-    with pytest.raises(ValueError) as excinfo:
+    swagger_spec = Spec(minimal_swagger_dict, config={'use_models': use_models})
+
+    duplicate_message = 'Duplicate "Pet" model found at path [\'definitions\', \'Pet\']. ' \
+                        'Original "Pet" model at path [\'definitions\', \'Pet\']'
+    try:
         tag_models(
             minimal_swagger_dict['definitions'],
             'Pet',
             ['definitions', 'Pet'],
             visited_models={'Pet': ['definitions', 'Pet']},
-            swagger_spec=swagger_spec)
-    assert 'Duplicate' in str(excinfo.value)
+            swagger_spec=swagger_spec,
+        )
+    except ValueError as e:
+        assert str(e) == duplicate_message
+        assert not mock_log.warning.called
+    else:
+        mock_log.warning.assert_called_once_with(duplicate_message)
 
 
 def test_skip_already_tagged_models(minimal_swagger_dict, pet_model_spec):


### PR DESCRIPTION
The current implementation of ``bravado-core`` raises ``ValueError`` exception if ``tag_models`` or ``bless_models`` identifies a duplicated model.

This behavior is correct is ``use_models`` config is set to ``True``, but it is erroneous if no models are required to the ``Spec`` object.

This PR tries to solve this issue.