### PR TITLE
Use json references instead of swagger path

### DIFF
--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -193,7 +193,12 @@ def _collect_models(container, json_reference, models, swagger_spec):
         model_name = _get_model_name(container)
         model_type = models.get(model_name)
         if not model_type:
-            models[model_name] = create_model_type(swagger_spec, model_name, model_spec)
+            models[model_name] = create_model_type(
+                swagger_spec=swagger_spec,
+                model_name=model_name,
+                model_spec=model_spec,
+                json_reference=re.sub('/{MODEL_MARKER}$'.format(MODEL_MARKER=MODEL_MARKER), '', json_reference),
+            )
         elif (
             # the condition with strip_xscope is the most selective check
             # but it implies memory allocation, so additional lightweight checks
@@ -557,7 +562,7 @@ class ModelDocstring(object):
         return cls.__docstring__
 
 
-def create_model_type(swagger_spec, model_name, model_spec, bases=(Model,)):
+def create_model_type(swagger_spec, model_name, model_spec, bases=(Model,), json_reference=None):
     """Create a dynamic class from the model data defined in the swagger
     spec.
 
@@ -587,6 +592,7 @@ def create_model_type(swagger_spec, model_name, model_spec, bases=(Model,)):
         _model_spec=model_spec,
         _properties=collapsed_properties(model_spec, swagger_spec),
         _inherits_from=inherits_from,
+        _json_reference=json_reference,
     ))
 
 

--- a/bravado_core/spec_flattening.py
+++ b/bravado_core/spec_flattening.py
@@ -8,7 +8,6 @@ from collections import defaultdict
 from six import iteritems
 from six import iterkeys
 from six import itervalues
-from six.moves.urllib.parse import urljoin
 from six.moves.urllib.parse import urlparse
 from six.moves.urllib.parse import urlunparse
 from six.moves.urllib_parse import ParseResult
@@ -253,7 +252,7 @@ def flattened_spec(swagger_spec, marshal_uri_function=_marshal_uri):
         for model_name, model_type in iteritems(swagger_spec.definitions):
             if model_name in flatten_models:
                 continue
-            model_url = urlparse(urljoin(spec_url, '#/definitions/{}'.format(model_name)))
+            model_url = urlparse(model_type._json_reference)
             known_mappings['definitions'][model_url] = descend(value=model_type._model_spec)
 
     for mapping_key, mappings in iteritems(known_mappings):

--- a/test-data/2.0/multi-file-multi-directory-spec/flattened-multi-file-multi-directory-spec.json
+++ b/test-data/2.0/multi-file-multi-directory-spec/flattened-multi-file-multi-directory-spec.json
@@ -1,187 +1,187 @@
 {
-    "consumes": [
-        "application/json"
-    ],
-    "definitions": {
-        "lfile:definitions.yaml|..ErrorResponse": {
-            "properties": {
-                "error_code": {
-                    "description": "Machine-friendly error code",
-                    "type": "string"
-                },
-                "error_description": {
-                    "description": "Human-friendly error code",
-                    "type": "string"
+  "consumes": [
+    "application/json"
+  ],
+  "definitions": {
+    "lfile:definitions.yaml|..DebugErrorResponse": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/lfile:definitions.yaml|..ErrorResponse"
+        },
+        {
+          "properties": {
+            "stacktrace": {
+              "description": "Stringified stacktrace",
+              "type": "string"
+            }
+          }
+        }
+      ],
+      "type": "object",
+      "x-model": "DebugErrorResponse"
+    },
+    "lfile:definitions.yaml|..ErrorResponse": {
+      "properties": {
+        "error_code": {
+          "description": "Machine-friendly error code",
+          "type": "string"
+        },
+        "error_description": {
+          "description": "Human-friendly error code",
+          "type": "string"
+        }
+      },
+      "required": [
+        "error_code"
+      ],
+      "type": "object",
+      "x-derived-objects": [
+        {
+          "allOf": [
+            {
+              "$ref": "#/definitions/lfile:definitions.yaml|..ErrorResponse"
+            },
+            {
+              "properties": {
+                "error_specific_to_this_endpoint": {
+                  "type": "string"
                 }
+              }
+            }
+          ]
+        }
+      ],
+      "x-model": "ErrorResponse"
+    },
+    "lfile:endpoint..v1..responses.yaml|..200..schema": {
+      "type": "object",
+      "x-model": "endpoint_v1_HTTP_OK"
+    },
+    "lfile:endpoint..v1..responses.yaml|..403..schema": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/lfile:definitions.yaml|..ErrorResponse"
+        },
+        {
+          "properties": {
+            "action": {
+              "description": "name of the forbidden action",
+              "type": "string"
+            }
+          },
+          "required": [
+            "action"
+          ],
+          "type": "object",
+          "x-model": "endpoint_v1_HTTP_FORBIDDEN_action_part"
+        }
+      ],
+      "type": "object",
+      "x-model": "endpoint_v1_HTTP_FORBIDDEN"
+    },
+    "lfile:endpoint..v1..responses.yaml|..403..schema..allOf..1": {
+      "properties": {
+        "action": {
+          "description": "name of the forbidden action",
+          "type": "string"
+        }
+      },
+      "required": [
+        "action"
+      ],
+      "type": "object",
+      "x-model": "endpoint_v1_HTTP_FORBIDDEN_action_part"
+    }
+  },
+  "info": {
+    "title": "Consumer Mobile API v2 Service",
+    "version": "1.46.0"
+  },
+  "parameters": {
+    "lfile:endpoint..parameters.yaml|..parameters..number": {
+      "in": "query",
+      "name": "number",
+      "required": false,
+      "type": "integer"
+    }
+  },
+  "paths": {
+    "/endpoint/v1": {
+      "get": {
+        "description": "This is the description of a random get endpoint",
+        "operationId": "endpoint_v1",
+        "parameters": [
+          {
+            "$ref": "#/parameters/lfile:endpoint..parameters.yaml|..parameters..number"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/lfile:endpoint..v1..responses.yaml|..200"
+          },
+          "403": {
+            "$ref": "#/responses/lfile:endpoint..v1..responses.yaml|..403"
+          },
+          "default": {
+            "$ref": "#/responses/lfile:endpoint..v1..responses.yaml|..default"
+          }
+        }
+      }
+    }
+  },
+  "produces": [
+    "application/json"
+  ],
+  "responses": {
+    "lfile:endpoint..v1..responses.yaml|..200": {
+      "description": "HTTP/200",
+      "schema": {
+        "type": "object",
+        "x-model": "endpoint_v1_HTTP_OK"
+      }
+    },
+    "lfile:endpoint..v1..responses.yaml|..403": {
+      "description": "HTTP/403",
+      "schema": {
+        "allOf": [
+          {
+            "$ref": "#/definitions/lfile:definitions.yaml|..ErrorResponse"
+          },
+          {
+            "properties": {
+              "action": {
+                "description": "name of the forbidden action",
+                "type": "string"
+              }
             },
             "required": [
-                "error_code"
-            ],
-            "type": "object",
-            "x-derived-objects": [
-                {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/lfile:definitions.yaml|..ErrorResponse"
-                        },
-                        {
-                            "properties": {
-                                "error_specific_to_this_endpoint": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    ]
-                }
-            ],
-            "x-model": "ErrorResponse"
-        },
-        "lfile:swagger.yaml|..definitions..DebugErrorResponse": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/lfile:definitions.yaml|..ErrorResponse"
-                },
-                {
-                    "properties": {
-                        "stacktrace": {
-                            "description": "Stringified stacktrace",
-                            "type": "string"
-                        }
-                    }
-                }
-            ],
-            "type": "object",
-            "x-model": "DebugErrorResponse"
-        },
-        "lfile:swagger.yaml|..definitions..endpoint_v1_HTTP_FORBIDDEN": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/lfile:definitions.yaml|..ErrorResponse"
-                },
-                {
-                    "properties": {
-                        "action": {
-                            "description": "name of the forbidden action",
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "action"
-                    ],
-                    "type": "object",
-                    "x-model": "endpoint_v1_HTTP_FORBIDDEN_action_part"
-                }
-            ],
-            "type": "object",
-            "x-model": "endpoint_v1_HTTP_FORBIDDEN"
-        },
-        "lfile:swagger.yaml|..definitions..endpoint_v1_HTTP_FORBIDDEN_action_part": {
-            "properties": {
-                "action": {
-                    "description": "name of the forbidden action",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "action"
+              "action"
             ],
             "type": "object",
             "x-model": "endpoint_v1_HTTP_FORBIDDEN_action_part"
-        },
-        "lfile:swagger.yaml|..definitions..endpoint_v1_HTTP_OK": {
-            "type": "object",
-            "x-model": "endpoint_v1_HTTP_OK"
-        }
+          }
+        ],
+        "type": "object",
+        "x-model": "endpoint_v1_HTTP_FORBIDDEN"
+      }
     },
-    "info": {
-        "title": "Consumer Mobile API v2 Service",
-        "version": "1.46.0"
-    },
-    "parameters": {
-        "lfile:endpoint..parameters.yaml|..parameters..number": {
-            "in": "query",
-            "name": "number",
-            "required": false,
-            "type": "integer"
-        }
-    },
-    "paths": {
-        "/endpoint/v1": {
-            "get": {
-                "description": "This is the description of a random get endpoint",
-                "operationId": "endpoint_v1",
-                "parameters": [
-                    {
-                        "$ref": "#/parameters/lfile:endpoint..parameters.yaml|..parameters..number"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "$ref": "#/responses/lfile:endpoint..v1..responses.yaml|..200"
-                    },
-                    "403": {
-                        "$ref": "#/responses/lfile:endpoint..v1..responses.yaml|..403"
-                    },
-                    "default": {
-                        "$ref": "#/responses/lfile:endpoint..v1..responses.yaml|..default"
-                    }
-                }
+    "lfile:endpoint..v1..responses.yaml|..default": {
+      "description": "Unplanned status code",
+      "schema": {
+        "allOf": [
+          {
+            "$ref": "#/definitions/lfile:definitions.yaml|..ErrorResponse"
+          },
+          {
+            "properties": {
+              "error_specific_to_this_endpoint": {
+                "type": "string"
+              }
             }
-        }
-    },
-    "produces": [
-        "application/json"
-    ],
-    "responses": {
-        "lfile:endpoint..v1..responses.yaml|..200": {
-            "description": "HTTP/200",
-            "schema": {
-                "type": "object",
-                "x-model": "endpoint_v1_HTTP_OK"
-            }
-        },
-        "lfile:endpoint..v1..responses.yaml|..403": {
-            "description": "HTTP/403",
-            "schema": {
-                "allOf": [
-                    {
-                        "$ref": "#/definitions/lfile:definitions.yaml|..ErrorResponse"
-                    },
-                    {
-                        "properties": {
-                            "action": {
-                                "description": "name of the forbidden action",
-                                "type": "string"
-                            }
-                        },
-                        "required": [
-                            "action"
-                        ],
-                        "type": "object",
-                        "x-model": "endpoint_v1_HTTP_FORBIDDEN_action_part"
-                    }
-                ],
-                "type": "object",
-                "x-model": "endpoint_v1_HTTP_FORBIDDEN"
-            }
-        },
-        "lfile:endpoint..v1..responses.yaml|..default": {
-            "description": "Unplanned status code",
-            "schema": {
-                "allOf": [
-                    {
-                        "$ref": "#/definitions/lfile:definitions.yaml|..ErrorResponse"
-                    },
-                    {
-                        "properties": {
-                            "error_specific_to_this_endpoint": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                ]
-            }
-        }
-    },
-    "swagger": "2.0"
+          }
+        ]
+      }
+    }
+  },
+  "swagger": "2.0"
 }

--- a/test-data/2.0/multi-file-specs-with-no-x-model/flattened-multi-file-with-no-xmodel.json
+++ b/test-data/2.0/multi-file-specs-with-no-x-model/flattened-multi-file-with-no-xmodel.json
@@ -1,16 +1,10 @@
 {
-  "swagger": "2.0",
-  "info": {
-    "title": "Test",
-    "version": "1.0"
-  },
-  "paths": {},
   "definitions": {
     "lfile:aux.json|..definitions..referenced_object": {
       "type": "object",
       "x-model": "lfile:aux.json|..definitions..referenced_object"
     },
-    "lfile:swagger.json|..definitions..object..x-model": {
+    "lfile:swagger.json|..definitions..object": {
       "properties": {
         "property": {
           "$ref": "#/definitions/lfile:aux.json|..definitions..referenced_object"
@@ -19,5 +13,11 @@
       "type": "object",
       "x-model": "object"
     }
-  }
+  },
+  "info": {
+    "title": "Test",
+    "version": "1.0"
+  },
+  "paths": {},
+  "swagger": "2.0"
 }

--- a/test-data/2.0/multi-file-specs-with-no-x-model/flattened-multi-file-with-no-xmodel.json
+++ b/test-data/2.0/multi-file-specs-with-no-x-model/flattened-multi-file-with-no-xmodel.json
@@ -10,7 +10,7 @@
       "type": "object",
       "x-model": "lfile:aux.json|..definitions..referenced_object"
     },
-    "lfile:swagger.json|..definitions..object": {
+    "lfile:swagger.json|..definitions..object..x-model": {
       "properties": {
         "property": {
           "$ref": "#/definitions/lfile:aux.json|..definitions..referenced_object"

--- a/tests/model/bless_models_test.py
+++ b/tests/model/bless_models_test.py
@@ -24,6 +24,7 @@ def test_bless_models_short_circuit_if_no_dict_like_container(mock_is_dict_like,
         ['paths', '/endpoint', 'post', 'responses', '200'],
         visited_models={},
         swagger_spec=swagger_spec,
+        json_reference=None,
     )
     mock_is_dict_like.assert_called_once_with(minimal_swagger_dict['paths']['/endpoint']['post']['responses']['200'])
 
@@ -60,6 +61,7 @@ def test_bless_models_gets_out_if_initial_pre_conditions_are_not_met(
         ['paths', '/endpoint', 'post', 'responses', '200'],
         visited_models={},
         swagger_spec=swagger_spec,
+        json_reference=None,
     )
     assert mock__get_model_name.call_count == 0
 
@@ -88,6 +90,7 @@ def test_bless_model_adds_model_marker(minimal_swagger_dict):
         ['paths', '/endpoint', 'post', 'responses', '200'],
         visited_models={},
         swagger_spec=swagger_spec,
+        json_reference=None,
     )
     assert response_schema.get('x-model') == response_schema['title']
 
@@ -115,5 +118,6 @@ def test_bless_model_does_not_generate_model_tag_if_no_title_is_set(minimal_swag
         ['paths', '/endpoint', 'post', 'responses', '200'],
         visited_models={},
         swagger_spec=swagger_spec,
+        json_reference=None,
     )
     assert 'x-model' not in response_schema

--- a/tests/model/bless_models_test.py
+++ b/tests/model/bless_models_test.py
@@ -20,11 +20,9 @@ def test_bless_models_short_circuit_if_no_dict_like_container(mock_is_dict_like,
     swagger_spec = Spec(minimal_swagger_dict)
     _bless_models(
         minimal_swagger_dict['paths']['/endpoint']['post']['responses']['200'],
-        'schema',
-        ['paths', '/endpoint', 'post', 'responses', '200'],
         visited_models={},
         swagger_spec=swagger_spec,
-        json_reference=None,
+        json_reference='#/paths//endpoint/post/responses/200/schema',
     )
     mock_is_dict_like.assert_called_once_with(minimal_swagger_dict['paths']['/endpoint']['post']['responses']['200'])
 
@@ -57,11 +55,9 @@ def test_bless_models_gets_out_if_initial_pre_conditions_are_not_met(
     swagger_spec = Spec(minimal_swagger_dict)
     _bless_models(
         minimal_swagger_dict['paths']['/endpoint']['post']['responses']['200'],
-        'schema',
-        ['paths', '/endpoint', 'post', 'responses', '200'],
         visited_models={},
         swagger_spec=swagger_spec,
-        json_reference=None,
+        json_reference='#/paths//endpoint/post/responses/200',
     )
     assert mock__get_model_name.call_count == 0
 
@@ -86,11 +82,9 @@ def test_bless_model_adds_model_marker(minimal_swagger_dict):
     swagger_spec = Spec(minimal_swagger_dict)
     _bless_models(
         minimal_swagger_dict['paths']['/endpoint']['post']['responses']['200'],
-        'schema',
-        ['paths', '/endpoint', 'post', 'responses', '200'],
         visited_models={},
         swagger_spec=swagger_spec,
-        json_reference=None,
+        json_reference='#/paths//endpoint/post/responses/200/schema',
     )
     assert response_schema.get('x-model') == response_schema['title']
 
@@ -114,10 +108,8 @@ def test_bless_model_does_not_generate_model_tag_if_no_title_is_set(minimal_swag
     swagger_spec = Spec(minimal_swagger_dict)
     _bless_models(
         minimal_swagger_dict['paths']['/endpoint']['post']['responses']['200'],
-        'schema',
-        ['paths', '/endpoint', 'post', 'responses', '200'],
         visited_models={},
         swagger_spec=swagger_spec,
-        json_reference=None,
+        json_reference='#/paths//endpoint/post/responses/200',
     )
     assert 'x-model' not in response_schema

--- a/tests/model/collect_models_test.py
+++ b/tests/model/collect_models_test.py
@@ -25,11 +25,9 @@ def test_simple(minimal_swagger_dict, pet_model_spec):
     models = {}
     _collect_models(
         minimal_swagger_dict['definitions']['Pet'],
-        'x-model',
-        ['definitions', 'Pet', 'x-model'],
         models=models,
         swagger_spec=swagger_spec,
-        json_reference='origin_url#/definitions/Pet/x-model',
+        json_reference='#/definitions/Pet/x-model',
     )
     assert 'Pet' in models
 
@@ -56,11 +54,9 @@ def test_no_model_type_generation_for_not_object_type(minimal_swagger_dict):
     models = {}
     _collect_models(
         minimal_swagger_dict['definitions']['Pets'],
-        'x-model',
-        ['definitions', 'Pets', 'x-model'],
         models=models,
         swagger_spec=swagger_spec,
-        json_reference=None,
+        json_reference='#/definitions/Pets/x-model',
     )
     assert 'Pets' not in models
 
@@ -76,19 +72,21 @@ def test_raise_error_if_duplicate_models_are_identified(minimal_swagger_dict, pe
             model_spec={},
         )
     }
-    path = ['definitions', model_name, 'x-model'],
+
+    json_reference = '#/definitions/{model_name}/x-model'.format(model_name=model_name)
     with pytest.raises(ValueError) as excinfo:
         _collect_models(
             minimal_swagger_dict['definitions'][model_name],
-            'x-model',
-            path,
             models=models,
             swagger_spec=swagger_spec,
-            json_reference=None,
+            json_reference=json_reference,
         )
 
     expected_lines = [
-        'Identified duplicated model: model_name "{mod_name}", path: {path}.'.format(mod_name=model_name, path=path),
+        'Identified duplicated model: model_name "{mod_name}", uri: {json_reference}.'.format(
+            mod_name=model_name,
+            json_reference=json_reference,
+        ),
         'Known model spec: "{}"',
         'New model spec: "{pet_model_spec}"'.format(pet_model_spec=pet_model_spec),
         'TIP: enforce different model naming by using {MODEL_MARKER}'.format(MODEL_MARKER='x-model'),

--- a/tests/model/collect_models_test.py
+++ b/tests/model/collect_models_test.py
@@ -30,6 +30,7 @@ def test_simple(minimal_swagger_dict, pet_model_spec):
         json_reference='#/definitions/Pet/x-model',
     )
     assert 'Pet' in models
+    assert models['Pet']._json_reference == '#/definitions/Pet'
 
 
 def test_no_model_type_generation_for_not_object_type(minimal_swagger_dict):

--- a/tests/model/collect_models_test.py
+++ b/tests/model/collect_models_test.py
@@ -29,6 +29,7 @@ def test_simple(minimal_swagger_dict, pet_model_spec):
         ['definitions', 'Pet', 'x-model'],
         models=models,
         swagger_spec=swagger_spec,
+        json_reference='origin_url#/definitions/Pet/x-model',
     )
     assert 'Pet' in models
 
@@ -59,6 +60,7 @@ def test_no_model_type_generation_for_not_object_type(minimal_swagger_dict):
         ['definitions', 'Pets', 'x-model'],
         models=models,
         swagger_spec=swagger_spec,
+        json_reference=None,
     )
     assert 'Pets' not in models
 
@@ -82,6 +84,7 @@ def test_raise_error_if_duplicate_models_are_identified(minimal_swagger_dict, pe
             path,
             models=models,
             swagger_spec=swagger_spec,
+            json_reference=None,
         )
 
     expected_lines = [

--- a/tests/model/model_discovery_test.py
+++ b/tests/model/model_discovery_test.py
@@ -24,6 +24,7 @@ def test_model_discovery_flow_with_ref_dereference(mock__run_post_processing, mi
         config={
             'internally_dereference_refs': True,
         },
+        origin_url='',
     )
     model_discovery(swagger_spec=spec)
 

--- a/tests/model/post_process_spec_test.py
+++ b/tests/model/post_process_spec_test.py
@@ -28,7 +28,7 @@ def test_single_key():
         on_container_callbacks=[callback],
     )
     assert callback.call_count == 1
-    callback.assert_called_once_with(spec_dict, 'definitions', ['definitions'], json_reference='#/definitions')
+    callback.assert_called_once_with(spec_dict, '#/definitions')
 
 
 def test_visits_refs_only_once():
@@ -43,9 +43,9 @@ def test_visits_refs_only_once():
     # Yech! mock doesn't make this easy
     mutable = {'cnt': 0}
 
-    def callback(container, key, path, mutable, json_reference):
+    def callback(container, json_reference, mutable):
         # Bump the mutable counter every time bar is de-reffed
-        if key == 'bar':
+        if json_reference.endswith('/bar'):
             mutable['cnt'] += 1
 
     _post_process_spec(

--- a/tests/model/post_process_spec_test.py
+++ b/tests/model/post_process_spec_test.py
@@ -28,7 +28,7 @@ def test_single_key():
         on_container_callbacks=[callback],
     )
     assert callback.call_count == 1
-    callback.assert_called_once_with(spec_dict, 'definitions', ['definitions'])
+    callback.assert_called_once_with(spec_dict, 'definitions', ['definitions'], json_reference='#/definitions')
 
 
 def test_visits_refs_only_once():
@@ -43,7 +43,7 @@ def test_visits_refs_only_once():
     # Yech! mock doesn't make this easy
     mutable = {'cnt': 0}
 
-    def callback(container, key, path, mutable):
+    def callback(container, key, path, mutable, json_reference):
         # Bump the mutable counter every time bar is de-reffed
         if key == 'bar':
             mutable['cnt'] += 1

--- a/tests/model/tag_models_test.py
+++ b/tests/model/tag_models_test.py
@@ -27,7 +27,9 @@ def test_tags_model(minimal_swagger_dict, pet_model_spec):
         'Pet',
         ['definitions', 'Pet'],
         visited_models={},
-        swagger_spec=swagger_spec)
+        swagger_spec=swagger_spec,
+        json_reference=None,
+    )
     assert pet_model_spec['x-model'] == 'Pet'
 
 
@@ -40,7 +42,9 @@ def test_type_missing(minimal_swagger_dict, pet_model_spec):
         'Pet',
         ['definitions', 'Pet'],
         visited_models={},
-        swagger_spec=swagger_spec)
+        swagger_spec=swagger_spec,
+        json_reference=None,
+    )
     assert 'x-model' not in pet_model_spec
 
 
@@ -57,7 +61,9 @@ def test_model_not_object(minimal_swagger_dict):
         'Pet',
         ['definitions', 'Pet'],
         visited_models={},
-        swagger_spec=swagger_spec)
+        swagger_spec=swagger_spec,
+        json_reference=None,
+    )
     assert 'x-model' not in minimal_swagger_dict['definitions']['Pet']
 
 
@@ -69,7 +75,9 @@ def test_path_too_short(minimal_swagger_dict, pet_model_spec):
         'definitions',
         ['definitions'],
         visited_models={},
-        swagger_spec=swagger_spec)
+        swagger_spec=swagger_spec,
+        json_reference=None,
+    )
     assert 'x-model' not in pet_model_spec
 
 
@@ -90,6 +98,7 @@ def test_duplicate_model(mock_log, minimal_swagger_dict, pet_model_spec, use_mod
             ['definitions', 'Pet'],
             visited_models={'Pet': ['definitions', 'Pet']},
             swagger_spec=swagger_spec,
+            json_reference=None,
         )
     except ValueError as e:
         raised_exception = e
@@ -111,5 +120,7 @@ def test_skip_already_tagged_models(minimal_swagger_dict, pet_model_spec):
         'Pet',
         ['definitions', 'Pet'],
         visited_models={},
-        swagger_spec=swagger_spec)
+        swagger_spec=swagger_spec,
+        json_reference=None,
+    )
     assert pet_model_spec['x-model'] == 'SpecialPet'

--- a/tests/model/tag_models_test.py
+++ b/tests/model/tag_models_test.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import copy
+
 import mock
 import pytest
 
@@ -24,11 +26,9 @@ def test_tags_model(minimal_swagger_dict, pet_model_spec):
     swagger_spec = Spec(minimal_swagger_dict)
     _tag_models(
         minimal_swagger_dict['definitions'],
-        'Pet',
-        ['definitions', 'Pet'],
         visited_models={},
         swagger_spec=swagger_spec,
-        json_reference=None,
+        json_reference='#/definitions/Pet',
     )
     assert pet_model_spec['x-model'] == 'Pet'
 
@@ -39,11 +39,9 @@ def test_type_missing(minimal_swagger_dict, pet_model_spec):
     swagger_spec = Spec(minimal_swagger_dict)
     _tag_models(
         minimal_swagger_dict['definitions'],
-        'Pet',
-        ['definitions', 'Pet'],
         visited_models={},
         swagger_spec=swagger_spec,
-        json_reference=None,
+        json_reference='#/definitions/Pet',
     )
     assert 'x-model' not in pet_model_spec
 
@@ -58,11 +56,9 @@ def test_model_not_object(minimal_swagger_dict):
     swagger_spec = Spec(minimal_swagger_dict)
     _tag_models(
         minimal_swagger_dict['definitions'],
-        'Pet',
-        ['definitions', 'Pet'],
         visited_models={},
         swagger_spec=swagger_spec,
-        json_reference=None,
+        json_reference='#/definitions/Pet',
     )
     assert 'x-model' not in minimal_swagger_dict['definitions']['Pet']
 
@@ -72,11 +68,9 @@ def test_path_too_short(minimal_swagger_dict, pet_model_spec):
     swagger_spec = Spec(minimal_swagger_dict)
     _tag_models(
         minimal_swagger_dict,
-        'definitions',
-        ['definitions'],
         visited_models={},
         swagger_spec=swagger_spec,
-        json_reference=None,
+        json_reference='#/definitions',
     )
     assert 'x-model' not in pet_model_spec
 
@@ -84,21 +78,20 @@ def test_path_too_short(minimal_swagger_dict, pet_model_spec):
 @pytest.mark.parametrize('use_models', [True, False])
 @mock.patch.object(model, 'log', autospec=True)
 def test_duplicate_model(mock_log, minimal_swagger_dict, pet_model_spec, use_models):
-    minimal_swagger_dict['definitions']['Pet'] = pet_model_spec
+    minimal_swagger_dict['definitions']['DuplicatedPet'] = copy.deepcopy(pet_model_spec)
+    minimal_swagger_dict['definitions']['Pet'] = copy.deepcopy(pet_model_spec)
     swagger_spec = Spec(minimal_swagger_dict, config={'use_models': use_models})
 
-    duplicate_message = 'Duplicate "Pet" model found at path [\'definitions\', \'Pet\']. ' \
-                        'Original "Pet" model at path [\'definitions\', \'Pet\']'
+    duplicate_message = 'Duplicate "Pet" model found at "#/definitions/Pet". ' \
+                        'Original "Pet" model at "#/definitions/DuplicatedPet"'
 
     raised_exception = None
     try:
         _tag_models(
             minimal_swagger_dict['definitions'],
-            'Pet',
-            ['definitions', 'Pet'],
-            visited_models={'Pet': ['definitions', 'Pet']},
+            visited_models={'Pet': '#/definitions/DuplicatedPet'},
             swagger_spec=swagger_spec,
-            json_reference=None,
+            json_reference='#/definitions/Pet',
         )
     except ValueError as e:
         raised_exception = e
@@ -117,10 +110,8 @@ def test_skip_already_tagged_models(minimal_swagger_dict, pet_model_spec):
     swagger_spec = Spec(minimal_swagger_dict)
     _tag_models(
         minimal_swagger_dict['definitions'],
-        'Pet',
-        ['definitions', 'Pet'],
         visited_models={},
         swagger_spec=swagger_spec,
-        json_reference=None,
+        json_reference='#/definitions/Pet',
     )
     assert pet_model_spec['x-model'] == 'SpecialPet'

--- a/tests/spec/Spec/build_test.py
+++ b/tests/spec/Spec/build_test.py
@@ -159,10 +159,10 @@ def test_build_raises_in_case_of_duplicated_models_in_definitions(minimal_swagge
         Spec.from_dict(minimal_swagger_dict)
 
     expected_exception_string = (
-        'Duplicate "model" model found at path {new_path}. '
-        'Original "model" model at path {old_path}'.format(
-            new_path=['definitions', 'model'],
-            old_path=['definitions', 'duplicated_model'],
+        'Duplicate "model" model found at "{new_json_reference}". '
+        'Original "model" model at "{old_json_reference}"'.format(
+            new_json_reference='#/definitions/model',
+            old_json_reference='#/definitions/duplicated_model',
         )
     )
     assert expected_exception_string == str(exinfo.value)
@@ -202,7 +202,7 @@ def test_build_raises_in_case_of_duplicated_models_in_paths(minimal_swagger_dict
 
     # NOTE: the exception depends on the descending order
     expected_exception_string = (
-        'Identified duplicated model: model_name "{mod_name}", path: {path}.\n'
+        'Identified duplicated model: model_name "{mod_name}", uri: {json_reference}.\n'
         '    Known model spec: "{known_model}"\n'
         '    New model spec: "{new_model}"\n'
         'TIP: enforce different model naming by using {MODEL_MARKER}'.format(
@@ -210,7 +210,7 @@ def test_build_raises_in_case_of_duplicated_models_in_paths(minimal_swagger_dict
             mod_name=model_name,
             MODEL_MARKER='x-model',
             new_model=model_201,
-            path=['paths', '/endpoint', 'get', 'responses', '201', 'schema', 'x-model'],
+            json_reference='#/paths//endpoint/get/responses/201/schema/x-model',
         )
     )
 
@@ -249,7 +249,7 @@ def test_build_raises_in_case_of_duplicated_models_between_paths_and_definitions
 
     # NOTE: the exception depends on the descending order
     expected_exception_string = (
-        'Identified duplicated model: model_name "{mod_name}", path: {path}.\n'
+        'Identified duplicated model: model_name "{mod_name}", uri: {json_reference}.\n'
         '    Known model spec: "{known_model}"\n'
         '    New model spec: "{new_model}"\n'
         'TIP: enforce different model naming by using {MODEL_MARKER}'.format(
@@ -257,7 +257,7 @@ def test_build_raises_in_case_of_duplicated_models_between_paths_and_definitions
             mod_name=model_name,
             MODEL_MARKER='x-model',
             new_model=response_model,
-            path=['paths', '/endpoint', 'get', 'responses', '200', 'schema', 'x-model'],
+            json_reference='#/paths//endpoint/get/responses/200/schema/x-model'
         )
     )
 


### PR DESCRIPTION
The goal of this PR is to replace `path` with `json_reference` during model discovery.
The change allows to:
 * simplify the identification of models that are under `[any-file]#/definitions`
NOTE: an additional PR will be provided to get models from all linked files (as affirmed in documentation)
 * improve exceptions in case of duplicated models as they will not contain the paths in swagger specs but the _real_ references on files (extremely useful in case of multi file spec)
