### PR TITLE
Remove direct usage of jsonschema._validators

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,7 @@
--   repo: git://github.com/pre-commit/pre-commit-hooks
-    sha: v0.7.1
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.0.0
     hooks:
-    -   id: autopep8-wrapper
-        args:
-        - -i
-        - --ignore=E309,E501
     -   id: check-json
     -   id: check-yaml
     -   id: debug-statements
@@ -15,12 +12,19 @@
     -   id: trailing-whitespace
     -   id: requirements-txt-fixer
         files: requirements-dev.txt
--   repo: git://github.com/asottile/reorder_python_imports
-    sha: v0.3.2
+-   repo: https://github.com/pre-commit/mirrors-autopep8
+    rev: v1.4.2
+    hooks:
+    -   id: autopep8
+        args:
+        - -i
+        - --ignore=E309,E501
+-   repo: https://github.com/asottile/reorder_python_imports
+    rev: v1.3.3
     hooks:
     -   id: reorder-python-imports
--   repo: git://github.com/Yelp/detect-secrets
-    sha: 0.9.1
+-   repo: https://github.com/Yelp/detect-secrets
+    rev: 0.10.5
     hooks:
     -   id: detect-secrets
         args: ['--baseline', '.secrets.baseline']

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,10 +1,13 @@
 {
-  "exclude_regex": "tests/.*",
-  "generated_at": "2018-07-12T23:38:53Z",
+  "exclude_regex": "tests/.*|^.secrets.baseline$",
+  "generated_at": "2018-10-31T07:56:13Z",
   "plugins_used": [
     {
       "base64_limit": 4.5,
       "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
     },
     {
       "hex_limit": 3,
@@ -15,5 +18,5 @@
     }
   ],
   "results": {},
-  "version": "0.9.1"
+  "version": "0.10.5"
 }

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -261,10 +261,10 @@ Changelog
 - Unqualified $refs no longer supported.
   Bad:  ``{"$ref": "User"}``
   Good: ``{"$ref": "#/definitions/User"}``
-- Automatic tagging of models is only supported in the root swagger spec file. 
-  If you have models defined in $ref targets that are in other files, you must 
+- Automatic tagging of models is only supported in the root swagger spec file.
+  If you have models defined in $ref targets that are in other files, you must
   manually tag them with 'x-model' for them to be available as python types.
-  See `Model Discovery <http://bravado-core.readthedocs.org/en/latest/models.html#model-discovery>`_ 
+  See `Model Discovery <http://bravado-core.readthedocs.org/en/latest/models.html#model-discovery>`_
   for more info.
 
 3.1.1 (2015-10-19)

--- a/bravado_core/swagger20_validator.py
+++ b/bravado_core/swagger20_validator.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import functools
 
-from jsonschema import _validators
 from jsonschema import validators
 from jsonschema.exceptions import ValidationError
 from jsonschema.validators import Draft4Validator
@@ -18,6 +17,12 @@ Draft4Validator which customizes/wraps some of the operations of the default
 validator.
 """
 
+# Extract "original" validators as defined in jsonschema library. Saving those to constants to reduce indirections during validation.  # noqa
+_DRAFT4_ENUM_VALIDATOR = Draft4Validator.VALIDATORS['enum']
+_DRAFT4_FORMAT_VALIDATOR = Draft4Validator.VALIDATORS['format']
+_DRAFT4_REQUIRED_VALIDATOR = Draft4Validator.VALIDATORS['required']
+_DRAFT4_TYPE_VALIDATOR = Draft4Validator.VALIDATORS['type']
+
 
 def format_validator(swagger_spec, validator, format, instance, schema):
     """Skip the `format` validator when a Swagger parameter value is None.
@@ -32,7 +37,7 @@ def format_validator(swagger_spec, validator, format, instance, schema):
             is_prop_nullable(swagger_spec, schema)) and instance is None:
         return
 
-    for error in _validators.format(validator, format, instance, schema):
+    for error in _DRAFT4_FORMAT_VALIDATOR(validator, format, instance, schema):
         yield error
 
 
@@ -59,7 +64,7 @@ def type_validator(swagger_spec, validator, types, instance, schema):
             is_prop_nullable(swagger_spec, schema)) and instance is None:
         return
 
-    for error in _validators.type_draft4(validator, types, instance, schema):
+    for error in _DRAFT4_TYPE_VALIDATOR(validator, types, instance, schema):
         yield error
 
 
@@ -83,8 +88,7 @@ def required_validator(swagger_spec, validator, required, instance, schema):
             yield ValidationError('{0} is a required parameter.'.format(
                 schema['name']))
     else:
-        for error in _validators.required_draft4(validator, required, instance,
-                                                 schema):
+        for error in _DRAFT4_REQUIRED_VALIDATOR(validator, required, instance, schema):
             yield error
 
 
@@ -109,7 +113,7 @@ def enum_validator(swagger_spec, validator, enums, instance, schema):
 
     if schema.get('type') == 'array':
         for element in instance:
-            for error in _validators.enum(validator, enums, element, schema):
+            for error in _DRAFT4_ENUM_VALIDATOR(validator, enums, element, schema):
                 yield error
         return
 
@@ -118,7 +122,7 @@ def enum_validator(swagger_spec, validator, enums, instance, schema):
         if not is_required(swagger_spec, schema) and instance is None:
             return
 
-    for error in _validators.enum(validator, enums, instance, schema):
+    for error in _DRAFT4_ENUM_VALIDATOR(validator, enums, instance, schema):
         yield error
 
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -32,4 +32,3 @@ Indices and tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
-

--- a/tests/param/marshal_param_test.py
+++ b/tests/param/marshal_param_test.py
@@ -108,7 +108,7 @@ def test_path_integer(empty_swagger_spec, param_spec):
         ('34', '/pet/34'),
         ('a value', '/pet/a%20value'),
         (u'Ümlaut', '/pet/%C3%9Cmlaut'),
-        ('/\%?=', '/pet/%2F%5C%25%3F%3D'),
+        ('/\\%?=', '/pet/%2F%5C%25%3F%3D'),
     ]
 )
 def test_path_string(empty_swagger_spec, param_spec, string_param, expected_path):

--- a/tests/swagger20_validator/enum_validator_test.py
+++ b/tests/swagger20_validator/enum_validator_test.py
@@ -26,9 +26,8 @@ def test_multiple_jsonschema_calls_if_enum_items_present_as_array():
     assert "'d4' is not one of ['a1', 'b2', 'c3']" in str(errors[0])
 
 
-@patch('jsonschema._validators.enum')
-def test_single_jsonschema_call_if_enum_instance_not_array(
-        jsonschema_enum_validator):
+@patch('bravado_core.swagger20_validator._DRAFT4_ENUM_VALIDATOR')
+def test_single_jsonschema_call_if_enum_instance_not_array(jsonschema_enum_validator):
     enums = ['a1', 'b2', 'c3']
     param_schema = {
         'enum': enums
@@ -40,9 +39,8 @@ def test_single_jsonschema_call_if_enum_instance_not_array(
         None, enums, ['a1', 'd4'], param_schema)
 
 
-@patch('jsonschema._validators.enum')
-def test_skip_validation_for_optional_enum_with_None_value(
-        jsonschema_enum_validator):
+@patch('bravado_core.swagger20_validator._DRAFT4_ENUM_VALIDATOR')
+def test_skip_validation_for_optional_enum_with_None_value(jsonschema_enum_validator):
     enums = ['encrypted', 'plaintext']
     param_schema = {
         'type': 'string',

--- a/tests/swagger20_validator/format_validator_test.py
+++ b/tests/swagger20_validator/format_validator_test.py
@@ -9,9 +9,10 @@ from bravado_core.swagger20_validator import format_validator
 from bravado_core.validate import validate_object
 
 
-@patch('jsonschema._validators.format')
+@patch('bravado_core.swagger20_validator._DRAFT4_FORMAT_VALIDATOR')
 def test_skip_when_validating_a_parameter_schema_and_parameter_value_is_None(
-        m_format_validator, minimal_swagger_spec):
+    m_format_validator, minimal_swagger_spec,
+):
     param_schema = {
         'name': 'foo',
         'in': 'query',
@@ -27,9 +28,10 @@ def test_skip_when_validating_a_parameter_schema_and_parameter_value_is_None(
     assert m_format_validator.call_count == 0
 
 
-@patch('jsonschema._validators.format')
+@patch('bravado_core.swagger20_validator._DRAFT4_FORMAT_VALIDATOR')
 def test_validate_when_parameter_schema_and_parameter_value_is_not_None(
-        m_format_validator, minimal_swagger_spec):
+    m_format_validator, minimal_swagger_spec,
+):
     param_schema = {
         'name': 'foo',
         'in': 'query',
@@ -42,9 +44,10 @@ def test_validate_when_parameter_schema_and_parameter_value_is_not_None(
     m_format_validator.assert_called_once_with(*args)
 
 
-@patch('jsonschema._validators.format')
-def test_validate_when_not_a_parameter_schema(m_format_validator,
-                                              minimal_swagger_spec):
+@patch('bravado_core.swagger20_validator._DRAFT4_FORMAT_VALIDATOR')
+def test_validate_when_not_a_parameter_schema(
+    m_format_validator, minimal_swagger_spec,
+):
     string_schema = {
         'name': 'foo',
         'type': 'string',
@@ -56,9 +59,10 @@ def test_validate_when_not_a_parameter_schema(m_format_validator,
     m_format_validator.assert_called_once_with(*args)
 
 
-@patch('jsonschema._validators.format')
+@patch('bravado_core.swagger20_validator._DRAFT4_FORMAT_VALIDATOR')
 def test_skip_when_nullable_property_schema_and_value_is_None(
-        m_format_validator, minimal_swagger_spec):
+    m_format_validator, minimal_swagger_spec,
+):
     prop_schema = {
         'x-nullable': True,
         'type': 'string',
@@ -73,9 +77,10 @@ def test_skip_when_nullable_property_schema_and_value_is_None(
     assert m_format_validator.call_count == 0
 
 
-@patch('jsonschema._validators.format')
+@patch('bravado_core.swagger20_validator._DRAFT4_FORMAT_VALIDATOR')
 def test_validate_when_not_nullable_property_schema_and_value_is_None(
-        m_format_validator, minimal_swagger_spec):
+    m_format_validator, minimal_swagger_spec,
+):
     prop_schema = {
         'x-nullable': False,
         'type': 'string',

--- a/tests/swagger20_validator/required_validator_test.py
+++ b/tests/swagger20_validator/required_validator_test.py
@@ -16,8 +16,9 @@ def param_spec():
     }
 
 
-def test_fail_if_required_parameter_but_not_present(minimal_swagger_spec,
-                                                    param_spec):
+def test_fail_if_required_parameter_but_not_present(
+    minimal_swagger_spec, param_spec,
+):
     errors = list(
         required_validator(
             minimal_swagger_spec,
@@ -30,8 +31,9 @@ def test_fail_if_required_parameter_but_not_present(minimal_swagger_spec,
     assert 'foo is a required parameter' in str(error)
 
 
-def test_pass_if_not_required_parameter_and_not_present(minimal_swagger_spec,
-                                                        param_spec):
+def test_pass_if_not_required_parameter_and_not_present(
+    minimal_swagger_spec, param_spec,
+):
     param_spec['required'] = False
     errors = list(
         required_validator(
@@ -44,16 +46,17 @@ def test_pass_if_not_required_parameter_and_not_present(minimal_swagger_spec,
     assert len(errors) == 0
 
 
-def test_call_to_jsonschema_if_not_param(minimal_swagger_spec):
+@patch('bravado_core.swagger20_validator._DRAFT4_REQUIRED_VALIDATOR')
+def test_call_to_jsonschema_if_not_param(jsonschema_required_validator, minimal_swagger_spec):
     property_spec = {'type': 'integer'}
     validator = Mock()
     required = True
     instance = 34
-    with patch('jsonschema._validators.required_draft4') as m:
-        list(required_validator(
-            minimal_swagger_spec,
-            validator,
-            required,
-            instance,
-            property_spec))
-    m.assert_called_once_with(validator, required, instance, property_spec)
+    list(required_validator(
+        minimal_swagger_spec,
+        validator,
+        required,
+        instance,
+        property_spec,
+    ))
+    jsonschema_required_validator.assert_called_once_with(validator, required, instance, property_spec)

--- a/tests/swagger20_validator/type_validator_test.py
+++ b/tests/swagger20_validator/type_validator_test.py
@@ -4,9 +4,10 @@ from mock import patch
 from bravado_core.swagger20_validator import type_validator
 
 
-@patch('jsonschema._validators.type_draft4')
+@patch('bravado_core.swagger20_validator._DRAFT4_TYPE_VALIDATOR')
 def test_skip_when_validating_a_parameter_schema_and_parameter_value_is_None(
-        m_draft4_type_validator, minimal_swagger_spec):
+    m_draft4_type_validator, minimal_swagger_spec,
+):
     param_schema = {'name': 'foo', 'in': 'query', 'type': 'string'}
     list(type_validator(
         minimal_swagger_spec,
@@ -17,9 +18,10 @@ def test_skip_when_validating_a_parameter_schema_and_parameter_value_is_None(
     assert m_draft4_type_validator.call_count == 0
 
 
-@patch('jsonschema._validators.type_draft4')
+@patch('bravado_core.swagger20_validator._DRAFT4_TYPE_VALIDATOR')
 def test_validate_when_parameter_schema_and_parameter_value_is_not_None(
-        m_draft4_type_validator, minimal_swagger_spec):
+    m_draft4_type_validator, minimal_swagger_spec,
+):
     param_schema = {'name': 'foo', 'in': 'query', 'type': 'string'}
     args = (None, param_schema['type'], 'foo',
             param_schema)
@@ -27,9 +29,10 @@ def test_validate_when_parameter_schema_and_parameter_value_is_not_None(
     m_draft4_type_validator.assert_called_once_with(*args)
 
 
-@patch('jsonschema._validators.type_draft4')
-def test_validate_when_not_a_parameter_schema(m_draft4_type_validator,
-                                              minimal_swagger_spec):
+@patch('bravado_core.swagger20_validator._DRAFT4_TYPE_VALIDATOR')
+def test_validate_when_not_a_parameter_schema(
+    m_draft4_type_validator, minimal_swagger_spec,
+):
     string_schema = {'name': 'foo', 'type': 'string'}
     args = (None, string_schema['type'], 'foo',
             string_schema)
@@ -37,9 +40,10 @@ def test_validate_when_not_a_parameter_schema(m_draft4_type_validator,
     m_draft4_type_validator.assert_called_once_with(*args)
 
 
-@patch('jsonschema._validators.type_draft4')
+@patch('bravado_core.swagger20_validator._DRAFT4_TYPE_VALIDATOR')
 def test_skip_when_nullable_property_schema_and_value_is_None(
-        m_draft4_type_validator, minimal_swagger_spec):
+    m_draft4_type_validator, minimal_swagger_spec,
+):
     prop_schema = {'x-nullable': True, 'type': 'string'}
     list(type_validator(
         minimal_swagger_spec,
@@ -50,9 +54,10 @@ def test_skip_when_nullable_property_schema_and_value_is_None(
     assert m_draft4_type_validator.call_count == 0
 
 
-@patch('jsonschema._validators.type_draft4')
+@patch('bravado_core.swagger20_validator._DRAFT4_TYPE_VALIDATOR')
 def test_validate_when_not_nullable_property_schema_and_value_is_None(
-        m_draft4_type_validator, minimal_swagger_spec):
+    m_draft4_type_validator, minimal_swagger_spec,
+):
     prop_schema = {'x-nullable': False, 'type': 'string'}
     args = (None, prop_schema['type'], None, prop_schema)
     list(type_validator(minimal_swagger_spec, *args))


### PR DESCRIPTION
Fixes: #303 

The goal of this PR is to guarantee bravado-core interoperability with jsonschema version 3 (released only in alpha for now).
The new release is changing how the validator methods are named within jsonschema._validators package.
In general we should not _import_ private definitions, but this was done.

In order to make bravado-core able to work with the current jsonschema releases and the new release (alpha released) we need to call the _original_ validators using a different approach.
Instead of calling validator methods from the private module we could extract them from `Draft4Validator.VALIDATORS` class attribute (by using only public informations).
