### PR TITLE
Don't use Swagger spec path for API URL

### DIFF
--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -435,6 +435,6 @@ def build_api_serving_url(spec_dict, origin_url=None, preferred_scheme=None):
         return schemes[0]
 
     netloc = spec_dict.get('host', origin.netloc)
-    path = spec_dict.get('basePath', origin.path)
+    path = spec_dict.get('basePath', '/')
     scheme = pick_a_scheme(spec_dict.get('schemes'))
     return urlunparse((scheme, netloc, path, None, None, None))

--- a/tests/spec/build_api_serving_url_test.py
+++ b/tests/spec/build_api_serving_url_test.py
@@ -12,13 +12,13 @@ def origin_url():
 
 def test_no_overrides(origin_url):
     spec = {}
-    assert origin_url == build_api_serving_url(spec, origin_url)
+    assert 'http://www.foo.com:80/' == build_api_serving_url(spec, origin_url)
 
 
 def test_override_host(origin_url):
     spec = {'host': 'womble.com'}
     api_serving_url = build_api_serving_url(spec, origin_url)
-    assert 'http://womble.com/bar/api-docs' == api_serving_url
+    assert 'http://womble.com/' == api_serving_url
 
 
 def test_override_basepath(origin_url):
@@ -30,26 +30,26 @@ def test_override_basepath(origin_url):
 def test_override_scheme(origin_url):
     spec = {'schemes': ['https']}
     api_serving_url = build_api_serving_url(spec, origin_url)
-    assert 'https://www.foo.com:80/bar/api-docs' == api_serving_url
+    assert 'https://www.foo.com:80/' == api_serving_url
 
 
 def test_override_scheme_multiple_schemes(origin_url):
     spec = {'schemes': ['https', 'ws']}
     api_serving_url = build_api_serving_url(spec, origin_url)
-    assert 'https://www.foo.com:80/bar/api-docs' == api_serving_url
+    assert 'https://www.foo.com:80/' == api_serving_url
 
 
 def test_pick_preferred_scheme(origin_url):
     spec = {'schemes': ['http', 'https']}
     api_serving_url = build_api_serving_url(
         spec, origin_url, preferred_scheme='https')
-    assert 'https://www.foo.com:80/bar/api-docs' == api_serving_url
+    assert 'https://www.foo.com:80/' == api_serving_url
 
 
 def test_pick_origin_scheme_when_preferred_scheme_none(origin_url):
     spec = {'schemes': ['http', 'https']}
     api_serving_url = build_api_serving_url(spec, origin_url)
-    assert 'http://www.foo.com:80/bar/api-docs' == api_serving_url
+    assert 'http://www.foo.com:80/' == api_serving_url
 
 
 def test_preferred_scheme_not_available(origin_url):


### PR DESCRIPTION
According to the Swagger spec we should not use the path part of the
spec URL, but instead just use the host part of the URL (see the
existing comment for build_api_serving_url, as well as
https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#fixed-fields
).

Also update tests to match new behaviour.

I don't know if bravado users depend on the current behavior - feedback appreciated.