### PR TITLE
fixes multi-scheme override logic

### DIFF
--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -516,12 +516,7 @@ def build_api_serving_url(spec_dict, origin_url=None, preferred_scheme=None):
         if origin.scheme in schemes:
             return origin.scheme
 
-        if len(schemes) == 1:
-            return schemes[0]
-
-        raise SwaggerSchemaError(
-            "Origin scheme {0} not supported by API. Available schemes "
-            "include {1}".format(origin.scheme, schemes))
+        return schemes[0]
 
     netloc = spec_dict.get('host', origin.netloc)
     path = spec_dict.get('basePath', origin.path)

--- a/tests/spec/build_api_serving_url_test.py
+++ b/tests/spec/build_api_serving_url_test.py
@@ -33,6 +33,12 @@ def test_override_scheme(origin_url):
     assert 'https://www.foo.com:80/bar/api-docs' == api_serving_url
 
 
+def test_override_scheme_multiple_schemes(origin_url):
+    spec = {'schemes': ['https', 'ws']}
+    api_serving_url = build_api_serving_url(spec, origin_url)
+    assert 'https://www.foo.com:80/bar/api-docs' == api_serving_url
+
+
 def test_pick_preferred_scheme(origin_url):
     spec = {'schemes': ['http', 'https']}
     api_serving_url = build_api_serving_url(


### PR DESCRIPTION
Currently, if you have a swagger spec with multiple supported schemes, and the origin url has a different scheme, then you will get a `SwaggerSchemaError`. If you have only _one_ supported scheme, however the origin url has a different scheme, then the scheme will simply be the supported scheme.

I think this is an arbitrary distinction, and we should prefer to either 1) fail in both cases or 2) succeed in both cases.

I much prefer option 2, which is what this PR does.

To repro on master:

1. Create swagger spec with schemes `http` and `https`
2. Call `from_dict` with `origin_url=file://foo/swagger.json`

Other (separate) observation: `build_api_serving_url` takes a `preferred_scheme` option, but this is actually used nowhere. Do we still need it? If so, should we expose this as part of the `Spec` object api?