### PR TITLE
Remove/reduce typos and remove build-in variable shadows

### DIFF
--- a/bravado_core/docstring.py
+++ b/bravado_core/docstring.py
@@ -14,7 +14,7 @@ def operation_docstring_wrapper(operation):
     Docstrings can only be specified for modules, classes, and functions. Hence,
     the docstring for an Operation is static as defined by the Operation class.
     To make the docstring for an Operation invocation work correctly, it has
-    to be masquaraded as a function. The docstring will then be attached to the
+    to be masqueraded as a function. The docstring will then be attached to the
     function which works quite nicely. Example in REPL:
 
     >> petstore = SwaggerClient.from_url('http://url_to_petstore/')
@@ -26,7 +26,7 @@ def operation_docstring_wrapper(operation):
     getPetById(**kwargs)
         [GET] Find pet by ID
 
-        Returns a pet when ID < 10.  ID > 10 or nonintegers will simulate API error conditions  # noqa
+        Returns a pet when ID < 10.  ID > 10 or non-integers will simulate API error conditions  # noqa
 
         :param petId: ID of pet that needs to be fetched
         :type petId: integer

--- a/bravado_core/exception.py
+++ b/bravado_core/exception.py
@@ -24,7 +24,7 @@ class MatchingResponseNotFound(SwaggerMappingError):
 
 class SwaggerValidationError(SwaggerMappingError):
     """Raised when an error is encountered during validating user defined
-    format values in a request or a resposne.
+    format values in a request or a response.
     """
 
 

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -374,24 +374,24 @@ class Model(object):
     def __getitem__(self, property_name):
         """Get a property value by name.
 
-        :type attr_name: str
+        :type property_name: str
         """
         return self.__dict[property_name]
 
     def __setitem__(self, property_name, val):
         """Set a property value by name.
 
-        :type attr_name: str
+        :type property_name: str
         """
         self.__dict[property_name] = val
 
     def __delitem__(self, property_name):
         """Unset a property by name.
 
-        Additional properties will be deleted alltogether. Properties defined
-        in the spec will be set to ``None``.
+        Properties defined in the spec will be set to ``None``.
+        Additional properties will be completely removed.
 
-        :type attr_name: str
+        :type property_name: str
         """
         if property_name in self._properties:
             self.__dict[property_name] = None
@@ -576,6 +576,8 @@ def create_model_type(swagger_spec, model_name, model_spec, bases=(Model,), json
     :param tuple bases: Base classes for type. At least one should be
         :class:`.Model` or a subclass of it.
     :returns: dynamic type inheriting from ``bases``.
+    :param json_reference: JSON Uri where model spec could be found
+    :type json_reference: str
     :rtype: type
     """
 
@@ -642,6 +644,7 @@ def create_model_docstring(swagger_spec, model_spec):
         attr_spec = deref(attr_spec)
         schema_type = deref(attr_spec['type'])
 
+        attr_type = None
         if schema_type in SWAGGER_PRIMITIVES:
             # TODO: update to python types and take 'format' into account
             attr_type = schema_type
@@ -742,7 +745,8 @@ def _post_process_spec(spec_dict, spec_resolver, on_container_callbacks):
     def descend(fragment, json_reference=None):
         """
         :param fragment: node in spec_dict
-        :param path: list of strings that form the current path to fragment
+        :param json_reference: JSON Uri where the current fragment could be found
+        :type json_reference: str
         """
         if is_dict_like(fragment):
             for key, value in sorted(iteritems(fragment)):

--- a/bravado_core/operation.py
+++ b/bravado_core/operation.py
@@ -16,7 +16,7 @@ log = logging.getLogger(__name__)
 def _sanitize_operation_id(operation_id, http_method, path_name):
     sanitized_operation_id = sanitize_name(operation_id or '')
 
-    # Handle crazy corner cases where someone explictily sets operation
+    # Handle crazy corner cases where someone explicitly sets operation
     # id a value that gets sanitized down to an empty string
     if len(sanitized_operation_id) == 0:
         # build based on the http method and request path

--- a/bravado_core/param.py
+++ b/bravado_core/param.py
@@ -252,8 +252,10 @@ def cast_request_param(param_type, param_name, param_value):
     try:
         return CAST_TYPE_TO_FUNC.get(param_type, lambda x: x)(param_value)
     except (ValueError, TypeError):
-        log.warn("Failed to cast %s value of %s to %s",
-                 param_name, param_value, param_type)
+        log.warning(
+            "Failed to cast %s value of %s to %s",
+            param_name, param_value, param_type,
+        )
         # Ignore type error, let jsonschema validation handle incorrect types
         return param_value
 
@@ -354,7 +356,7 @@ def unmarshal_collection_format(swagger_spec, param_spec, value):
     if schema.is_list_like(value):
         value_array = value
     elif collection_format == 'multi':
-        # http client lib should have already unmarshaled the value
+        # http client lib should have already unmarshalled the value
         value_array = [value]
     else:
         sep = COLLECTION_FORMATS[collection_format]

--- a/bravado_core/response.py
+++ b/bravado_core/response.py
@@ -99,10 +99,8 @@ def unmarshal_response(response, op):
     deref = op.swagger_spec.deref
     response_spec = get_response_spec(response.status_code, op)
 
-    def has_content(response_spec):
-        return 'schema' in response_spec
-
-    if not has_content(response_spec):
+    if 'schema' not in response_spec:
+        # If response spec does not define schema
         return None
 
     content_type = response.headers.get('content-type', '').lower()
@@ -141,7 +139,6 @@ def get_response_spec(status_code, op):
     :raises: MatchingResponseNotFound when the status_code could not be mapped
         to a response specification.
     """
-    # TODO: check global #/responses
     deref = op.swagger_spec.deref
     op_spec = deref(op.op_spec)
     response_specs = deref(op_spec.get('responses'))

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -49,7 +49,7 @@ def is_prop_nullable(swagger_spec, schema_object_spec):
 def is_ref(spec):
     """ Check if the given spec is a Mapping and contains a $ref.
 
-    FYI: This function gets called A LOT during unmarshaling and is_dict_like
+    FYI: This function gets called A LOT during unmarshalling and is_dict_like
     adds a bunch of extra time. It is faster to use a try/except than it is
     to call is_dict_like first for every spec input.
 
@@ -86,6 +86,8 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
     """Given a jsonschema object spec and value, retrieve the spec for the
      given property taking 'additionalProperties' into consideration.
 
+    :param swagger_spec: Spec object
+    :type swagger_spec: bravado_core.spec.Spec
     :param object_spec: spec for a jsonschema 'object' in dict form
     :param object_value: jsonschema object containing the given property. Only
         used in error message.
@@ -135,7 +137,8 @@ def handle_null_value(swagger_spec, schema_object_spec):
      x-nullable attribute in the spec to see if it is allowed and returns None
      if so and raises an exception otherwise.
 
-    :param swagger_spec: :class:`bravado_core.spec.Spec`
+    :param swagger_spec: Spec object
+    :type swagger_spec: bravado_core.spec.Spec
     :param schema_object_spec: dict
     :return: The default if there is a default value, None if the spec is nullable
     :raises: SwaggerMappingError if the spec is not nullable and no default exists

--- a/bravado_core/security_requirement.py
+++ b/bravado_core/security_requirement.py
@@ -12,9 +12,9 @@ class SecurityRequirement(object):
     """
     Wrapper of security requirement object (http://swagger.io/specification/#securityRequirementObject)
 
-    :type swagger_spec: :class:`bravado_core.spec.Spec`
-    :type op: :class:`bravado_core.operation.Operation`
-    :type security_requirement_spec: security requirement specification in dict form
+    :param swagger_spec: Spec object
+    :type swagger_spec: bravado_core.spec.Spec
+    :param security_requirement_spec: security requirement specification in dict form
     """
 
     def __init__(self, swagger_spec, security_requirement_spec):

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -62,7 +62,7 @@ CONFIG_DEFAULTS = {
     # Specification.
     'formats': [],
 
-    # Fill with None all the missing properties during object unmarshal-ing
+    # Fill with None all the missing properties during object unmarshalling
     'include_missing_properties': True,
 
     # What to do when a type is missing
@@ -70,7 +70,7 @@ CONFIG_DEFAULTS = {
     # If False, do no validation
     'default_type_to_object': False,
 
-    # Completely dereference $refs to maximize marshaling and unmarshaling performances.
+    # Completely dereference $refs to maximize marshaling and unmarshalling performances.
     # NOTE: this depends on validate_swagger_spec
     'internally_dereference_refs': False,
 }
@@ -81,7 +81,7 @@ class Spec(object):
 
     :param spec_dict: Swagger API specification in json-like dict form
     :param origin_url: URL from which the spec was retrieved.
-    :param http_client: Used to retrive the spec via http/https.
+    :param http_client: Used to retrieve the spec via http/https.
     :type http_client: :class:`bravado.http_client.HTTPClient`
     :param config: Configuration dict. See CONFIG_DEFAULTS.
     """
@@ -152,14 +152,14 @@ class Spec(object):
         You may be asking, "Why is there a difference between the Swagger spec
         a client sees and the one used internally?". Well, as part of the
         ingestion process, x-scope metadata is added to spec_dict so that
-        $refs can be de-reffed successfully during requset/response validation
-        and marshalling. This medatadata is specific to the context of the
+        $refs can be de-reffed successfully during request/response validation
+        and marshalling. This metadata is specific to the context of the
         server and contains files and paths that are not relevant to the
         client. This is required so the client does not re-use (and in turn,
         re-creates) the invalid x-scope metadata created by the server.
 
         For example, a section of spec_dict that contains a ref would change
-        as folows.
+        as follows.
 
         Before:
 
@@ -182,12 +182,12 @@ class Spec(object):
 
     @classmethod
     def from_dict(cls, spec_dict, origin_url=None, http_client=None, config=None):
-        """Build a :class:`Spec` from Swagger API Specificiation
+        """Build a :class:`Spec` from Swagger API Specification
 
         :param spec_dict: swagger spec in json-like dict form.
         :param origin_url: the url used to retrieve the spec, if any
         :type  origin_url: str
-        :param: http_client: http client used to download remote $refs
+        :param http_client: http client used to download remote $refs
         :param config: Configuration dict. See CONFIG_DEFAULTS.
         """
         spec = cls(spec_dict, origin_url, http_client, config)
@@ -212,8 +212,8 @@ class Spec(object):
             self.deref = lambda ref_dict: ref_dict
             self._internal_spec_dict = self.deref_flattened_spec
 
-        for format in self.config['formats']:
-            self.register_format(format)
+        for user_defined_format in self.config['formats']:
+            self.register_format(user_defined_format)
 
         self.api_url = build_api_serving_url(self.spec_dict, self.origin_url)
 
@@ -277,18 +277,18 @@ class Spec(object):
     def get_format(self, name):
         """
         :param name: Name of the format to retrieve
-        :rtype: :class:`bravado_core.formatters.SwaggerFormat`
+        :rtype: :class:`bravado_core.formatter.SwaggerFormat`
         """
-        format = self.user_defined_formats.get(name)
-        if format is None:
-            format = formatter.DEFAULT_FORMATS.get(name)
+        user_defined_format = self.user_defined_formats.get(name)
+        if user_defined_format is None:
+            user_defined_format = formatter.DEFAULT_FORMATS.get(name)
 
-        if format is None:
+        if user_defined_format is None:
             warnings.warn(
                 message='{0} format is not registered with bravado-core!'.format(name),
                 category=Warning,
             )
-        return format
+        return user_defined_format
 
     @cached_property
     def security_definitions(self):

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -348,13 +348,9 @@ class Spec(object):
 
 
 def is_yaml(url, content_type=None):
-    yaml_content_types = set([
-        'application/yaml',
-        'application/x-yaml',
-        'text/yaml',
-    ])
+    yaml_content_types = {'application/yaml', 'application/x-yaml', 'text/yaml'}
 
-    yaml_file_extensions = set(['.yaml', '.yml'])
+    yaml_file_extensions = {'.yaml', '.yml'}
 
     if content_type in yaml_content_types:
         return True

--- a/bravado_core/swagger20_validator.py
+++ b/bravado_core/swagger20_validator.py
@@ -186,7 +186,7 @@ def ref_validator(validator, ref, instance, schema):
      the full scope built when ingesting the spec from its root
      (#/ in swagger.json). So, we need to modify the behavior of ref
      validation to use the `x-scope` annotations that were created during spec
-     ingestion (see post_process_spec in spec.py).
+     ingestion (see model_discovery in bravado_core/model.py).
 
     :param validator: Validator class used to validate the object
     :type validator: :class: `Swagger20Validator` or
@@ -198,7 +198,7 @@ def ref_validator(validator, ref, instance, schema):
         eg {'$ref': '#/foo/bar/Baz'}
     :type schema: dict
     """
-    # This is a copy of jsonscehama._validators.ref(..) with the
+    # This is a copy of jsonschema._validators.ref(..) with the
     # in_scope(..) context manager applied before any refs are resolved.
     resolve = getattr(validator.resolver, "resolve")
     if resolve is None:

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -17,7 +17,7 @@ from bravado_core.schema import SWAGGER_PRIMITIVES
 def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
     """Unmarshal the value using the given schema object specification.
 
-    Unmarshaling includes:
+    Unmarshalling includes:
     - transform the value according to 'format' if available
     - return the value in a form suitable for use. e.g. conversion to a Model
       type.
@@ -26,7 +26,7 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
     :type schema_object_spec: dict
     :type value: int, float, long, string, unicode, boolean, list, dict, etc
 
-    :return: unmarshaled value
+    :return: unmarshalled value
     :rtype: int, float, long, string, unicode, boolean, list, dict, object (in
         the case of a 'format' conversion', or Model type
     """

--- a/bravado_core/validate.py
+++ b/bravado_core/validate.py
@@ -83,7 +83,7 @@ def validate_primitive(swagger_spec, primitive_spec, value):
 def validate_array(swagger_spec, array_spec, value):
     """
     :type swagger_spec: :class:`bravado_core.spec.Spec`
-    :param spec: spec for an 'array' type in dict form
+    :param array_spec: spec for an 'array' type in dict form
     :type value: list
     """
     get_validator_type(swagger_spec)(

--- a/tests/param/cast_request_param_test.py
+++ b/tests/param/cast_request_param_test.py
@@ -7,7 +7,7 @@ from bravado_core.param import cast_request_param
 @patch('bravado_core.param.log')
 def test_logs_cast_failure(mock_logger):
     cast_request_param('integer', 'gimme_int', 'not_int')
-    assert mock_logger.warn.call_count == 1
+    assert mock_logger.warning.call_count == 1
 
 
 @patch('bravado_core.param.log')
@@ -23,7 +23,7 @@ def test_type_error_returns_untouched_value_and_logs(mock_logger):
     result_val = cast_request_param('integer', 'gimme_int', initial_val)
     assert result_val == initial_val
     assert result_val is initial_val
-    assert mock_logger.warn.call_count == 1
+    assert mock_logger.warning.call_count == 1
 
 
 def test_unknown_type_returns_untouched_value():


### PR DESCRIPTION
This PR proposes some cleanup of the codebase:
 * done typos finding and removal
 * removed outer scope variable shadows
