### PR TITLE
Fix issue with multiple security definitions ordering

### DIFF
--- a/bravado_core/operation.py
+++ b/bravado_core/operation.py
@@ -92,7 +92,7 @@ class Operation(object):
 
     @property
     def acceptable_security_definition_combinations(self):
-        return sorted(sorted(security_item.keys()) for security_item in self.security_specs)
+        return [sorted(security_item.keys()) for security_item in self.security_specs]
 
     @cached_property
     def security_parameters(self):

--- a/test-data/2.0/security/swagger.json
+++ b/test-data/2.0/security/swagger.json
@@ -115,6 +115,31 @@
           }
         }
       }
+    },
+    "/example6": {
+      "get": {
+        "description": "Endpoint not requires any header parameter",
+        "security": [
+          {
+            "apiKey1": []
+          },
+          {
+            "apiKey2": []
+          },
+          {
+            "apiKey3": []
+          },
+          {
+            "apiKey1": [],
+            "apiKey2": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
     }
   }
 }

--- a/tests/validate/validate_security_object_test.py
+++ b/tests/validate/validate_security_object_test.py
@@ -15,6 +15,10 @@ from bravado_core.validate import validate_security_object
         ('example3', 'get_example3', {'apiKey3': 'key'}),
         ('example4', 'get_example4', {}),
         ('example5', 'get_example5', {}),
+        ('example6', 'get_example6', {'apiKey1': 'key'}),
+        ('example6', 'get_example6', {'apiKey2': 'key'}),
+        ('example6', 'get_example6', {'apiKey3': 'key'}),
+        ('example6', 'get_example6', {'apiKey1': 'key', 'apiKey2': 'key'}),
     ]
 )
 def test_validate_correct_security_objects(security_spec, resource, operation, request_data):


### PR DESCRIPTION
While working on some internal investigation I've noticed that a bug was present into the implementation of `validate_security_object` method.
The bright side of it is that I could be triggered with a very specific case which, considering that no issues were open, is uncommon.
To trigger the issue we should have multiple matched security requirements with at least one unmatched security requirement, check `test-data/2.0/security/swagger.json` for an example.

##### How does `acceptable_security_definition_combinations` update fix the bug?
The validation logic of the security component is defined in [`validate.validate_security_object`](https://github.com/Yelp/bravado-core/blob/v5.0.6/bravado_core/validate.py#L108), if we would extract from it the main actions are

1. ...
2. keep track of the index of all the matching security definitions (note: the used order is the order defined on the specs)
2. if there are multiple matching definitions, then extract all the possible combinations that are on the previously identified indexes <- here is where the bug raises
3. ...

The code, implicitly, assumes that the order provided by `operation.acceptable_security_definition_combinations` will be consistent with with `operation. security_requirements` but this is not true as:
* `operation. security_requirements` provides the results with the order provided in the swagger specs
* `operation.acceptable_security_definition_combinations` sorts the result

In order to fix the issue is enough to not sort the acceptable_security_definition_combinations