### PR TITLE
Update test_validate_invalid_polymorphic_does_not_alter_validation_paths assertion

### DIFF
--- a/tests/validate/validate_object_test.py
+++ b/tests/validate/validate_object_test.py
@@ -445,7 +445,7 @@ def test_validate_invalid_polymorphic_does_not_alter_validation_paths(polymorphi
     validation_error = excinfo.value
     assert validation_error.validator == 'required'
     assert validation_error.validator_value == ['birth_date']
-    assert validation_error.message == '\'birth_date\' is a required property'
+    assert validation_error.message == '{} is a required property'.format(repr(u'birth_date'))
     # as birth_date is defined on the 2nd item of the Dog allOf list the expected schema path should be allOf/1/required
     assert list(validation_error.schema_path) == ['allOf', 1, 'required']
 


### PR DESCRIPTION
The assertion seems to break our internal tests.
```
>       assert validation_error.message == '\'birth_date\' is a required property'
E       assert "u'birth_date...ired property" == "'birth_date' ...ired property"
```
This is most likely caused by the usual unicode issue :(

I do see two potential approaches there:
 * ensure that `from __future__ import unicode_literals` is present on all python files (via pre-commit hook)
 * invert and relax the assertion

I wanted to try the first approach but it ends up taking a bit longer as a few tests need to be fixed (issue similar to the above snipped), so I'm relaxing the condition first so we could get internal tests green again