### PR TITLE
Fix unbounded recursion in polymorphic object validation

### DIFF
--- a/bravado_core/swagger20_validator.py
+++ b/bravado_core/swagger20_validator.py
@@ -177,9 +177,8 @@ def discriminator_validator(swagger_spec, validator, discriminator_attribute, in
     #   it in order to have a brand new dictionary that we can modify
     new_schema = discriminated_schema.copy()
     new_schema['allOf'] = [
-        all_of_schema
+        all_of_schema if all_of_schema not in schemas_to_remove else {}
         for all_of_schema in new_schema['allOf']
-        if all_of_schema not in schemas_to_remove
     ]
 
     from bravado_core.validate import validate_object  # Local import due to circular dependency

--- a/bravado_core/swagger20_validator.py
+++ b/bravado_core/swagger20_validator.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import functools
-from copy import deepcopy
 
 from jsonschema import _validators
 from jsonschema import validators
@@ -154,15 +153,15 @@ def discriminator_validator(swagger_spec, validator, discriminator_attribute, in
     if discriminator_value == schema[MODEL_MARKER]:
         return
 
-    new_schema = deepcopy(swagger_spec.definitions[discriminator_value]._model_spec)
-    if 'allOf' not in new_schema:
+    discriminated_schema = swagger_spec.definitions[discriminator_value]._model_spec
+    if 'allOf' not in discriminated_schema:
         raise ValidationError(
             message='discriminated schema \'{}\' must inherit from \'{}\''.format(
                 discriminator_value, schema[MODEL_MARKER]
             )
         )
 
-    schemas_to_remove = [s for s in new_schema['allOf'] if swagger_spec.deref(s) == schema]
+    schemas_to_remove = [s for s in discriminated_schema['allOf'] if swagger_spec.deref(s) == schema]
     if not schemas_to_remove:
         # Not checking against len(schemas_to_remove) > 1 because it should be prevented by swagger spec validation
         raise ValidationError(
@@ -173,7 +172,15 @@ def discriminator_validator(swagger_spec, validator, discriminator_attribute, in
 
     # Remove the current schema from the allOf list in order to avoid unbounded recursion
     # (the current object is already validated against schema)
-    new_schema['allOf'].remove(schemas_to_remove[0])
+    # WARNING: This is especially important if internally_dereference_refs is set to true
+    #   as we're modifying new_schema and new_schema is a dict (so mutable) we need to copy
+    #   it in order to have a brand new dictionary that we can modify
+    new_schema = discriminated_schema.copy()
+    new_schema['allOf'] = [
+        all_of_schema
+        for all_of_schema in new_schema['allOf']
+        if all_of_schema not in schemas_to_remove
+    ]
 
     from bravado_core.validate import validate_object  # Local import due to circular dependency
     validate_object(swagger_spec=swagger_spec, object_spec=new_schema, value=instance)


### PR DESCRIPTION
### What this PR tries to address
While performing validation of polymorphic objects the logic is split into 2 main areas:
 * validate the object according to the "common" object definition
 * identify the schema of the discriminated model and validate the object against that schema

In order to overcome unbounded-recursion (related to jsonschema validation) the `discriminator_validator` was implementing a _removal_ logic to ensure that the "common" object definition is removed from the schema (as it was already validated).

In order to prevent tampering of the model spec saved in the Spec object we were doing a `deepcopy` of the model spec.

If `internally_dereference_refs` is not enabled the `schemas_to_remove` is correctly evaluated as the dictionaries do not have a recursive structure and so `__eq__` is able to properly determine if two instances are equal or not.

As soon as we enable `internally_dereference_refs` the dictionaries could have a recursive definition (and acutally in case of polymorphic objects they have to), this means that `__eq__` will not be able to traverse the all dictionary without having an uncontrolled recursion.

### How does this PR address the issue
As `__eq__` method checks the content of the objects only if the memory addresses are different we could workaround the above mentioned issues by evaluating `schemas_to_remove` on the "original" model specs and not on its copy.

Applying this transformation it will allow us to:
 * fix the unbounded-recursion issue
 * postpone the copy after having ensured that "common" model il in the `allOf` list
 * reduce the amount of data that are copied: as we're not deep-copying everything but we preserve the original references except for the fields that we'll be modifying

### Additional fix (unrelated to unbounded recursion)
While validating polymorphic objects the "common" object definition is removed from the `allOf` list, this could alter the validation_path in case of validation error.
In order to prevent this unwanted alteration, this PR replaces the common schema with an empty schema instead of removing it.
An empty schema (`{}`) has the feature to be valid schema for any possible JSON input, so basically this converts the validation of that empty schema to a no-op