### PR TITLE
re-xfail test_deref_flattened_spec_not_recursive_specs

### DIFF
--- a/tests/spec/Spec/deref_flattened_spec_test.py
+++ b/tests/spec/Spec/deref_flattened_spec_test.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import pytest
 from six import iterkeys
 from six import itervalues
 from six.moves.urllib_parse import urljoin
@@ -37,6 +38,7 @@ def _equivalent(spec, obj1, obj2):
         return obj1 == obj2
 
 
+@pytest.mark.xfail(reason='Flaky test, issue #219')
 def test_deref_flattened_spec_not_recursive_specs(petstore_spec):
     spec_dict = petstore_spec.spec_dict
     deref_spec_dict = petstore_spec.deref_flattened_spec


### PR DESCRIPTION
During PR #263 I've de-xfailed `test_deref_flattened_spec_not_recursive_specs` as it looked to be pretty stable.
Apparently this is not true, as it failed on travis (and succeed after pressing of rebuild) and fails on internal jenkins machines.

I'm xfailing it back