### PR TITLE
Add internally_dereference_refs and use_spec_url_for_base_path Spec config in docs

### DIFF
--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -45,14 +45,14 @@ Config key                    Type            Default   Description
                                                         | validated at all.
 ----------------------------- --------------- --------- ----------------------------------------------------
 *internally_dereference_refs* boolean         False     | Completely dereference $refs to maximize
-                                                        | marshaling and unmarshalling performances.
+                                                        | marshalling and unmarshalling performance.
                                                         | **NOTE**: this depends on validate_swagger_spec
 ----------------------------- --------------- --------- ----------------------------------------------------
-*use_spec_url_for_base_path*  boolean         False     | What value to assume for basePath if it is missing
+*use_spec_url_for_base_path*  boolean         False     | What value to assume for `basePath` if it is missing
                                                         | from the spec (this config option is ignored if
                                                         | `basePath` is present in the spec).
-                                                        | If `True`, use the `path` element of the URL the
+                                                        | If enabled, use the `path` element of the URL the
                                                         | spec was retrieved from.
-                                                        | If `False`, set basePath to `/` (conforms to
-                                                        | Swagger 2.0 specification)
+                                                        | If disabled, set `basePath` to `/` (conforms to
+                                                        | the Swagger 2.0 specification)
 ============================= =============== ========= ====================================================

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -43,4 +43,16 @@ Config key                    Type            Default   Description
                                                         | to ``object`` and be validated as such.
                                                         | When set to ``False``, missing types will not be
                                                         | validated at all.
+----------------------------- --------------- --------- ----------------------------------------------------
+*internally_dereference_refs* boolean         False     | Completely dereference $refs to maximize
+                                                        | marshaling and unmarshalling performances.
+                                                        | **NOTE**: this depends on validate_swagger_spec
+----------------------------- --------------- --------- ----------------------------------------------------
+*use_spec_url_for_base_path*  boolean         False     | What value to assume for basePath if it is missing
+                                                        | from the spec (this config option is ignored if
+                                                        | `basePath` is present in the spec).
+                                                        | If `True`, use the `path` element of the URL the
+                                                        | spec was retrieved from.
+                                                        | If `False`, set basePath to `/` (conforms to
+                                                        | Swagger 2.0 specification)
 ============================= =============== ========= ====================================================


### PR DESCRIPTION
read the docs documentation is missing two Spec configuration flags `internally_dereference_refs` and `use_spec_url_for_base_path`.

The goal of this PR is to add them 😄 