### PR TITLE
Allow extra configs so tools built on top of bravado-core can use them

### DIFF
--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -127,22 +127,12 @@ class Spec(object):
     def _validate_config(self):
         """
         Validates the correctness of the configurations injected and makes sure that:
-        - no extra config keys are available on the config dictionary
         - dependent configs are checked
 
         :return: True if the initial configs are valid, False otherwise
         :rtype: bool
         """
         are_config_changed = False
-
-        extraneous_keys = set(iterkeys(self.config)) - set(iterkeys(CONFIG_DEFAULTS))
-        if extraneous_keys:
-            are_config_changed = True
-            for key in extraneous_keys:
-                warnings.warn(
-                    message='config {} is not a recognized config key'.format(key),
-                    category=Warning,
-                )
 
         if self.config['internally_dereference_refs'] and not self.config['validate_swagger_spec']:
             are_config_changed = True

--- a/tests/spec/validate_config_test.py
+++ b/tests/spec/validate_config_test.py
@@ -24,11 +24,6 @@ def test_validate_config_succeed(minimal_swagger_dict, minimal_swagger_abspath, 
     'config, expected_different_config, expected_warnings_call',
     [
         (
-            {'this_is_an_extra_key': True},
-            False,
-            'config this_is_an_extra_key is not a recognized config key',
-        ),
-        (
             {'validate_swagger_spec': False, 'internally_dereference_refs': True},
             True,
             'internally_dereference_refs config disabled because validate_swagger_spec has to be enabled',


### PR DESCRIPTION
Particularly, we'd like to introduce a few more configs to bravado, and reusing the bravado-core config store seems like a sensible idea.