### PR TITLE
Remove usage of deprecated msgpack parameter

### DIFF
--- a/bravado_core/response.py
+++ b/bravado_core/response.py
@@ -110,7 +110,7 @@ def unmarshal_response(response, op):
         if content_type.startswith(APP_JSON):
             content_value = response.json()
         else:
-            content_value = msgpack.loads(response.raw_bytes, encoding='utf-8')
+            content_value = msgpack.loads(response.raw_bytes, raw=False)
         if op.swagger_spec.config['validate_responses']:
             validate_schema_object(op.swagger_spec, content_spec, content_value)
 
@@ -199,7 +199,7 @@ def validate_response_body(op, response_spec, response):
         if response.content_type == APP_JSON:
             response_value = response.json()
         else:
-            response_value = msgpack.loads(response.raw_bytes, encoding='utf-8')
+            response_value = msgpack.loads(response.raw_bytes, raw=False)
         validate_schema_object(
             op.swagger_spec, response_body_spec, response_value)
     elif response.content_type.startswith("text/"):

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ install_requires = [
     "six",
     "swagger-spec-validator>=2.0.1",
     "pytz",
-    "msgpack-python",
+    "msgpack-python>=0.5.2",
 ]
 
 

--- a/tests/model/create_model_type_test.py
+++ b/tests/model/create_model_type_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import mock
+import pytest
 
 from bravado_core.model import create_model_type
 from tests.model.conftest import \
@@ -60,6 +61,7 @@ def test_marshal_and_unmarshal(petstore_spec):
     assert unmarshalled_marshalled_model.photoUrls == pet_photo_urls
 
 
+@pytest.mark.filterwarnings("ignore: Model object methods are now prefixed with single underscore")
 def test_deprecated_marshal_and_unmarshal(petstore_spec):
     """This test is a copy of the test above. It will be removed once we remove the deprecated
     marshal() and unmarshal() methods."""

--- a/tests/model/create_model_type_test.py
+++ b/tests/model/create_model_type_test.py
@@ -3,9 +3,6 @@ import mock
 import pytest
 
 from bravado_core.model import create_model_type
-from tests.model.conftest import \
-    definitions_spec as definitions_spec_fixture
-from tests.model.conftest import pet_spec as pet_spec_fixture
 
 
 def test_pet_model(empty_swagger_spec, pet_spec):
@@ -33,12 +30,7 @@ def test_no_arg_constructor(empty_swagger_spec, pet_spec):
 
 
 @mock.patch('bravado_core.model.create_model_docstring', autospec=True)
-def test_create_model_type_lazy_docstring(mock_create_docstring,
-                                          empty_swagger_spec):
-    # NOTE: some sort of weird interaction with pytest, pytest-mock and mock
-    #       made using the 'mocker' fixture here a no-go.
-    definitions_spec = definitions_spec_fixture()
-    pet_spec = pet_spec_fixture(definitions_spec)
+def test_create_model_type_lazy_docstring(mock_create_docstring, empty_swagger_spec, pet_spec):
     pet_type = create_model_type(empty_swagger_spec, 'Pet', pet_spec)
     assert mock_create_docstring.call_count == 0
     assert pet_type.__doc__ == mock_create_docstring.return_value

--- a/tests/model/model_test.py
+++ b/tests/model/model_test.py
@@ -82,12 +82,14 @@ def test_model_as_dict(definitions_spec, user_type, user_kwargs):
     assert user._asdict() == user_dict
 
 
+@pytest.mark.filterwarnings('ignore:_isinstance is deprecated')
 def test_model_is_instance_same_class(user_type, user_kwargs):
     user = user_type(**user_kwargs)
     assert user_type._isinstance(user)
     assert isinstance(user, user_type)
 
 
+@pytest.mark.filterwarnings('ignore:_isinstance is deprecated')
 def test_model_is_instance_inherits_from(cat_swagger_spec, pet_type, pet_spec, cat_type, cat_kwargs):
     cat = cat_type(**cat_kwargs)
     new_pet_type = create_model_type(cat_swagger_spec, 'Pet', pet_spec)


### PR DESCRIPTION
While running some local tests I noticed that a set of warnings are thrown, among them one was pretty new and was related to a deprecation into `msgpack-python` library.

The goal of the PR is to:
 * address msgpack-python deprecation by setting the min required version and removing usage of `encoding` in favour of `raw`
 * silence bravado-core deprecation warnings that are thrown in purpose