### PR TITLE
Additional sanitization rules to cover more cases

### DIFF
--- a/bravado_core/util.py
+++ b/bravado_core/util.py
@@ -17,7 +17,17 @@ SANITIZE_RULES = [
     for regex, replacement in [
         ('[^A-Za-z0-9_]', '_'),  # valid chars for method names
         ('__+', '_'),  # collapse consecutive _
-        ('^[0-9_]|_$', ''),  # trim leading/trailing _ and leading digits
+        ('^[0-9_]+|_+$', ''),  # trim leading/trailing _ and leading digits
+    ]
+]
+
+
+FALLBACK_SANITIZE_RULES = [
+    (re.compile(regex), replacement)
+    for regex, replacement in [
+        ('[^A-Za-z0-9_]', '_'),  # valid chars for method names
+        ('^[0-9]+', '_'),  # replace leading digits
+        ('__+', '_'),  # collapse consecutive _
     ]
 ]
 
@@ -62,10 +72,16 @@ def memoize_by_id(func):
 
 def sanitize_name(name):
     """Convert a given name so that it is a valid python identifier."""
+    sanitized_name = name
     for regex, replacement in SANITIZE_RULES:
-        name = regex.sub(replacement, name)
+        sanitized_name = regex.sub(replacement, sanitized_name)
 
-    return name
+    if sanitized_name == '':  # use fallback rules with more underscores
+        sanitized_name = '_' + name  # prepend _ so digits are not stripped
+        for regex, replacement in FALLBACK_SANITIZE_RULES:
+            sanitized_name = regex.sub(replacement, sanitized_name)
+
+    return sanitized_name
 
 
 class AliasKeyDict(dict):

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -79,6 +79,9 @@ def test_memoize_by_id_decorator():
     ('_getPetById_', 'getPetById'),        # leading/trailing underscore
     ('get__Pet_By__Id', 'get_Pet_By_Id'),  # double underscores
     ('^&#@!$foo%+++:;"<>?/', 'foo'),       # bunch of illegal chars
+    ('__foo__', 'foo'),                    # make sure we strip multiple underscores
+    ('100percent', 'percent'),             # make sure we remove all digits
+    ('100.0', '_100_0'),                   # a name consisting mostly of digits should keep them
 ])
 def test_sanitize_name(input, expected):
     assert sanitize_name(input) == expected


### PR DESCRIPTION
A few bugfixes around name sanitization; I ran into these cases when dealing with some of our internal specs.

1. We weren't stripping more than one leading digit (or underscore). We need to strip all digits.
1. In some cases the result can be an empty string; I've come up with a way to deal with it that works best when the name is mostly digits. There are still edge cases where this produces only an underscore, but I really hope those aren't real use cases. :)

