### PR TITLE
Generate model names

### DIFF
--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -233,6 +233,12 @@ class Spec(object):
                         visited_models=visited_models,
                         swagger_spec=swagger_spec,
                     ),
+                ],
+            )
+            # Generate python models types
+            post_process_spec(
+                swagger_spec,
+                on_container_callbacks=[
                     functools.partial(
                         collect_models,
                         models=swagger_spec.definitions,

--- a/test-data/2.0/multi-file-specs-with-no-x-model/flattened-multi-file-with-no-xmodel.json
+++ b/test-data/2.0/multi-file-specs-with-no-x-model/flattened-multi-file-with-no-xmodel.json
@@ -4,10 +4,22 @@
       "type": "object",
       "x-model": "lfile:aux.json|..definitions..referenced_object"
     },
+    "lfile:swagger.json|..definitions..definitions_not_used_properties_any_properties_key": {
+      "type": "object",
+      "x-model": "definitions_not_used_properties_any_properties_key",
+      "x-model-blessed": true
+    },
+    "lfile:swagger.json|..definitions..definitions_object_properties_property": {
+      "type": "object",
+      "x-model": "definitions_object_properties_property",
+      "x-model-blessed": true
+    },
     "lfile:swagger.json|..definitions..not_used_referenced": {
       "properties": {
         "key": {
-          "type": "object"
+          "type": "object",
+          "x-model": "definitions_not_used_properties_any_properties_key",
+          "x-model-blessed": true
         }
       }
     },

--- a/tests/model/bless_models_test.py
+++ b/tests/model/bless_models_test.py
@@ -89,10 +89,11 @@ def test_bless_model_adds_model_marker(minimal_swagger_dict):
         visited_models={},
         swagger_spec=swagger_spec,
     )
-    assert response_schema.get('x-model') == response_schema['title']
+    assert response_schema['x-model'] == response_schema['title']
+    assert response_schema.get('x-model-blessed') is True
 
 
-def test_bless_model_does_not_generate_model_tag_if_no_title_is_set(minimal_swagger_dict):
+def test_bless_model_generates_model_tag_if_no_title_is_set(minimal_swagger_dict):
     response_schema = {
         'type': 'object',
     }
@@ -109,11 +110,13 @@ def test_bless_model_does_not_generate_model_tag_if_no_title_is_set(minimal_swag
         },
     }
     swagger_spec = Spec(minimal_swagger_dict)
+    path = ['paths', '/endpoint', 'post', 'responses', '200']
     bless_models(
         minimal_swagger_dict['paths']['/endpoint']['post']['responses']['200'],
         'schema',
-        ['paths', '/endpoint', 'post', 'responses', '200'],
+        path=path,
         visited_models={},
         swagger_spec=swagger_spec,
     )
-    assert 'x-model' not in response_schema
+    assert response_schema['x-model'] == '_'.join(path).replace('/', '')
+    assert response_schema.get('x-model-blessed') is True

--- a/tests/model/tag_models_test.py
+++ b/tests/model/tag_models_test.py
@@ -29,6 +29,7 @@ def test_tags_model(minimal_swagger_dict, pet_model_spec):
         visited_models={},
         swagger_spec=swagger_spec)
     assert pet_model_spec['x-model'] == 'Pet'
+    assert 'x-model-blessed' not in pet_model_spec
 
 
 def test_type_missing(minimal_swagger_dict, pet_model_spec):


### PR DESCRIPTION
This PR adds model name generation to bravado-core model discovery system.

The current master is not generating model names (tagging the model with ``x-model``) if it is not possible to generate a model name from the model spec (so using ``x-model``, ``title`` and eventually definition ``key``).
The goal of this PR is to change this by generating model names for models that have not enough information to have a model name *pre-assigned* to them.

**How this could be achieved**
To generate model names we need to:
 * modify ``bless_models`` to generate a model name in case ``_get_model_name`` returns no name
 * in case of models in ``definitions`` we should prefer ``key`` respect the generated model name (to be consistent with the documentation and reduce breakage) -> generated model names are tracked as blessed and un-registered if needed (``_unregister_visited_model``)
 * spec post processing should perform two spec traversal rounds: 1 for tagging the models and 1 for generating the model types. This is needed to guarantee precedence of tagged models over blessed models. This could be seen as a performance hit during spec build.
  ⚠️  I will probably reconsider this as PR #254 guarantees that specs are traversed following a pre-defined order that gives priority to ``definitions`` over ``paths``

NOTES:
 * The generated model name has to be as unique. Using path should fix this but names clashing are still possible. PR #253 ensures that duplicated model names are not throwing exceptions if models are disabled. This gives us time to fix the specs (if we have the possibility to do that) or still be able to use ``bravado-core`` by giving up on models.

I'm not super sure yet of this changes, this PR has been published to gather comments 😄 

Before pushing this PR I do need to
 * update changelog
 * update models documentation page