### PR TITLE
Make docs is failing on travis with Sphinx 1.8.0, use a lower version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,8 @@ commands =
 [testenv:docs]
 basepython = /usr/bin/python2.7
 deps =
-    sphinx
+    # we're getting an error on travis with Sphinx 1.8.0, so we use a lower version
+    sphinx < 1.8.0
     sphinx-rtd-theme
 changedir = docs
 commands = sphinx-build -b html -d build/doctrees source build/html


### PR DESCRIPTION
It's unclear why it's failing on travis, it passes locally.