### PR TITLE
Add logic to rename definitions keys to model names, if possible

### DIFF
--- a/test-data/2.0/multi-file-multi-directory-spec/flattened-multi-file-multi-directory-spec.json
+++ b/test-data/2.0/multi-file-multi-directory-spec/flattened-multi-file-multi-directory-spec.json
@@ -3,10 +3,10 @@
     "application/json"
   ],
   "definitions": {
-    "lfile:definitions.yaml|..DebugErrorResponse": {
+    "DebugErrorResponse": {
       "allOf": [
         {
-          "$ref": "#/definitions/lfile:definitions.yaml|..ErrorResponse"
+          "$ref": "#/definitions/ErrorResponse"
         },
         {
           "properties": {
@@ -20,7 +20,7 @@
       "type": "object",
       "x-model": "DebugErrorResponse"
     },
-    "lfile:definitions.yaml|..ErrorResponse": {
+    "ErrorResponse": {
       "properties": {
         "error_code": {
           "description": "Machine-friendly error code",
@@ -39,7 +39,7 @@
         {
           "allOf": [
             {
-              "$ref": "#/definitions/lfile:definitions.yaml|..ErrorResponse"
+              "$ref": "#/definitions/ErrorResponse"
             },
             {
               "properties": {
@@ -53,14 +53,10 @@
       ],
       "x-model": "ErrorResponse"
     },
-    "lfile:endpoint..v1..responses.yaml|..200..schema": {
-      "type": "object",
-      "x-model": "endpoint_v1_HTTP_OK"
-    },
-    "lfile:endpoint..v1..responses.yaml|..403..schema": {
+    "endpoint_v1_HTTP_FORBIDDEN": {
       "allOf": [
         {
-          "$ref": "#/definitions/lfile:definitions.yaml|..ErrorResponse"
+          "$ref": "#/definitions/ErrorResponse"
         },
         {
           "properties": {
@@ -79,7 +75,7 @@
       "type": "object",
       "x-model": "endpoint_v1_HTTP_FORBIDDEN"
     },
-    "lfile:endpoint..v1..responses.yaml|..403..schema..allOf..1": {
+    "endpoint_v1_HTTP_FORBIDDEN_action_part": {
       "properties": {
         "action": {
           "description": "name of the forbidden action",
@@ -91,6 +87,10 @@
       ],
       "type": "object",
       "x-model": "endpoint_v1_HTTP_FORBIDDEN_action_part"
+    },
+    "endpoint_v1_HTTP_OK": {
+      "type": "object",
+      "x-model": "endpoint_v1_HTTP_OK"
     }
   },
   "info": {
@@ -145,7 +145,7 @@
       "schema": {
         "allOf": [
           {
-            "$ref": "#/definitions/lfile:definitions.yaml|..ErrorResponse"
+            "$ref": "#/definitions/ErrorResponse"
           },
           {
             "properties": {
@@ -170,7 +170,7 @@
       "schema": {
         "allOf": [
           {
-            "$ref": "#/definitions/lfile:definitions.yaml|..ErrorResponse"
+            "$ref": "#/definitions/ErrorResponse"
           },
           {
             "properties": {

--- a/test-data/2.0/multi-file-recursive/flattened-multi-file-recursive-spec.json
+++ b/test-data/2.0/multi-file-recursive/flattened-multi-file-recursive-spec.json
@@ -1,21 +1,48 @@
 {
   "definitions": {
-    "lfile:aux.json|..definitions..not_used_remote_reference": {
+    "model_with_allOf_recursive": {
+      "allOf": [
+        {
+          "properties": {
+            "pong": {
+              "$ref": "#/definitions/pong"
+            }
+          }
+        },
+        {
+          "properties": {
+            "ping": {
+              "$ref": "#/definitions/ping"
+            }
+          }
+        }
+      ],
+      "x-model": "model_with_allOf_recursive"
+    },
+    "not_referenced_models_in_not_direcly_linked_file": {
+      "type": "object",
+      "x-model": "not_referenced_models_in_not_direcly_linked_file"
+    },
+    "not_used": {
+      "type": "object",
+      "x-model": "not_used"
+    },
+    "not_used_remote_reference": {
       "properties": {
         "random_number": {
-          "$ref": "#/definitions/lfile:aux_2.json|..definitions..random_integer"
+          "$ref": "#/definitions/random_integer"
         }
       },
       "type": "object",
       "x-model": "not_used_remote_reference"
     },
-    "lfile:aux.json|..definitions..ping": {
+    "ping": {
       "properties": {
         "message": {
           "type": "string"
         },
         "pong": {
-          "$ref": "#/definitions/lfile:swagger.json|..definitions..pong"
+          "$ref": "#/definitions/pong"
         }
       },
       "required": [
@@ -24,11 +51,22 @@
       "type": "object",
       "x-model": "ping"
     },
-    "lfile:aux_2.json|..definitions..not_referenced_models_in_not_direcly_linked_file": {
+    "pong": {
+      "properties": {
+        "message": {
+          "type": "string"
+        },
+        "ping": {
+          "$ref": "#/definitions/ping"
+        }
+      },
+      "required": [
+        "message"
+      ],
       "type": "object",
-      "x-model": "not_referenced_models_in_not_direcly_linked_file"
+      "x-model": "pong"
     },
-    "lfile:aux_2.json|..definitions..random_integer": {
+    "random_integer": {
       "properties": {
         "max-value": {
           "type": "integer"
@@ -42,44 +80,6 @@
       },
       "type": "object",
       "x-model": "random_integer"
-    },
-    "lfile:swagger.json|..definitions..model_with_allOf_recursive": {
-      "allOf": [
-        {
-          "properties": {
-            "pong": {
-              "$ref": "#/definitions/lfile:swagger.json|..definitions..pong"
-            }
-          }
-        },
-        {
-          "properties": {
-            "ping": {
-              "$ref": "#/definitions/lfile:aux.json|..definitions..ping"
-            }
-          }
-        }
-      ],
-      "x-model": "model_with_allOf_recursive"
-    },
-    "lfile:swagger.json|..definitions..not_used": {
-      "type": "object",
-      "x-model": "not_used"
-    },
-    "lfile:swagger.json|..definitions..pong": {
-      "properties": {
-        "message": {
-          "type": "string"
-        },
-        "ping": {
-          "$ref": "#/definitions/lfile:aux.json|..definitions..ping"
-        }
-      },
-      "required": [
-        "message"
-      ],
-      "type": "object",
-      "x-model": "pong"
     }
   },
   "info": {
@@ -128,7 +128,7 @@
           "200": {
             "description": "A recursive response",
             "schema": {
-              "$ref": "#/definitions/lfile:aux.json|..definitions..ping"
+              "$ref": "#/definitions/ping"
             }
           }
         }
@@ -141,7 +141,7 @@
             "description": "A list of recursive response",
             "schema": {
               "items": {
-                "$ref": "#/definitions/lfile:aux.json|..definitions..ping"
+                "$ref": "#/definitions/ping"
               },
               "type": "array"
             }

--- a/test-data/2.0/multi-file-specs-with-no-x-model/flattened-multi-file-with-no-xmodel.json
+++ b/test-data/2.0/multi-file-specs-with-no-x-model/flattened-multi-file-with-no-xmodel.json
@@ -1,17 +1,17 @@
 {
   "definitions": {
-    "lfile:aux.json|..definitions..referenced_object": {
-      "type": "object",
-      "x-model": "referenced_object"
-    },
-    "lfile:swagger.json|..definitions..object": {
+    "object": {
       "properties": {
         "property": {
-          "$ref": "#/definitions/lfile:aux.json|..definitions..referenced_object"
+          "$ref": "#/definitions/referenced_object"
         }
       },
       "type": "object",
       "x-model": "object"
+    },
+    "referenced_object": {
+      "type": "object",
+      "x-model": "referenced_object"
     }
   },
   "info": {

--- a/tests/spec/Spec/flattened_spec_test.py
+++ b/tests/spec/Spec/flattened_spec_test.py
@@ -177,3 +177,146 @@ def test_flattened_specs_with_no_xmodel_tags(multi_file_with_no_xmodel_spec, fla
         http_handlers={},
     )
     assert flattened_spec == flattened_multi_file_with_no_xmodel_dict
+
+
+@pytest.mark.parametrize(
+    'spec_dict, expected_spec_dict',
+    [
+        [
+            {
+                'definitions': {
+                    'model': {
+                        'type': 'object',
+                        'x-model': 'model',
+                    },
+                },
+            },
+            {
+                'definitions': {
+                    'model': {
+                        'type': 'object',
+                        'x-model': 'model',
+                    },
+                },
+            },
+        ],
+        [
+            {
+                'definitions': {
+                    'model': {
+                        'type': 'object',
+                        'x-model': 'different-model',
+                    },
+                },
+            },
+            {
+                'definitions': {
+                    'different-model': {
+                        'type': 'object',
+                        'x-model': 'different-model',
+                    },
+                },
+            },
+        ],
+        [
+            {
+                'definitions': {
+                    'model': {
+                        'type': 'object',
+                        'x-model': 'different-model',
+                    },
+                    'different-model': {
+                        'type': 'string',
+                    },
+                },
+            },
+            {
+                'definitions': {
+                    'model': {
+                        'type': 'object',
+                        'x-model': 'different-model',
+                    },
+                    'different-model': {
+                        'type': 'string',
+                    },
+                },
+            },
+        ],
+        [
+            {
+                'definitions': {
+                    'model': {
+                        'type': 'object',
+                        'properties': {
+                            'mod': {
+                                '$ref': '#/definitions/model'
+                            }
+                        },
+                        'x-model': 'different-model',
+                    },
+                },
+            },
+            {
+                'definitions': {
+                    'different-model': {
+                        'type': 'object',
+                        'properties': {
+                            'mod': {
+                                '$ref': '#/definitions/different-model'
+                            }
+                        },
+                        'x-model': 'different-model',
+                    },
+                },
+            },
+        ],
+        [
+            {
+                'definitions': {
+                    'model': {
+                        'type': 'object',
+                        'properties': {
+                            'mod': {
+                                '$ref': '#/definitions/second-model'
+                            }
+                        },
+                        'x-model': 'different-model',
+                    },
+                    'second-model': {
+                        'type': 'object',
+                        'properties': {
+                            'mod': {
+                                '$ref': '#/definitions/model'
+                            }
+                        },
+                        'x-model': 'second-model',
+                    },
+                },
+            },
+            {
+                'definitions': {
+                    'different-model': {
+                        'type': 'object',
+                        'properties': {
+                            'mod': {
+                                '$ref': '#/definitions/second-model'
+                            }
+                        },
+                        'x-model': 'different-model',
+                    },
+                    'second-model': {
+                        'type': 'object',
+                        'properties': {
+                            'mod': {
+                                '$ref': '#/definitions/different-model'
+                            }
+                        },
+                        'x-model': 'second-model',
+                    },
+                },
+            },
+        ],
+    ]
+)
+def test_rename_definition_references(spec_flattener, spec_dict, expected_spec_dict):
+    assert spec_flattener.rename_definition_references(spec_dict) == expected_spec_dict


### PR DESCRIPTION
The idea of this PR is to post-process the flattened specs in order to rename `#/definitions/<schema-object>` to `#/definitions/<model-name>` if possible.

Doing this is moistly useful to enhance human readability of the provided specs.

The post-processing process takes into account that it could be possible that `#/definitions/<model-name>` is for some reason already in use, if it is the case it won't rename references and objects guaranteeing that specs will be equivalent