### PR TITLE
Fix spec flattening in case of relative references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ build
 .idea/
 *.iml
 .benchmarks/
+.pytest_cache/

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -124,6 +124,7 @@ class Spec(object):
             handlers=build_http_handlers(http_client),
         )
 
+        self._internal_spec_dict = spec_dict
         self._validate_config()
 
     def _validate_config(self):
@@ -259,18 +260,12 @@ class Spec(object):
 
             # Avoid to evaluate is_ref every time, no references are possible at this time
             self.deref = lambda ref_dict: ref_dict
+            self._internal_spec_dict = self.deref_flattened_spec
 
         for format in self.config['formats']:
             self.register_format(format)
 
         self.api_url = build_api_serving_url(self.spec_dict, self.origin_url)
-
-    @cached_property
-    def _internal_spec_dict(self):
-        if self.config['internally_dereference_refs']:
-            return self.deref_flattened_spec
-        else:
-            return self.spec_dict
 
     def _force_deref(self, ref_dict):
         """Dereference ref_dict (if it is indeed a ref) and return what the

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -368,12 +368,8 @@ class Spec(object):
 
         return strip_xscope(
             spec_dict=flattened_spec(
-                spec_dict=self.spec_dict,
-                spec_resolver=self.resolver,
-                spec_url=self.origin_url,
-                http_handlers=build_http_handlers(self.http_client),
-                spec_definitions=self.definitions,
                 swagger_spec=self,
+                http_handlers=build_http_handlers(self.http_client),
             ),
         )
 

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -124,6 +124,8 @@ class Spec(object):
             handlers=build_http_handlers(http_client),
         )
 
+        # spec dict used to build resources, in case internally_dereference_refs config is enabled
+        # it will be overridden by the dereferenced specs (by build method). More context in PR#263
         self._internal_spec_dict = spec_dict
         self._validate_config()
 
@@ -246,6 +248,8 @@ class Spec(object):
         # deref_flattened_spec depends on flattened_spec which assumes that model
         # discovery is performed
         run_post_processing(self)
+        # Flattening the specs requires resources to be available.
+        # Let's build them before self.deref_flattened_spec is called
         self.resources = build_resources(self)
 
         if self.config['internally_dereference_refs']:

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -245,6 +245,7 @@ class Spec(object):
         # deref_flattened_spec depends on flattened_spec which assumes that model
         # discovery is performed
         run_post_processing(self)
+        self.resources = build_resources(self)
 
         if self.config['internally_dereference_refs']:
             deref_flattened_spec = self.deref_flattened_spec
@@ -253,6 +254,7 @@ class Spec(object):
             # Rebuild definitions using dereferences specs as base
             # this ensures that the generated models have no references
             run_post_processing(tmp_spec)
+            self.resources = build_resources(tmp_spec)
             self.definitions = tmp_spec.definitions
 
             # Avoid to evaluate is_ref every time, no references are possible at this time
@@ -262,7 +264,6 @@ class Spec(object):
             self.register_format(format)
 
         self.api_url = build_api_serving_url(self.spec_dict, self.origin_url)
-        self.resources = build_resources(self)
 
     @cached_property
     def _internal_spec_dict(self):

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -367,10 +367,7 @@ class Spec(object):
             self.build()
 
         return strip_xscope(
-            spec_dict=flattened_spec(
-                swagger_spec=self,
-                http_handlers=build_http_handlers(self.http_client),
-            ),
+            spec_dict=flattened_spec(swagger_spec=self),
         )
 
     @cached_property

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -373,6 +373,7 @@ class Spec(object):
                 spec_url=self.origin_url,
                 http_handlers=build_http_handlers(self.http_client),
                 spec_definitions=self.definitions,
+                swagger_spec=self,
             ),
         )
 

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -364,7 +364,7 @@ class Spec(object):
 
         # If resources are defined it means that Spec has been built and so swagger specs have been validated
         if self.resources is None:
-            self._validate_spec()
+            self.build()
 
         return strip_xscope(
             spec_dict=flattened_spec(

--- a/bravado_core/spec_flattening.py
+++ b/bravado_core/spec_flattening.py
@@ -209,10 +209,9 @@ def flattened_spec(
 
     def descend(value):
         if is_ref(value):
-            uri, deref_value = resolve(value['$ref'])
-
             # Update spec_resolver scope to be able to dereference relative specs from a not root file
-            with in_scope(spec_resolver, {'x-scope': [uri]}):
+            with in_scope(spec_resolver, value):
+                uri, deref_value = resolve(value['$ref'])
                 object_type = determine_object_type(object_dict=deref_value)
                 if object_type.get_root_holder() is None:
                     return descend(value=deref_value)

--- a/bravado_core/spec_flattening.py
+++ b/bravado_core/spec_flattening.py
@@ -195,7 +195,7 @@ def flattened_spec(
 
     if spec_dict is None:
         raise ValueError(
-            'spec_dict is None, the method assumes to receive a valid swagger spec dict'
+            'spec_dict is None, the method assumes to receive a valid swagger spec dict or a swagger spec object'
         )
 
     # Create internal copy of spec_dict to avoid external dict pollution

--- a/bravado_core/spec_flattening.py
+++ b/bravado_core/spec_flattening.py
@@ -127,7 +127,7 @@ def _warn_if_uri_clash_on_same_marshaled_representation(uri_schema_mappings, mar
 
 
 def flattened_spec(
-    spec_dict, spec_resolver=None, spec_url=None, http_handlers=None,
+    spec_dict=None, spec_resolver=None, spec_url=None, http_handlers=None,
     marshal_uri_function=_marshal_uri, spec_definitions=None, swagger_spec=None,
 ):
     """
@@ -160,11 +160,19 @@ def flattened_spec(
     :param marshal_uri_function: function used to marshal uris in string suitable to be keys in Swagger Specs.
     :type marshal_uri_function: Callable with the same signature of ``_marshal_uri``
     :param spec_definitions: known swagger definitions (hint: definitions attribute of bravado_core.spec.Spec instance)
-    :type dict: bravado_core.spec.Spec
+    :type spec_definitions: dict
+    :param swagger_spec: bravado-core Spec object
+    :type swagger_spec: bravado_core.spec.Spec
 
     :return: Flattened representation of the Swagger Specs
     :rtype: dict
     """
+
+    if swagger_spec is not None:
+        spec_dict = swagger_spec.spec_dict if spec_dict is None else spec_dict
+        spec_resolver = swagger_spec.resolver if spec_resolver is None else spec_resolver
+        spec_url = swagger_spec.origin_url if spec_url is None else spec_url
+        spec_definitions = swagger_spec.definitions if spec_definitions is None else spec_url
 
     # Create internal copy of spec_dict to avoid external dict pollution
     spec_dict = copy.deepcopy(spec_dict)

--- a/bravado_core/spec_flattening.py
+++ b/bravado_core/spec_flattening.py
@@ -128,7 +128,7 @@ def _warn_if_uri_clash_on_same_marshaled_representation(uri_schema_mappings, mar
 
 def flattened_spec(
     spec_dict, spec_resolver=None, spec_url=None, http_handlers=None,
-    marshal_uri_function=_marshal_uri, spec_definitions=None,
+    marshal_uri_function=_marshal_uri, spec_definitions=None, swagger_spec=None,
 ):
     """
     Flatten Swagger Specs description into an unique and JSON serializable document.
@@ -207,12 +207,17 @@ def flattened_spec(
     # Avoid object attribute extraction during descend
     resolve = spec_resolver.resolve
 
+    default_type_to_object = swagger_spec.config['default_type_to_object'] if swagger_spec else True
+
     def descend(value):
         if is_ref(value):
             # Update spec_resolver scope to be able to dereference relative specs from a not root file
             with in_scope(spec_resolver, value):
                 uri, deref_value = resolve(value['$ref'])
-                object_type = determine_object_type(object_dict=deref_value)
+                object_type = determine_object_type(
+                    object_dict=deref_value,
+                    default_type_to_object=default_type_to_object,
+                )
                 if object_type.get_root_holder() is None:
                     return descend(value=deref_value)
                 else:

--- a/bravado_core/spec_flattening.py
+++ b/bravado_core/spec_flattening.py
@@ -22,6 +22,7 @@ from bravado_core.schema import is_ref
 from bravado_core.util import determine_object_type
 from bravado_core.util import ObjectType
 
+
 MARSHAL_REPLACEMENT_PATTERNS = {
     '/': '..',  # / is converted to .. (ie. api_docs/swager.json -> api_docs..swagger.json)
     '#': '|',  # # is converted to | (ie. swager.json#definitions -> swagger.json|definitions)
@@ -147,6 +148,10 @@ def flattened_spec(
     Please refer to https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/2.0.md#responseObject for the
     most recent Swagger 2.0 specifications.
 
+    WARNING: In the future releases all the parameters except swagger_spec and marshal_uri_function will be removed.
+    Please make sure to use only those two parameters.
+    Until the deprecation is not effective you can still pass all the parameters but it's strongly discouraged.
+
     :param spec_dict: Swagger Spec dictionary representation. Note: the method assumes that the specs are valid specs.
     :type spec_dict: dict
     :param spec_resolver: Swagger Spec resolver for fetching external references
@@ -161,18 +166,37 @@ def flattened_spec(
     :type marshal_uri_function: Callable with the same signature of ``_marshal_uri``
     :param spec_definitions: known swagger definitions (hint: definitions attribute of bravado_core.spec.Spec instance)
     :type spec_definitions: dict
-    :param swagger_spec: bravado-core Spec object
+    :param swagger_spec: bravado-core Spec object.
+        If the parameter is set it will take precedence over spec_dict, spec_resolver, spec_url,
+            http_handlers, spec_definitions parameters
     :type swagger_spec: bravado_core.spec.Spec
 
     :return: Flattened representation of the Swagger Specs
     :rtype: dict
     """
+    # local imports due to circular dependency
+    from bravado_core.spec import Spec
+    from bravado_core.spec import build_http_handlers
+
+    if any(value is not None for value in (spec_dict, spec_resolver, spec_url, http_handlers, spec_definitions)):
+        warnings.warn(
+            message='In the next major release the all the parameters except swagger_spec and'
+                    'marshal_uri_function  will be removed from the signature. '
+                    'Please make sure to update your code to use only the newly supported parameters',
+            category=PendingDeprecationWarning,
+        )
 
     if swagger_spec is not None:
-        spec_dict = swagger_spec.spec_dict if spec_dict is None else spec_dict
-        spec_resolver = swagger_spec.resolver if spec_resolver is None else spec_resolver
-        spec_url = swagger_spec.origin_url if spec_url is None else spec_url
-        spec_definitions = swagger_spec.definitions if spec_definitions is None else spec_url
+        spec_dict = swagger_spec.spec_dict
+        spec_resolver = swagger_spec.resolver
+        spec_url = swagger_spec.origin_url
+        http_handlers = build_http_handlers(swagger_spec.http_client)
+        spec_definitions = swagger_spec.definitions
+
+    if spec_dict is None:
+        raise ValueError(
+            'spec_dict is None, the method assumes to receive a valid swagger spec dict'
+        )
 
     # Create internal copy of spec_dict to avoid external dict pollution
     spec_dict = copy.deepcopy(spec_dict)
@@ -259,7 +283,6 @@ def flattened_spec(
     resolved_spec = descend(value=spec_dict)
 
     if spec_definitions is not None:
-        from bravado_core.spec import Spec  # local import due to circular dependency
         # Creating the bravado_core.spec.Spec object will trigger models discovery and tagging.
         # The process will add x-model key to ``known_mappings['definitions']`` items
         Spec.from_dict(

--- a/bravado_core/util.py
+++ b/bravado_core/util.py
@@ -125,7 +125,7 @@ class ObjectType(Enum):
         return self.value
 
 
-def determine_object_type(object_dict):
+def determine_object_type(object_dict, default_type_to_object=None):
     """
     Use best guess to determine the object type based on the object keys.
 
@@ -133,8 +133,10 @@ def determine_object_type(object_dict):
     the four types of object that could be references in the specs: parameter, path item, response and schema.
 
     :type object_dict: dict
+    :default_type_to_object: Default object type attribute to object if missing (as from bravado_core.spec.Spec config)
+    :type default_type_to_object: bool
 
-    :return: determined type of ``object_dict``. The return values is an ObjectType:
+    :return: determined type of ``object_dict``. The return values is an ObjectType
     :rtype: ObjectType
     """
 
@@ -171,7 +173,10 @@ def determine_object_type(object_dict):
                 # NOTE: In case the method is mis-determining the type of a schema object, confusing it with a
                 #       response type it will be enough to add, to the object, one key that is not defined
                 #       in ``response_allowed_keys``.  (ie. ``additionalProperties: {}``, implicitly defined be specs)
-                return ObjectType.SCHEMA
+                if default_type_to_object or 'type' in object_dict:
+                    return ObjectType.SCHEMA
+                else:
+                    return ObjectType.UNKNOWN
 
 
 def strip_xscope(spec_dict):

--- a/test-data/2.0/multi-file-multi-directory-spec/definitions.yaml
+++ b/test-data/2.0/multi-file-multi-directory-spec/definitions.yaml
@@ -1,0 +1,23 @@
+ErrorResponse:
+  properties:
+    error_code:
+      description: Machine-friendly error code
+      type: string
+    error_description:
+      description: Human-friendly error code
+      type: string
+  required:
+  - error_code
+  type: object
+  x-model: ErrorResponse
+  x-derived-objects:
+  - $ref: ./endpoint/v1/objects.yaml#/EndpointErrorObject
+DebugErrorResponse:
+  allOf:
+  - $ref: '#/ErrorResponse'
+  - properties:
+      stacktrace:
+        description: Stringified stacktrace
+        type: string
+  type: object
+  x-model: DebugErrorResponse

--- a/test-data/2.0/multi-file-multi-directory-spec/endpoint/parameters.yaml
+++ b/test-data/2.0/multi-file-multi-directory-spec/endpoint/parameters.yaml
@@ -1,0 +1,6 @@
+parameters:
+  number:
+    in: query
+    name: number
+    type: integer
+    required: false

--- a/test-data/2.0/multi-file-multi-directory-spec/endpoint/v1/objects.yaml
+++ b/test-data/2.0/multi-file-multi-directory-spec/endpoint/v1/objects.yaml
@@ -1,0 +1,6 @@
+EndpointErrorObject:
+  allOf:
+  - $ref: ../../definitions.yaml#/ErrorResponse
+  - properties:
+      error_specific_to_this_endpoint:
+        type: string

--- a/test-data/2.0/multi-file-multi-directory-spec/endpoint/v1/paths.yaml
+++ b/test-data/2.0/multi-file-multi-directory-spec/endpoint/v1/paths.yaml
@@ -1,0 +1,7 @@
+get:
+  description: This is the description of a random get endpoint
+  operationId: endpoint_v1
+  parameters:
+    - $ref: ../parameters.yaml#/parameters/number
+  responses:
+    $ref: ./responses.yaml

--- a/test-data/2.0/multi-file-multi-directory-spec/endpoint/v1/paths.yaml
+++ b/test-data/2.0/multi-file-multi-directory-spec/endpoint/v1/paths.yaml
@@ -4,4 +4,9 @@ get:
   parameters:
     - $ref: ../parameters.yaml#/parameters/number
   responses:
-    $ref: ./responses.yaml
+    '200':
+      $ref: ./responses.yaml#/200
+    '403':
+      $ref: ./responses.yaml#/403
+    default:
+      $ref: ./responses.yaml#/default

--- a/test-data/2.0/multi-file-multi-directory-spec/endpoint/v1/responses.yaml
+++ b/test-data/2.0/multi-file-multi-directory-spec/endpoint/v1/responses.yaml
@@ -1,0 +1,24 @@
+'200':
+  description: HTTP/200
+  schema:
+    type: object
+    x-model: endpoint_v1_HTTP_OK
+'403':
+  description: HTTP/403
+  schema:
+    allOf:
+    - $ref: ../../definitions.yaml#/ErrorResponse
+    - properties:
+        action:
+          description: name of the forbidden action
+          type: string
+      required:
+      - action
+      type: object
+      x-model: endpoint_v1_HTTP_FORBIDDEN_action_part
+    type: object
+    x-model: endpoint_v1_HTTP_FORBIDDEN
+default:
+  description: Unplanned status code
+  schema:
+    $ref: ./objects.yaml#/EndpointErrorObject

--- a/test-data/2.0/multi-file-multi-directory-spec/flattened-multi-file-multi-directory-spec.json
+++ b/test-data/2.0/multi-file-multi-directory-spec/flattened-multi-file-multi-directory-spec.json
@@ -2,48 +2,11 @@
   "consumes": [
     "application/json"
   ],
+  "info": {
+    "title": "Consumer Mobile API v2 Service",
+    "version": "1.46.0"
+  },
   "definitions": {
-    "lfile:definitions.yaml": {
-      "DebugErrorResponse": {
-        "allOf": [
-          {
-            "$ref": "#/definitions/lfile:definitions.yaml|..ErrorResponse"
-          },
-          {
-            "properties": {
-              "stacktrace": {
-                "description": "Stringified stacktrace",
-                "type": "string"
-              }
-            }
-          }
-        ],
-        "type": "object",
-        "x-model": "DebugErrorResponse"
-      },
-      "ErrorResponse": {
-        "properties": {
-          "error_code": {
-            "description": "Machine-friendly error code",
-            "type": "string"
-          },
-          "error_description": {
-            "description": "Human-friendly error code",
-            "type": "string"
-          }
-        },
-        "required": [
-          "error_code"
-        ],
-        "type": "object",
-        "x-derived-objects": [
-          {
-            "$ref": "#/definitions/lfile:endpoint..v1..objects.yaml|..EndpointErrorObject"
-          }
-        ],
-        "x-model": "ErrorResponse"
-      }
-    },
     "lfile:definitions.yaml|..ErrorResponse": {
       "properties": {
         "error_code": {
@@ -59,67 +22,23 @@
         "error_code"
       ],
       "type": "object",
+      "x-model": "ErrorResponse",
       "x-derived-objects": [
         {
-          "$ref": "#/definitions/lfile:endpoint..v1..objects.yaml|..EndpointErrorObject"
-        }
-      ],
-      "x-model": "ErrorResponse"
-    },
-    "lfile:endpoint..v1..objects.yaml|..EndpointErrorObject": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/lfile:definitions.yaml|..ErrorResponse"
-        },
-        {
-          "properties": {
-            "error_specific_to_this_endpoint": {
-              "type": "string"
-            }
-          }
-        }
-      ],
-      "x-model": "lfile:endpoint..v1..objects.yaml|..EndpointErrorObject"
-    },
-    "lfile:endpoint..v1..responses.yaml": {
-      "200": {
-        "description": "HTTP/200",
-        "schema": {
-          "type": "object",
-          "x-model": "endpoint_v1_HTTP_OK"
-        }
-      },
-      "403": {
-        "description": "HTTP/403",
-        "schema": {
           "allOf": [
             {
               "$ref": "#/definitions/lfile:definitions.yaml|..ErrorResponse"
             },
             {
               "properties": {
-                "action": {
-                  "description": "name of the forbidden action",
+                "error_specific_to_this_endpoint": {
                   "type": "string"
                 }
-              },
-              "required": [
-                "action"
-              ],
-              "type": "object",
-              "x-model": "endpoint_v1_HTTP_FORBIDDEN_action_part"
+              }
             }
-          ],
-          "type": "object",
-          "x-model": "endpoint_v1_HTTP_FORBIDDEN"
+          ]
         }
-      },
-      "default": {
-        "description": "Unplanned status code",
-        "schema": {
-          "$ref": "#/definitions/lfile:endpoint..v1..objects.yaml|..EndpointErrorObject"
-        }
-      }
+      ]
     },
     "lfile:swagger.yaml|..definitions..DebugErrorResponse": {
       "allOf": [
@@ -137,6 +56,23 @@
       ],
       "type": "object",
       "x-model": "DebugErrorResponse"
+    },
+    "lfile:swagger.yaml|..definitions..endpoint_v1_HTTP_OK": {
+      "type": "object",
+      "x-model": "endpoint_v1_HTTP_OK"
+    },
+    "lfile:swagger.yaml|..definitions..endpoint_v1_HTTP_FORBIDDEN_action_part": {
+      "properties": {
+        "action": {
+          "description": "name of the forbidden action",
+          "type": "string"
+        }
+      },
+      "required": [
+        "action"
+      ],
+      "type": "object",
+      "x-model": "endpoint_v1_HTTP_FORBIDDEN_action_part"
     },
     "lfile:swagger.yaml|..definitions..endpoint_v1_HTTP_FORBIDDEN": {
       "allOf": [
@@ -159,35 +95,6 @@
       ],
       "type": "object",
       "x-model": "endpoint_v1_HTTP_FORBIDDEN"
-    },
-    "lfile:swagger.yaml|..definitions..endpoint_v1_HTTP_FORBIDDEN_action_part": {
-      "properties": {
-        "action": {
-          "description": "name of the forbidden action",
-          "type": "string"
-        }
-      },
-      "required": [
-        "action"
-      ],
-      "type": "object",
-      "x-model": "endpoint_v1_HTTP_FORBIDDEN_action_part"
-    },
-    "lfile:swagger.yaml|..definitions..endpoint_v1_HTTP_OK": {
-      "type": "object",
-      "x-model": "endpoint_v1_HTTP_OK"
-    }
-  },
-  "info": {
-    "title": "Consumer Mobile API v2 Service",
-    "version": "1.46.0"
-  },
-  "parameters": {
-    "lfile:endpoint..parameters.yaml|..parameters..number": {
-      "in": "query",
-      "name": "number",
-      "required": false,
-      "type": "integer"
     }
   },
   "paths": {
@@ -201,7 +108,55 @@
           }
         ],
         "responses": {
-          "$ref": "#/definitions/lfile:endpoint..v1..responses.yaml"
+          "200": {
+            "description": "HTTP/200",
+            "schema": {
+              "type": "object",
+              "x-model": "endpoint_v1_HTTP_OK"
+            }
+          },
+          "403": {
+            "description": "HTTP/403",
+            "schema": {
+              "allOf": [
+                {
+                  "$ref": "#/definitions/lfile:definitions.yaml|..ErrorResponse"
+                },
+                {
+                  "properties": {
+                    "action": {
+                      "description": "name of the forbidden action",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "action"
+                  ],
+                  "type": "object",
+                  "x-model": "endpoint_v1_HTTP_FORBIDDEN_action_part"
+                }
+              ],
+              "type": "object",
+              "x-model": "endpoint_v1_HTTP_FORBIDDEN"
+            }
+          },
+          "default": {
+            "description": "Unplanned status code",
+            "schema": {
+              "allOf": [
+                {
+                  "$ref": "#/definitions/lfile:definitions.yaml|..ErrorResponse"
+                },
+                {
+                  "properties": {
+                    "error_specific_to_this_endpoint": {
+                      "type": "string"
+                    }
+                  }
+                }
+              ]
+            }
+          }
         }
       }
     }
@@ -209,5 +164,13 @@
   "produces": [
     "application/json"
   ],
-  "swagger": "2.0"
+  "swagger": "2.0",
+  "parameters": {
+    "lfile:endpoint..parameters.yaml|..parameters..number": {
+      "in": "query",
+      "name": "number",
+      "type": "integer",
+      "required": false
+    }
+  }
 }

--- a/test-data/2.0/multi-file-multi-directory-spec/flattened-multi-file-multi-directory-spec.json
+++ b/test-data/2.0/multi-file-multi-directory-spec/flattened-multi-file-multi-directory-spec.json
@@ -1,0 +1,213 @@
+{
+  "consumes": [
+    "application/json"
+  ],
+  "definitions": {
+    "lfile:definitions.yaml": {
+      "DebugErrorResponse": {
+        "allOf": [
+          {
+            "$ref": "#/definitions/lfile:definitions.yaml|..ErrorResponse"
+          },
+          {
+            "properties": {
+              "stacktrace": {
+                "description": "Stringified stacktrace",
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "type": "object",
+        "x-model": "DebugErrorResponse"
+      },
+      "ErrorResponse": {
+        "properties": {
+          "error_code": {
+            "description": "Machine-friendly error code",
+            "type": "string"
+          },
+          "error_description": {
+            "description": "Human-friendly error code",
+            "type": "string"
+          }
+        },
+        "required": [
+          "error_code"
+        ],
+        "type": "object",
+        "x-derived-objects": [
+          {
+            "$ref": "#/definitions/lfile:endpoint..v1..objects.yaml|..EndpointErrorObject"
+          }
+        ],
+        "x-model": "ErrorResponse"
+      }
+    },
+    "lfile:definitions.yaml|..ErrorResponse": {
+      "properties": {
+        "error_code": {
+          "description": "Machine-friendly error code",
+          "type": "string"
+        },
+        "error_description": {
+          "description": "Human-friendly error code",
+          "type": "string"
+        }
+      },
+      "required": [
+        "error_code"
+      ],
+      "type": "object",
+      "x-derived-objects": [
+        {
+          "$ref": "#/definitions/lfile:endpoint..v1..objects.yaml|..EndpointErrorObject"
+        }
+      ],
+      "x-model": "ErrorResponse"
+    },
+    "lfile:endpoint..v1..objects.yaml|..EndpointErrorObject": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/lfile:definitions.yaml|..ErrorResponse"
+        },
+        {
+          "properties": {
+            "error_specific_to_this_endpoint": {
+              "type": "string"
+            }
+          }
+        }
+      ],
+      "x-model": "lfile:endpoint..v1..objects.yaml|..EndpointErrorObject"
+    },
+    "lfile:endpoint..v1..responses.yaml": {
+      "200": {
+        "description": "HTTP/200",
+        "schema": {
+          "type": "object",
+          "x-model": "endpoint_v1_HTTP_OK"
+        }
+      },
+      "403": {
+        "description": "HTTP/403",
+        "schema": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/lfile:definitions.yaml|..ErrorResponse"
+            },
+            {
+              "properties": {
+                "action": {
+                  "description": "name of the forbidden action",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "action"
+              ],
+              "type": "object",
+              "x-model": "endpoint_v1_HTTP_FORBIDDEN_action_part"
+            }
+          ],
+          "type": "object",
+          "x-model": "endpoint_v1_HTTP_FORBIDDEN"
+        }
+      },
+      "default": {
+        "description": "Unplanned status code",
+        "schema": {
+          "$ref": "#/definitions/lfile:endpoint..v1..objects.yaml|..EndpointErrorObject"
+        }
+      }
+    },
+    "lfile:swagger.yaml|..definitions..DebugErrorResponse": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/lfile:definitions.yaml|..ErrorResponse"
+        },
+        {
+          "properties": {
+            "stacktrace": {
+              "description": "Stringified stacktrace",
+              "type": "string"
+            }
+          }
+        }
+      ],
+      "type": "object",
+      "x-model": "DebugErrorResponse"
+    },
+    "lfile:swagger.yaml|..definitions..endpoint_v1_HTTP_FORBIDDEN": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/lfile:definitions.yaml|..ErrorResponse"
+        },
+        {
+          "properties": {
+            "action": {
+              "description": "name of the forbidden action",
+              "type": "string"
+            }
+          },
+          "required": [
+            "action"
+          ],
+          "type": "object",
+          "x-model": "endpoint_v1_HTTP_FORBIDDEN_action_part"
+        }
+      ],
+      "type": "object",
+      "x-model": "endpoint_v1_HTTP_FORBIDDEN"
+    },
+    "lfile:swagger.yaml|..definitions..endpoint_v1_HTTP_FORBIDDEN_action_part": {
+      "properties": {
+        "action": {
+          "description": "name of the forbidden action",
+          "type": "string"
+        }
+      },
+      "required": [
+        "action"
+      ],
+      "type": "object",
+      "x-model": "endpoint_v1_HTTP_FORBIDDEN_action_part"
+    },
+    "lfile:swagger.yaml|..definitions..endpoint_v1_HTTP_OK": {
+      "type": "object",
+      "x-model": "endpoint_v1_HTTP_OK"
+    }
+  },
+  "info": {
+    "title": "Consumer Mobile API v2 Service",
+    "version": "1.46.0"
+  },
+  "parameters": {
+    "lfile:endpoint..parameters.yaml|..parameters..number": {
+      "in": "query",
+      "name": "number",
+      "required": false,
+      "type": "integer"
+    }
+  },
+  "paths": {
+    "/endpoint/v1": {
+      "get": {
+        "description": "This is the description of a random get endpoint",
+        "operationId": "endpoint_v1",
+        "parameters": [
+          {
+            "$ref": "#/parameters/lfile:endpoint..parameters.yaml|..parameters..number"
+          }
+        ],
+        "responses": {
+          "$ref": "#/definitions/lfile:endpoint..v1..responses.yaml"
+        }
+      }
+    }
+  },
+  "produces": [
+    "application/json"
+  ],
+  "swagger": "2.0"
+}

--- a/test-data/2.0/multi-file-multi-directory-spec/flattened-multi-file-multi-directory-spec.json
+++ b/test-data/2.0/multi-file-multi-directory-spec/flattened-multi-file-multi-directory-spec.json
@@ -1,176 +1,187 @@
 {
-  "consumes": [
-    "application/json"
-  ],
-  "info": {
-    "title": "Consumer Mobile API v2 Service",
-    "version": "1.46.0"
-  },
-  "definitions": {
-    "lfile:definitions.yaml|..ErrorResponse": {
-      "properties": {
-        "error_code": {
-          "description": "Machine-friendly error code",
-          "type": "string"
-        },
-        "error_description": {
-          "description": "Human-friendly error code",
-          "type": "string"
-        }
-      },
-      "required": [
-        "error_code"
-      ],
-      "type": "object",
-      "x-model": "ErrorResponse",
-      "x-derived-objects": [
-        {
-          "allOf": [
-            {
-              "$ref": "#/definitions/lfile:definitions.yaml|..ErrorResponse"
-            },
-            {
-              "properties": {
-                "error_specific_to_this_endpoint": {
-                  "type": "string"
+    "consumes": [
+        "application/json"
+    ],
+    "definitions": {
+        "lfile:definitions.yaml|..ErrorResponse": {
+            "properties": {
+                "error_code": {
+                    "description": "Machine-friendly error code",
+                    "type": "string"
+                },
+                "error_description": {
+                    "description": "Human-friendly error code",
+                    "type": "string"
                 }
-              }
-            }
-          ]
-        }
-      ]
-    },
-    "lfile:swagger.yaml|..definitions..DebugErrorResponse": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/lfile:definitions.yaml|..ErrorResponse"
+            },
+            "required": [
+                "error_code"
+            ],
+            "type": "object",
+            "x-derived-objects": [
+                {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/lfile:definitions.yaml|..ErrorResponse"
+                        },
+                        {
+                            "properties": {
+                                "error_specific_to_this_endpoint": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    ]
+                }
+            ],
+            "x-model": "ErrorResponse"
         },
-        {
-          "properties": {
-            "stacktrace": {
-              "description": "Stringified stacktrace",
-              "type": "string"
-            }
-          }
-        }
-      ],
-      "type": "object",
-      "x-model": "DebugErrorResponse"
-    },
-    "lfile:swagger.yaml|..definitions..endpoint_v1_HTTP_OK": {
-      "type": "object",
-      "x-model": "endpoint_v1_HTTP_OK"
-    },
-    "lfile:swagger.yaml|..definitions..endpoint_v1_HTTP_FORBIDDEN_action_part": {
-      "properties": {
-        "action": {
-          "description": "name of the forbidden action",
-          "type": "string"
-        }
-      },
-      "required": [
-        "action"
-      ],
-      "type": "object",
-      "x-model": "endpoint_v1_HTTP_FORBIDDEN_action_part"
-    },
-    "lfile:swagger.yaml|..definitions..endpoint_v1_HTTP_FORBIDDEN": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/lfile:definitions.yaml|..ErrorResponse"
+        "lfile:swagger.yaml|..definitions..DebugErrorResponse": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/lfile:definitions.yaml|..ErrorResponse"
+                },
+                {
+                    "properties": {
+                        "stacktrace": {
+                            "description": "Stringified stacktrace",
+                            "type": "string"
+                        }
+                    }
+                }
+            ],
+            "type": "object",
+            "x-model": "DebugErrorResponse"
         },
-        {
-          "properties": {
-            "action": {
-              "description": "name of the forbidden action",
-              "type": "string"
-            }
-          },
-          "required": [
-            "action"
-          ],
-          "type": "object",
-          "x-model": "endpoint_v1_HTTP_FORBIDDEN_action_part"
+        "lfile:swagger.yaml|..definitions..endpoint_v1_HTTP_FORBIDDEN": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/lfile:definitions.yaml|..ErrorResponse"
+                },
+                {
+                    "properties": {
+                        "action": {
+                            "description": "name of the forbidden action",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "action"
+                    ],
+                    "type": "object",
+                    "x-model": "endpoint_v1_HTTP_FORBIDDEN_action_part"
+                }
+            ],
+            "type": "object",
+            "x-model": "endpoint_v1_HTTP_FORBIDDEN"
+        },
+        "lfile:swagger.yaml|..definitions..endpoint_v1_HTTP_FORBIDDEN_action_part": {
+            "properties": {
+                "action": {
+                    "description": "name of the forbidden action",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "action"
+            ],
+            "type": "object",
+            "x-model": "endpoint_v1_HTTP_FORBIDDEN_action_part"
+        },
+        "lfile:swagger.yaml|..definitions..endpoint_v1_HTTP_OK": {
+            "type": "object",
+            "x-model": "endpoint_v1_HTTP_OK"
         }
-      ],
-      "type": "object",
-      "x-model": "endpoint_v1_HTTP_FORBIDDEN"
-    }
-  },
-  "paths": {
-    "/endpoint/v1": {
-      "get": {
-        "description": "This is the description of a random get endpoint",
-        "operationId": "endpoint_v1",
-        "parameters": [
-          {
-            "$ref": "#/parameters/lfile:endpoint..parameters.yaml|..parameters..number"
-          }
-        ],
-        "responses": {
-          "200": {
+    },
+    "info": {
+        "title": "Consumer Mobile API v2 Service",
+        "version": "1.46.0"
+    },
+    "parameters": {
+        "lfile:endpoint..parameters.yaml|..parameters..number": {
+            "in": "query",
+            "name": "number",
+            "required": false,
+            "type": "integer"
+        }
+    },
+    "paths": {
+        "/endpoint/v1": {
+            "get": {
+                "description": "This is the description of a random get endpoint",
+                "operationId": "endpoint_v1",
+                "parameters": [
+                    {
+                        "$ref": "#/parameters/lfile:endpoint..parameters.yaml|..parameters..number"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/responses/lfile:endpoint..v1..responses.yaml|..200"
+                    },
+                    "403": {
+                        "$ref": "#/responses/lfile:endpoint..v1..responses.yaml|..403"
+                    },
+                    "default": {
+                        "$ref": "#/responses/lfile:endpoint..v1..responses.yaml|..default"
+                    }
+                }
+            }
+        }
+    },
+    "produces": [
+        "application/json"
+    ],
+    "responses": {
+        "lfile:endpoint..v1..responses.yaml|..200": {
             "description": "HTTP/200",
             "schema": {
-              "type": "object",
-              "x-model": "endpoint_v1_HTTP_OK"
+                "type": "object",
+                "x-model": "endpoint_v1_HTTP_OK"
             }
-          },
-          "403": {
+        },
+        "lfile:endpoint..v1..responses.yaml|..403": {
             "description": "HTTP/403",
             "schema": {
-              "allOf": [
-                {
-                  "$ref": "#/definitions/lfile:definitions.yaml|..ErrorResponse"
-                },
-                {
-                  "properties": {
-                    "action": {
-                      "description": "name of the forbidden action",
-                      "type": "string"
+                "allOf": [
+                    {
+                        "$ref": "#/definitions/lfile:definitions.yaml|..ErrorResponse"
+                    },
+                    {
+                        "properties": {
+                            "action": {
+                                "description": "name of the forbidden action",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "action"
+                        ],
+                        "type": "object",
+                        "x-model": "endpoint_v1_HTTP_FORBIDDEN_action_part"
                     }
-                  },
-                  "required": [
-                    "action"
-                  ],
-                  "type": "object",
-                  "x-model": "endpoint_v1_HTTP_FORBIDDEN_action_part"
-                }
-              ],
-              "type": "object",
-              "x-model": "endpoint_v1_HTTP_FORBIDDEN"
+                ],
+                "type": "object",
+                "x-model": "endpoint_v1_HTTP_FORBIDDEN"
             }
-          },
-          "default": {
+        },
+        "lfile:endpoint..v1..responses.yaml|..default": {
             "description": "Unplanned status code",
             "schema": {
-              "allOf": [
-                {
-                  "$ref": "#/definitions/lfile:definitions.yaml|..ErrorResponse"
-                },
-                {
-                  "properties": {
-                    "error_specific_to_this_endpoint": {
-                      "type": "string"
+                "allOf": [
+                    {
+                        "$ref": "#/definitions/lfile:definitions.yaml|..ErrorResponse"
+                    },
+                    {
+                        "properties": {
+                            "error_specific_to_this_endpoint": {
+                                "type": "string"
+                            }
+                        }
                     }
-                  }
-                }
-              ]
+                ]
             }
-          }
         }
-      }
-    }
-  },
-  "produces": [
-    "application/json"
-  ],
-  "swagger": "2.0",
-  "parameters": {
-    "lfile:endpoint..parameters.yaml|..parameters..number": {
-      "in": "query",
-      "name": "number",
-      "type": "integer",
-      "required": false
-    }
-  }
+    },
+    "swagger": "2.0"
 }

--- a/test-data/2.0/multi-file-multi-directory-spec/swagger.yaml
+++ b/test-data/2.0/multi-file-multi-directory-spec/swagger.yaml
@@ -1,0 +1,18 @@
+consumes:
+  - application/json
+
+info:
+  title: Consumer Mobile API v2 Service
+  version: 1.46.0
+
+definitions:
+  $ref: ./definitions.yaml
+
+paths:
+  /endpoint/v1:
+    $ref: ./endpoint/v1/paths.yaml
+
+produces:
+  - application/json
+
+swagger: '2.0'

--- a/test-data/2.0/multi-file-specs-with-no-x-model/flattened-multi-file-with-no-xmodel.json
+++ b/test-data/2.0/multi-file-specs-with-no-x-model/flattened-multi-file-with-no-xmodel.json
@@ -1,15 +1,14 @@
 {
+  "swagger": "2.0",
+  "info": {
+    "title": "Test",
+    "version": "1.0"
+  },
+  "paths": {},
   "definitions": {
     "lfile:aux.json|..definitions..referenced_object": {
       "type": "object",
       "x-model": "lfile:aux.json|..definitions..referenced_object"
-    },
-    "lfile:swagger.json|..definitions..not_used_referenced": {
-      "properties": {
-        "key": {
-          "type": "object"
-        }
-      }
     },
     "lfile:swagger.json|..definitions..object": {
       "properties": {
@@ -20,11 +19,5 @@
       "type": "object",
       "x-model": "object"
     }
-  },
-  "info": {
-    "title": "Test",
-    "version": "1.0"
-  },
-  "paths": {},
-  "swagger": "2.0"
+  }
 }

--- a/tests/spec/Spec/deref_flattened_spec_test.py
+++ b/tests/spec/Spec/deref_flattened_spec_test.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import pytest
 from six import iterkeys
 from six import itervalues
 from six.moves.urllib_parse import urljoin
@@ -38,7 +37,6 @@ def _equivalent(spec, obj1, obj2):
         return obj1 == obj2
 
 
-@pytest.mark.xfail(reason='Flaky test, issue #219')
 def test_deref_flattened_spec_not_recursive_specs(petstore_spec):
     spec_dict = petstore_spec.spec_dict
     deref_spec_dict = petstore_spec.deref_flattened_spec

--- a/tests/spec/Spec/flattened_spec_test.py
+++ b/tests/spec/Spec/flattened_spec_test.py
@@ -1,17 +1,20 @@
 # -*- coding: utf-8 -*-
 import copy
 import functools
+import os
 
 import mock
 import pytest
 from six.moves.urllib.parse import urlparse
 from swagger_spec_validator import validator20
+from yaml import safe_load
 
 from bravado_core import spec
 from bravado_core.spec import CONFIG_DEFAULTS
 from bravado_core.spec import Spec
 from bravado_core.spec_flattening import _marshal_uri
 from bravado_core.spec_flattening import _warn_if_uri_clash_on_same_marshaled_representation
+from tests.conftest import get_url
 
 
 @mock.patch('bravado_core.spec_flattening.warnings')
@@ -208,3 +211,26 @@ def test_flattened_specs_with_no_xmodel_tags(multi_file_with_no_xmodel_spec, fla
         http_handlers={},
     )
     assert flattened_spec == flattened_multi_file_with_no_xmodel_dict
+
+
+@pytest.fixture
+def multi_file_multi_directory_abspath(my_dir):
+    return os.path.abspath(os.path.join(my_dir, '../test-data/2.0/multi-file-multi-directory-spec/swagger.yaml'))
+
+
+@pytest.fixture
+def multi_file_multi_directory_dict(multi_file_multi_directory_abspath):
+    with open(multi_file_multi_directory_abspath) as f:
+        return safe_load(f)
+
+
+@pytest.fixture
+def multi_file_multi_directory_spec(multi_file_multi_directory_dict, multi_file_multi_directory_abspath):
+    return Spec.from_dict(multi_file_multi_directory_dict, origin_url=get_url(multi_file_multi_directory_abspath))
+
+
+def test_flattened_multi_file_multi_directory_specs(multi_file_multi_directory_spec):
+    try:
+        multi_file_multi_directory_spec.flattened_spec
+    except BaseException as e:
+        pytest.fail('Unexpected exception: {e}'.format(e=e), e.__traceback__)

--- a/tests/spec/Spec/flattened_spec_test.py
+++ b/tests/spec/Spec/flattened_spec_test.py
@@ -140,6 +140,7 @@ def test_flattened_spec_build_specs_if_not_already_built(
         spec_url=petstore_spec.origin_url,
         http_handlers=mock.ANY,
         spec_definitions=mock.ANY,
+        swagger_spec=petstore_spec,
     )
     mock_strip_xscope.assert_called_once_with(mock_flattened_spec.return_value)
 
@@ -163,6 +164,7 @@ def test_flattened_spec_warning_if_no_origin_url(
         spec_url=petstore_spec.origin_url,
         http_handlers=mock_build_http_handlers.return_value,
         spec_definitions=petstore_spec.definitions,
+        swagger_spec=petstore_spec,
     )
 
     if has_origin_url:
@@ -194,6 +196,7 @@ def test_flattened_spec_warning_if_no_definitions(
         spec_url=petstore_spec.origin_url,
         http_handlers=mock_build_http_handlers.return_value,
         spec_definitions=petstore_spec.definitions,
+        swagger_spec=petstore_spec,
     )
 
     if has_spec_definitions:

--- a/tests/spec/Spec/flattened_spec_test.py
+++ b/tests/spec/Spec/flattened_spec_test.py
@@ -240,7 +240,8 @@ def test_flattened_specs_warns_if_long_list_of_parameters_is_passed(mock_warning
 def test_flattened_specs_raises_if_spec_dict_is_None():
     with pytest.raises(ValueError) as excinfo:
         flattened_spec(spec_dict=None)
-    assert 'spec_dict is None, the method assumes to receive a valid swagger spec dict' in str(excinfo.value)
+    assert 'spec_dict is None, the method assumes to receive a valid ' \
+           'swagger spec dict or a swagger spec object' in str(excinfo.value)
 
 
 @mock.patch('bravado_core.spec_flattening.warnings')

--- a/tests/spec/Spec/flattened_spec_test.py
+++ b/tests/spec/Spec/flattened_spec_test.py
@@ -135,12 +135,8 @@ def test_flattened_spec_build_specs_if_not_already_built(
         mock_build.assert_called_once_with()
 
     mock_flattened_spec.assert_called_once_with(
-        spec_dict=minimal_swagger_dict,
-        spec_resolver=petstore_spec.resolver,
-        spec_url=petstore_spec.origin_url,
-        http_handlers=mock.ANY,
-        spec_definitions=mock.ANY,
         swagger_spec=petstore_spec,
+        http_handlers=mock.ANY,
     )
     mock_strip_xscope.assert_called_once_with(mock_flattened_spec.return_value)
 
@@ -159,12 +155,8 @@ def test_flattened_spec_warning_if_no_origin_url(
 
     petstore_spec.flattened_spec
     wrap_flattened_spec.assert_called_once_with(
-        spec_dict=petstore_spec.spec_dict,
-        spec_resolver=petstore_spec.resolver,
-        spec_url=petstore_spec.origin_url,
-        http_handlers=mock_build_http_handlers.return_value,
-        spec_definitions=petstore_spec.definitions,
         swagger_spec=petstore_spec,
+        http_handlers=mock_build_http_handlers.return_value,
     )
 
     if has_origin_url:
@@ -191,12 +183,8 @@ def test_flattened_spec_warning_if_no_definitions(
 
     petstore_spec.flattened_spec
     wrap_flattened_spec.assert_called_once_with(
-        spec_dict=petstore_spec.spec_dict,
-        spec_resolver=petstore_spec.resolver,
-        spec_url=petstore_spec.origin_url,
-        http_handlers=mock_build_http_handlers.return_value,
-        spec_definitions=petstore_spec.definitions,
         swagger_spec=petstore_spec,
+        http_handlers=mock_build_http_handlers.return_value,
     )
 
     if has_spec_definitions:

--- a/tests/spec/from_dict_test.py
+++ b/tests/spec/from_dict_test.py
@@ -170,3 +170,9 @@ def test_flattened_multi_file_multi_directory_specs(
     multi_file_multi_directory_spec, flattened_multi_file_multi_directory_dict,
 ):
     assert multi_file_multi_directory_spec.flattened_spec == flattened_multi_file_multi_directory_dict
+
+    # Ensure that flattened_spec is a valid swagger spec
+    try:
+        Spec.from_dict(multi_file_multi_directory_spec.flattened_spec)
+    except Exception as e:
+        pytest.fail('Unexpected exception: {e}'.format(e=e), e.__traceback__)

--- a/tests/spec/from_dict_test.py
+++ b/tests/spec/from_dict_test.py
@@ -8,6 +8,7 @@ from six.moves.urllib import parse as urlparse
 
 from bravado_core.response import get_response_spec
 from bravado_core.spec import Spec
+from tests.conftest import _read_json
 from tests.conftest import get_url
 
 
@@ -140,6 +141,19 @@ def multi_file_multi_directory_dict(multi_file_multi_directory_abspath):
         return yaml.safe_load(f)
 
 
+@pytest.fixture
+def flattened_multi_file_multi_directory_abspath(my_dir):
+    return os.path.join(
+        my_dir,
+        '../test-data/2.0/multi-file-multi-directory-spec/flattened-multi-file-multi-directory-spec.json',
+    )
+
+
+@pytest.fixture
+def flattened_multi_file_multi_directory_dict(flattened_multi_file_multi_directory_abspath):
+    return _read_json(flattened_multi_file_multi_directory_abspath)
+
+
 @pytest.fixture(
     params=[False, True],
     ids=['with-references', 'fully-dereferenced'],
@@ -152,8 +166,7 @@ def multi_file_multi_directory_spec(request, multi_file_multi_directory_dict, mu
     )
 
 
-def test_flattened_multi_file_multi_directory_specs(multi_file_multi_directory_spec):
-    try:
-        multi_file_multi_directory_spec.flattened_spec
-    except BaseException as e:
-        pytest.fail('Unexpected exception: {e}'.format(e=e), e.__traceback__)
+def test_flattened_multi_file_multi_directory_specs(
+    multi_file_multi_directory_spec, flattened_multi_file_multi_directory_dict,
+):
+    assert multi_file_multi_directory_spec.flattened_spec == flattened_multi_file_multi_directory_dict

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -118,16 +118,18 @@ def test_AliasKeyDict_del():
 
 
 @pytest.mark.parametrize(
-    'object_dict, expected_object_type',
+    'default_type_to_object, object_dict, expected_object_type',
     (
-        [{'in': 'body', 'name': 'body', 'required': True, 'schema': {'type': 'object'}}, ObjectType.PARAMETER],
-        [{'get': {'responses': {'200': {'description': 'response description'}}}}, ObjectType.PATH_ITEM],
-        [{'description': 'response description', 'schema': {'type': 'object'}}, ObjectType.RESPONSE],
-        [{'description': 'response description', 'parameters': {'param': {'type': 'object'}}}, ObjectType.SCHEMA],
+        [True, 'anything that is not a dictionary', ObjectType.UNKNOWN],
+        [True, {'in': 'body', 'name': 'body', 'required': True, 'schema': {'type': 'object'}}, ObjectType.PARAMETER],
+        [True, {'get': {'responses': {'200': {'description': 'response description'}}}}, ObjectType.PATH_ITEM],
+        [True, {'description': 'response description', 'schema': {'type': 'object'}}, ObjectType.RESPONSE],
+        [True, {'description': 'response description', 'parameters': {'param': {'type': 'object'}}}, ObjectType.SCHEMA],
+        [False, {'description': 'response description', 'parameters': {'param': {'type': 'object'}}}, ObjectType.UNKNOWN],  # noqa
     )
 )
-def test_determine_object_type(object_dict, expected_object_type):
-    assert determine_object_type(object_dict) == expected_object_type
+def test_determine_object_type(default_type_to_object, object_dict, expected_object_type):
+    assert determine_object_type(object_dict, default_type_to_object) == expected_object_type
 
 
 def test_empty():


### PR DESCRIPTION
While working on internal specs I've spotted two issues related to flattening and dereferencing specs with relative links on different directories.

Everything works fine if the references are not on different files, but as soon as we reference a file on a different directory all the links on the new files are relative to the new path.

The issue is caused because:
 * reference resolving does not take in consideration the resolution scope (changes on `bravado_core/spec_flattening.py`)
 * flattening specs requires resources to be available; as resources are not built at the time of `flattened_spec` call, enforcing resource building as an extra step of `run_post_processing` fixes the issue

**Note**:
while doing those changes I've also noted that `_internal_spec_dict` was returning `deref_flattened_spec` if `internally_dereference_refs` config is enabled.
Sadly the evaluation of `deref_flattened_spec` requires resource building, which requires `_internal_spec_dict`, so an ugly cycle of badly handled dependencies.
In order to decouple these dependencies and remove the minimal overhead related to property evaluation I've converted `_internal_spec_dict` property to Spec attribute, which is overridden in case `internally_dereference_refs` config is set