### PR TITLE
allow to specify Content-Disposition filename

### DIFF
--- a/bravado_core/param.py
+++ b/bravado_core/param.py
@@ -285,7 +285,12 @@ def add_file(param, value, request):
                     param.op.consumes
             ))
 
-    file_tuple = (param.name, (param.name, value))
+    if isinstance(value, tuple):
+        filename, val = value
+    else:
+        filename, val = param.name, value
+
+    file_tuple = (param.name, (filename, val))
     request['files'].append(file_tuple)
 
 

--- a/tests/param/add_file_test.py
+++ b/tests/param/add_file_test.py
@@ -25,6 +25,24 @@ def test_single_file(empty_swagger_spec):
     assert expected_request == request
 
 
+def test_single_named_file(empty_swagger_spec):
+    request = {}
+    file_name = "iamfile.name"
+    file_contents = "I am the contents of a file"
+    op = Mock(spec=Operation, consumes=['multipart/form-data'])
+    param_spec = {
+        'type': 'file',
+        'in': 'formData',
+        'name': 'photo'
+    }
+    param = Param(empty_swagger_spec, op, param_spec)
+    add_file(param, (file_name, file_contents), request)
+    expected_request = {
+        'files': [('photo', (file_name, 'I am the contents of a file'))]
+    }
+    assert expected_request == request
+
+
 def test_multiple_files(empty_swagger_spec):
     request = {}
     file1_contents = "I am the contents of a file1"


### PR DESCRIPTION
Add support for specifying the 'filename' parameter in 'Content-Disposition'
header when making multipart/form-data POST requests.

The filename is specified by using a tuple of this form:

client.foo.post_bar(fooFile=("my-filename", "file content"))

The call above will generate approx this request:

Host: localhost:9090
User-Agent: python-requests/2.18.4
Content-Length: XXX
Content-Type: multipart/form-data; boundary=15ebe1de468e4b759e100591280b9144

--15ebe1de468e4b759e100591280b9144
Content-Disposition: form-data; name="fooFile"; filename="my-filename"

file content
--15ebe1de468e4b759e100591280b9144--

(This is the same patch as in https://github.com/Yelp/bravado-core/pull/224, but now with a unit test on the new code)