### PR TITLE
Replace inline models with top-level definitions

### DIFF
--- a/test-data/2.0/multi-file-multi-directory-spec/flattened-multi-file-multi-directory-spec.json
+++ b/test-data/2.0/multi-file-multi-directory-spec/flattened-multi-file-multi-directory-spec.json
@@ -59,17 +59,7 @@
           "$ref": "#/definitions/ErrorResponse"
         },
         {
-          "properties": {
-            "action": {
-              "description": "name of the forbidden action",
-              "type": "string"
-            }
-          },
-          "required": [
-            "action"
-          ],
-          "type": "object",
-          "x-model": "endpoint_v1_HTTP_FORBIDDEN_action_part"
+          "$ref": "#/definitions/endpoint_v1_HTTP_FORBIDDEN_action_part"
         }
       ],
       "type": "object",
@@ -136,33 +126,13 @@
     "lfile:endpoint..v1..responses.yaml|..200": {
       "description": "HTTP/200",
       "schema": {
-        "type": "object",
-        "x-model": "endpoint_v1_HTTP_OK"
+        "$ref": "#/definitions/endpoint_v1_HTTP_OK"
       }
     },
     "lfile:endpoint..v1..responses.yaml|..403": {
       "description": "HTTP/403",
       "schema": {
-        "allOf": [
-          {
-            "$ref": "#/definitions/ErrorResponse"
-          },
-          {
-            "properties": {
-              "action": {
-                "description": "name of the forbidden action",
-                "type": "string"
-              }
-            },
-            "required": [
-              "action"
-            ],
-            "type": "object",
-            "x-model": "endpoint_v1_HTTP_FORBIDDEN_action_part"
-          }
-        ],
-        "type": "object",
-        "x-model": "endpoint_v1_HTTP_FORBIDDEN"
+        "$ref": "#/definitions/endpoint_v1_HTTP_FORBIDDEN"
       }
     },
     "lfile:endpoint..v1..responses.yaml|..default": {

--- a/test-data/2.0/multi-file-recursive/aux_2.json
+++ b/test-data/2.0/multi-file-recursive/aux_2.json
@@ -1,6 +1,12 @@
 {
     "definitions": {
-        "not_referenced_models_in_not_direcly_linked_file": {
+        "not_referenced_models_in_not_directly_linked_file": {
+            "properties": {
+                "inline_model": {
+                    "type": "object",
+                    "x-model": "inline_model"
+                }
+            },
             "type": "object"
         },
         "random_integer": {

--- a/test-data/2.0/multi-file-recursive/flattened-multi-file-recursive-spec.json
+++ b/test-data/2.0/multi-file-recursive/flattened-multi-file-recursive-spec.json
@@ -1,5 +1,9 @@
 {
   "definitions": {
+    "inline_model": {
+      "type": "object",
+      "x-model": "inline_model"
+    },
     "model_with_allOf_recursive": {
       "allOf": [
         {
@@ -19,9 +23,14 @@
       ],
       "x-model": "model_with_allOf_recursive"
     },
-    "not_referenced_models_in_not_direcly_linked_file": {
+    "not_referenced_models_in_not_directly_linked_file": {
+      "properties": {
+        "inline_model": {
+          "$ref": "#/definitions/inline_model"
+        }
+      },
       "type": "object",
-      "x-model": "not_referenced_models_in_not_direcly_linked_file"
+      "x-model": "not_referenced_models_in_not_directly_linked_file"
     },
     "not_used": {
       "type": "object",


### PR DESCRIPTION
While refactoring the flattening process I've noticed that in case of inline models (with `x-model` defined) the flattening replicates the model definition twice: inline the original object and in `#/definitions/`

This PR does essentially some clean-up :)
