### PR TITLE
Fix is parameter required check in marshal_param and unmarshal_param

### DIFF
--- a/bravado_core/param.py
+++ b/bravado_core/param.py
@@ -115,7 +115,7 @@ def marshal_param(param, value, request):
 
     # Rely on unmarshalling behavior on the other side of the pipe to use
     # the default value if one is available.
-    if value is None and not schema.is_required(swagger_spec, param_spec):
+    if value is None and not param.required:
         return
 
     value = marshal_schema_object(swagger_spec, param_spec, value)
@@ -188,7 +188,7 @@ def unmarshal_param(param, request):
             "Don't know how to unmarshal_param with location {0}".
             format(location))
 
-    if raw_value is None and not schema.is_required(swagger_spec, param_spec):
+    if raw_value is None and not param.required:
         return None
 
     if param_type == 'array' and location != 'body':

--- a/tests/param/unmarshal_param_test.py
+++ b/tests/param/unmarshal_param_test.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import datetime
+
 import pytest
 from mock import Mock
 from mock import patch
@@ -266,3 +268,34 @@ def test_ref(minimal_swagger_dict, array_param_spec):
     request = Mock(spec=IncomingRequest, query={'animals': value})
     result = unmarshal_param(param, request)
     assert ['cat', 'dog', 'bird'] == result
+
+
+@pytest.mark.parametrize(
+    'body, expected_value',
+    [
+        (None, None),
+        ({'an-attribute': '2018-05-24'}, {'an-attribute': datetime.date(2018, 5, 24)}),
+    ],
+)
+def test_body_parameter_not_present_not_required(empty_swagger_spec, body, expected_value):
+    param_spec = {
+        'in': 'body',
+        'name': 'body',
+        'required': False,
+        'schema': {
+            'type': 'object',
+            'properties': {
+                'an-attribute': {
+                    'type': 'string',
+                    'format': 'date',
+                },
+            },
+            'required': [
+                'an-attribute',
+            ],
+        },
+    }
+    param = Param(empty_swagger_spec, Mock(spec=Operation), param_spec)
+    request = Mock(spec=IncomingRequest, json=Mock(return_value=body))
+    value = unmarshal_param(param, request)
+    assert expected_value == value


### PR DESCRIPTION
While working on https://github.com/striglia/pyramid_swagger/pull/231 I've noticed that bravado-core, during the parameter marshaling and unmarshaling process, checks if the parameter is required in case `raw_value is None`.

Unfortunately the check does not use `param.required` attribute but `schema.is_required` method.

In case the parameter type is not an object the two approaches are equivalent as
 * `schema.is_required(swagger_spec, param_spec)` safely gets `required` attribute from `param_spec`
 * `param_spec` (retrieved from `get_param_type_spec` returns param.spec
In case of body parameter `param_spec` contains the `schema` attribute of the parameter, so `schema.is_required` extracts the required properties of the schema rather than required attribute of the parameter.

This PR addresses fixes it.

ℹ️  without `bravado_core/param.py` changes the added tests fail :)