### PR TITLE
If type casting fails on a ``TypeError`` allow JSON Schema to handle the error

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+4.13.1 (2018-03-02)
+-------------------
+- If type casting fails on a ``TypeError`` allow JSON Schema to handle the error
+
 4.13.0 (2018-02-23)
 -------------------
 - Models are generated only for objects - PR #246

--- a/bravado_core/__init__.py
+++ b/bravado_core/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-version = '4.13.0'
+version = '4.13.1'

--- a/bravado_core/param.py
+++ b/bravado_core/param.py
@@ -251,7 +251,7 @@ def cast_request_param(param_type, param_name, param_value):
 
     try:
         return CAST_TYPE_TO_FUNC.get(param_type, lambda x: x)(param_value)
-    except ValueError:
+    except (ValueError, TypeError):
         log.warn("Failed to cast %s value of %s to %s",
                  param_name, param_value, param_type)
         # Ignore type error, let jsonschema validation handle incorrect types

--- a/tests/param/cast_request_param_test.py
+++ b/tests/param/cast_request_param_test.py
@@ -17,6 +17,15 @@ def test_cast_failures_return_untouched_value(mock_logger):
     assert result_val == initial_val
 
 
+@patch('bravado_core.param.log')
+def test_type_error_returns_untouched_value_and_logs(mock_logger):
+    initial_val = ['123', '456']
+    result_val = cast_request_param('integer', 'gimme_int', initial_val)
+    assert result_val == initial_val
+    assert result_val is initial_val
+    assert mock_logger.warn.call_count == 1
+
+
 def test_unknown_type_returns_untouched_value():
     assert 'abc123' == cast_request_param('unknown_type', 'blah', 'abc123')
 


### PR DESCRIPTION
In #258, it was discovered that multiple query parameters of a primitive type cause a `TypeError` causing an application server to 500 instead of 400. This change catches the `TypeError`, allowing JSON Schema to handle the exception and return a 400 instead.