### PR TITLE
Fix marshalling of array params with collectionFormat multi

### DIFF
--- a/bravado_core/param.py
+++ b/bravado_core/param.py
@@ -272,6 +272,11 @@ def encode_request_param(param_type, param_name, param_value):
     :type  param_name: string
     :param param_value: param value
     """
+    if param_type == 'array':
+        # marshal_collection_format has already taken care of it; furthermore, if collectionFormat is
+        # multi then the value is still a sequence, we don't want to cast that to str
+        return param_value
+
     if param_value is None:  # pragma: no cover
         # We should never get into this branch, but better be more defensive
         return None

--- a/tests/param/marshal_param_test.py
+++ b/tests/param/marshal_param_test.py
@@ -10,6 +10,7 @@ from mock import patch
 from bravado_core.content_type import APP_JSON
 from bravado_core.exception import SwaggerMappingError
 from bravado_core.operation import Operation
+from bravado_core.param import encode_request_param
 from bravado_core.param import marshal_param
 from bravado_core.param import Param
 from bravado_core.param import unmarshal_param
@@ -326,3 +327,18 @@ def test_boolean_query_params_are_lower_case(
     # Checks that the conversion back continues to work
     request_object = Mock(spec=IncomingRequest, query={param_spec['name']: param_string_value})
     assert unmarshal_param(param, request_object) == param_python_value
+
+
+@pytest.mark.parametrize(
+    'param_type, param_value, expected_param_value',
+    (
+        ('string', 'abc', 'abc'),
+        ('string', 5, '5'),
+        ('boolean', True, 'true'),
+        ('boolean', False, 'false'),
+        ('array', [1, 2], [1, 2]),
+    ),
+)
+def test_encode_request_param(param_type, param_value, expected_param_value):
+    value = encode_request_param(param_type, 'some_name', param_value)
+    assert value == expected_param_value


### PR DESCRIPTION
array params are either already stringified or left as untouched if collectionFormat is multi. The latter case breaks with bravado-core 5.0.5 due to the behavior of the new `encode_request_param` function. An integration test failure in bravado-asyncio surfaced the issue. This PR fixes it.