### PR TITLE
Remove warning from tests execution

### DIFF
--- a/tests/spec/Spec/build_test.py
+++ b/tests/spec/Spec/build_test.py
@@ -6,6 +6,7 @@ from six import iterkeys
 from swagger_spec_validator.common import SwaggerValidationError
 
 from bravado_core.spec import Spec
+from tests.conftest import get_url
 from tests.validate.conftest import email_address_format
 
 
@@ -57,9 +58,10 @@ def test_build_with_custom_format(petstore_dict):
         False,
     ]
 )
-def test_build_with_internally_dereference_refs(petstore_dict, internally_dereference_refs):
+def test_build_with_internally_dereference_refs(petstore_abspath, petstore_dict, internally_dereference_refs):
     spec = Spec(
         petstore_dict,
+        origin_url=get_url(petstore_abspath),
         config={'internally_dereference_refs': internally_dereference_refs}
     )
     assert spec.deref == spec._force_deref


### PR DESCRIPTION
Running tests produces the following warning message
```
tests/spec/Spec/build_test.py::test_build_with_internally_dereference_refs[True]
  /Users/maci/pg/github/bravado-core/bravado_core/spec_flattening.py:176: Warning: It is recommended to set origin_url to your spec before flattering it. Doing so internal paths will be hidden, reducing the amount of exposed information.
    category=Warning,

-- Docs: http://doc.pytest.org/en/latest/warnings.html
```

The goal of this PR is to remove this warning and keeping clean output of the results