### PR TITLE
Fix discriminator validation

### DIFF
--- a/bravado_core/swagger20_validator.py
+++ b/bravado_core/swagger20_validator.py
@@ -80,8 +80,7 @@ def required_validator(swagger_spec, validator, required, instance, schema):
     """
     if is_param_spec(swagger_spec, schema):
         if required and instance is None:
-            yield ValidationError('{0} is a required parameter.'.format(
-                schema['name']))
+            yield ValidationError('{0} is a required parameter.'.format(schema['name']))
     else:
         for error in _validators.required_draft4(validator, required, instance,
                                                  schema):
@@ -144,7 +143,11 @@ def discriminator_validator(swagger_spec, validator, discriminator_attribute, in
     :type schema: dict
     """
 
-    discriminator_value = instance[discriminator_attribute]
+    try:
+        discriminator_value = instance[discriminator_attribute]
+    except KeyError:
+        raise ValidationError("'discriminator_field' is a required property".format(discriminator_attribute))
+
     if discriminator_value not in swagger_spec.definitions:
         raise ValidationError(
             message='\'{}\' is not a recognized schema'.format(discriminator_value)

--- a/bravado_core/swagger20_validator.py
+++ b/bravado_core/swagger20_validator.py
@@ -146,7 +146,7 @@ def discriminator_validator(swagger_spec, validator, discriminator_attribute, in
     try:
         discriminator_value = instance[discriminator_attribute]
     except KeyError:
-        raise ValidationError("'discriminator_field' is a required property".format(discriminator_attribute))
+        raise ValidationError("'{}' is a required property".format(discriminator_attribute))
 
     if discriminator_value not in swagger_spec.definitions:
         raise ValidationError(


### PR DESCRIPTION
Fixes #301 

The current implementation of `bravado_core.swagger20_validator.discriminator_validator` assumes that `discriminator_attribute` is present in `instance`.
This assumption is valid if we are able to guarantee that `required` validator operates before `discriminator` validator.

As we shoudln't making assumptions on keywords validation order we should make sure that the validator is more resilient to this type of issue, we should be removing the assumption.

According to the swagger specs, the discriminator field has to be a required field of the object, so to keep users less "distracted" I'm returning an error message like the one returned by the jsonschema library that highlights the fact that the attribute is missing.