### PR TITLE
Get models from definitions of referred files

### DIFF
--- a/test-data/2.0/multi-file-recursive/aux.json
+++ b/test-data/2.0/multi-file-recursive/aux.json
@@ -17,6 +17,11 @@
         },
         "not_used_remote_reference": {
             "type": "object",
+            "properties": {
+                "random_number": {
+                    "$ref": "aux_2.json#/definitions/random_integer"
+                }
+            },
             "x-model": "not_used_remote_reference"
         }
     },

--- a/test-data/2.0/multi-file-recursive/aux_2.json
+++ b/test-data/2.0/multi-file-recursive/aux_2.json
@@ -1,0 +1,21 @@
+{
+    "definitions": {
+        "not_referenced_models_in_not_direcly_linked_file": {
+            "type": "object"
+        },
+        "random_integer": {
+            "type": "object",
+            "properties": {
+                "value": {
+                    "type": "integer"
+                },
+                "min-value": {
+                    "type": "integer"
+                },
+                "max-value": {
+                    "type": "integer"
+                }
+            }
+        }
+    }
+}

--- a/test-data/2.0/multi-file-recursive/flattened-multi-file-recursive-spec.json
+++ b/test-data/2.0/multi-file-recursive/flattened-multi-file-recursive-spec.json
@@ -1,6 +1,11 @@
 {
   "definitions": {
     "lfile:aux.json|..definitions..not_used_remote_reference": {
+      "properties": {
+        "random_number": {
+          "$ref": "#/definitions/lfile:aux_2.json|..definitions..random_integer"
+        }
+      },
       "type": "object",
       "x-model": "not_used_remote_reference"
     },
@@ -18,6 +23,25 @@
       ],
       "type": "object",
       "x-model": "ping"
+    },
+    "lfile:aux_2.json|..definitions..not_referenced_models_in_not_direcly_linked_file": {
+      "type": "object",
+      "x-model": "not_referenced_models_in_not_direcly_linked_file"
+    },
+    "lfile:aux_2.json|..definitions..random_integer": {
+      "properties": {
+        "max-value": {
+          "type": "integer"
+        },
+        "min-value": {
+          "type": "integer"
+        },
+        "value": {
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "x-model": "random_integer"
     },
     "lfile:swagger.json|..definitions..model_with_allOf_recursive": {
       "allOf": [
@@ -39,11 +63,6 @@
       "x-model": "model_with_allOf_recursive"
     },
     "lfile:swagger.json|..definitions..not_used": {
-      "properties": {
-        "not_used_remote_reference": {
-          "$ref": "#/definitions/lfile:aux.json|..definitions..not_used_remote_reference"
-        }
-      },
       "type": "object",
       "x-model": "not_used"
     },

--- a/test-data/2.0/multi-file-recursive/swagger.json
+++ b/test-data/2.0/multi-file-recursive/swagger.json
@@ -21,11 +21,6 @@
         },
         "not_used": {
             "type": "object",
-            "properties": {
-                "not_used_remote_reference": {
-                    "$ref": "aux.json#/definitions/not_used_remote_reference"
-                }
-            },
             "x-model": "not_used"
         },
         "pong": {

--- a/test-data/2.0/multi-file-specs-with-no-x-model/flattened-multi-file-with-no-xmodel.json
+++ b/test-data/2.0/multi-file-specs-with-no-x-model/flattened-multi-file-with-no-xmodel.json
@@ -2,7 +2,7 @@
   "definitions": {
     "lfile:aux.json|..definitions..referenced_object": {
       "type": "object",
-      "x-model": "lfile:aux.json|..definitions..referenced_object"
+      "x-model": "referenced_object"
     },
     "lfile:swagger.json|..definitions..object": {
       "properties": {

--- a/tests/model/collect_models_test.py
+++ b/tests/model/collect_models_test.py
@@ -19,18 +19,22 @@ def pet_model_spec():
     }
 
 
-def test_simple(minimal_swagger_dict, pet_model_spec):
+@pytest.mark.parametrize(
+    'origin_url', [None, 'origin_url'],
+)
+def test_simple(minimal_swagger_dict, pet_model_spec, origin_url):
     minimal_swagger_dict['definitions']['Pet'] = pet_model_spec
-    swagger_spec = Spec(minimal_swagger_dict)
+    swagger_spec = Spec(minimal_swagger_dict, origin_url=origin_url)
     models = {}
+    json_reference = '{}#/definitions/Pet'.format(origin_url or '')
     _collect_models(
         minimal_swagger_dict['definitions']['Pet'],
         models=models,
         swagger_spec=swagger_spec,
-        json_reference='#/definitions/Pet/x-model',
+        json_reference=json_reference + '/x-model',
     )
     assert 'Pet' in models
-    assert models['Pet']._json_reference == '#/definitions/Pet'
+    assert models['Pet']._json_reference == json_reference
 
 
 def test_no_model_type_generation_for_not_object_type(minimal_swagger_dict):


### PR DESCRIPTION
The goal of this PR is to make bravado-core compliant with its own documentation :)
[Model discovery point 2](http://bravado-core.readthedocs.io/en/latest/models.html#model-discovery) states
> Search for refs that refer to external definitions with pattern `<filename>#/definitions/<model name>`

The current implementation was not fully scanning all the referenced files.
This PR achieves the goal of scanning over all the referred files during model discovery process by keeping track of the already fully scanned files.

**Potential issues**
I might be too pessimistic / paranoid but I prefer to make it "public" as early as possible
As we'll start to fully scan (and follow possible references) the referenced files we could end up in some endless process.
A possible example of the mentioned issue is:
 * file1: `{"definitions": {"def": {"$ref": "file2#/definitions/def"}}}`
 * fileX: `{"definitions": {"def": {"$ref": "file<X+1>#/definitions/def"}}}`

Do you have any concern about this potential issue?