### PR TITLE
Normalise URIs

### DIFF
--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -15,6 +15,7 @@ from bravado_core.schema import is_list_like
 from bravado_core.schema import is_ref
 from bravado_core.schema import SWAGGER_PRIMITIVES
 from bravado_core.util import determine_object_type
+from bravado_core.util import normalize_uri
 from bravado_core.util import ObjectType
 from bravado_core.util import strip_xscope
 
@@ -707,9 +708,8 @@ def _post_process_spec(spec_dict, spec_resolver, on_container_callbacks):
             if json_reference is None:
                 json_reference = '{}#'.format(spec_resolver.resolution_scope)
 
-            is_reference = is_ref(fragment)
-            if is_reference:
-                ref = fragment['$ref']
+            if is_ref(fragment):
+                fragment['$ref'] = ref = normalize_uri(fragment['$ref'])
                 attach_scope(fragment, spec_resolver)
                 with spec_resolver.resolving(ref) as target:
                     if id(target) in cache:

--- a/bravado_core/util.py
+++ b/bravado_core/util.py
@@ -7,6 +7,8 @@ from functools import wraps
 from enum import Enum
 from six import iteritems
 from six import iterkeys
+from six.moves.urllib.parse import urlparse
+from six.moves.urllib.parse import urlunparse
 
 from bravado_core.schema import is_dict_like
 from bravado_core.schema import is_list_like
@@ -216,3 +218,23 @@ def strip_xscope(spec_dict):
 
     descend(result)
     return result
+
+
+def normalize_uri(uri):
+    """
+    Normalize the input uri to reduce as much as possible equivalent URIs to
+    have different representation.
+
+    Currently supported cases:
+     * fragments not starting with /.
+       NOTE: from JSON pointer prospective whatever#fragment is equivalent to whatever#/fragment
+
+    :param uri: uri to normalize
+    :return: normalized uri
+    """
+    scheme, netloc, url, params, query, fragment = urlparse(uri)
+
+    if fragment and not fragment.startswith('/'):
+        fragment = '/{}'.format(fragment)
+
+    return urlunparse((scheme, netloc, url, params, query, fragment))

--- a/test-data/2.0/multi-file-recursive/flattened-multi-file-recursive-spec.json
+++ b/test-data/2.0/multi-file-recursive/flattened-multi-file-recursive-spec.json
@@ -131,6 +131,19 @@
         }
       ]
     },
+    "/normalised_uri": {
+      "get": {
+        "description": "This endpoint defines 200 and 300 response code with two equivalent but different references, after flattening we do expect the same reference",
+        "responses": {
+          "200": {
+            "$ref": "#/responses/lfile:aux.json|..responses..ok_response"
+          },
+          "300": {
+            "$ref": "#/responses/lfile:aux.json|..responses..ok_response"
+          }
+        }
+      }
+    },
     "/recursive/response": {
       "get": {
         "responses": {

--- a/test-data/2.0/multi-file-recursive/swagger.json
+++ b/test-data/2.0/multi-file-recursive/swagger.json
@@ -92,6 +92,19 @@
                     }
                 }
             }
+        },
+        "/normalised_uri": {
+            "get": {
+                "description": "This endpoint defines 200 and 300 response code with two equivalent but different references, after flattening we do expect the same reference",
+                "responses": {
+                    "200": {
+                        "$ref": "aux.json#/responses/ok_response"
+                    },
+                    "300": {
+                        "$ref": "aux.json#responses/ok_response"
+                    }
+                }
+            }
         }
     },
     "swagger": "2.0"

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -5,6 +5,7 @@ from bravado_core.util import AliasKeyDict
 from bravado_core.util import cached_property
 from bravado_core.util import determine_object_type
 from bravado_core.util import memoize_by_id
+from bravado_core.util import normalize_uri
 from bravado_core.util import ObjectType
 from bravado_core.util import sanitize_name
 from bravado_core.util import strip_xscope
@@ -193,3 +194,15 @@ def test_no_op():
 
 def test_petstore_spec(petstore_spec):
     assert petstore_spec.client_spec_dict == strip_xscope(petstore_spec.spec_dict)
+
+
+@pytest.mark.parametrize(
+    'uri, normalized_uri',
+    [
+        ('uri', 'uri'),
+        ('uri#/fragment', 'uri#/fragment'),
+        ('uri#fragment', 'uri#/fragment'),
+    ],
+)
+def test_normalize_uri(uri, normalized_uri):
+    assert normalize_uri(uri) == normalized_uri


### PR DESCRIPTION
While investigating internal issues I did noticed that the result of spec flattening is dependent on how the references looks like.

Specs like
```yaml
swagger: '2.0'
info:
  title: Test
  version: '1.0'
definitions:
  text:
    type: string
paths:
  /endpoint:
    get:
      responses:
        '200':
          description: ''
          schema:
            $ref: '#/definitions/text'
        '300':
          description: ''
          schema:
            $ref: '#definitions/text'
```
would be flattened in something like
```yaml
definitions:
  'lfile:.|..definitions..text':
    type: string
  'lfile:.|definitions..text':
    type: string
info:
  title: Test
  version: '1.0'
paths:
  /endpoint:
    get:
      responses:
        '200':
          description: ''
          schema:
            $ref: '#/definitions/lfile:.|..definitions..text'
        '300':
          description: ''
          schema:
            $ref: '#/definitions/lfile:.|definitions..text'
swagger: '2.0'
```

instead of
```yaml
definitions:
  'lfile:.|..definitions..text':
    type: string
info:
  title: Test
  version: '1.0'
paths:
  /endpoint:
    get:
      responses:
        '200':
          description: ''
          schema:
            $ref: '#/definitions/lfile:.|..definitions..text'
        '300':
          description: ''
          schema:
            $ref: '#/definitions/lfile:.|..definitions..text'
swagger: '2.0'
```

Note the duplicate definition of `text` (as `lfile:.|..definitions..text` and `lfile:.|definitions..text`)

This is caused by the fact that the original spec have two equivalent but not equal references to `text` (`#/definitions/text` and `#definitions/text`).

The goal of this PR is to ensure that once we're building a `bravado_core.spec.Spec` object we're performing some form of minimal normalisation of URIs such that duplication of definitions is reduced in case of flattening