### PR TITLE
Be resilient in case of None in references

### DIFF
--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -3,6 +3,7 @@ import copy
 from collections import Mapping
 
 from six import iteritems
+from six import string_types
 
 from bravado_core.exception import SwaggerMappingError
 
@@ -57,7 +58,7 @@ def is_ref(spec):
     :rtype: boolean
     """
     try:
-        return '$ref' in spec and is_dict_like(spec)
+        return '$ref' in spec and is_dict_like(spec) and isinstance(spec['$ref'], string_types)
     except TypeError:
         return False
 

--- a/test-data/2.0/specs-with-None-in-ref/flattened.json
+++ b/test-data/2.0/specs-with-None-in-ref/flattened.json
@@ -1,0 +1,36 @@
+{
+  "definitions": {
+    "model1": {
+      "type": "object",
+      "x-extends": [
+        {
+          "$ref": null
+        }
+      ],
+      "x-model": "model1"
+    },
+    "model2": {
+      "type": "object",
+      "x-model": "model2"
+    }
+  },
+  "info": {
+    "title": "Test",
+    "version": "1.0"
+  },
+  "paths": {
+    "/endpoint": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/model1"
+            }
+          }
+        }
+      }
+    }
+  },
+  "swagger": "2.0"
+}

--- a/test-data/2.0/specs-with-None-in-ref/swagger.json
+++ b/test-data/2.0/specs-with-None-in-ref/swagger.json
@@ -1,0 +1,34 @@
+{
+  "info": {
+    "title": "Test",
+    "version": "1.0"
+  },
+  "definitions": {
+    "model1": {
+      "type": "object",
+      "x-extends": [
+        {
+          "$ref": null
+        }
+      ]
+    },
+    "model2": {
+      "type": "object"
+    }
+  },
+  "paths": {
+    "/endpoint": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/model1"
+            }
+          }
+        }
+      }
+    }
+  },
+  "swagger": "2.0"
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -187,6 +187,31 @@ def simple_crossfer_spec(simple_crossfer_dict, simple_crossfer_abspath):
 
 
 @pytest.fixture
+def specs_with_none_in_ref_abspath(my_dir):
+    return os.path.join(my_dir, '../test-data/2.0/specs-with-None-in-ref/swagger.json')
+
+
+@pytest.fixture
+def specs_with_none_in_ref_dict(specs_with_none_in_ref_abspath):
+    return _read_json(specs_with_none_in_ref_abspath)
+
+
+@pytest.fixture
+def specs_with_none_in_ref_spec(specs_with_none_in_ref_dict, specs_with_none_in_ref_abspath):
+    return Spec.from_dict(specs_with_none_in_ref_dict, origin_url=get_url(specs_with_none_in_ref_abspath))
+
+
+@pytest.fixture
+def flattened_specs_with_none_in_ref_abspath(my_dir):
+    return os.path.join(my_dir, '../test-data/2.0/specs-with-None-in-ref/flattened.json')
+
+
+@pytest.fixture
+def flattened_specs_with_none_in_ref_dict(flattened_specs_with_none_in_ref_abspath):
+    return _read_json(flattened_specs_with_none_in_ref_abspath)
+
+
+@pytest.fixture
 def node_spec():
     """Used in tests that have recursive $refs
     """

--- a/tests/spec/Spec/flattened_spec_test.py
+++ b/tests/spec/Spec/flattened_spec_test.py
@@ -324,3 +324,7 @@ def test_rename_definition_references(spec_flattener, spec_dict, expected_spec_d
 
 def test_referenced_and_discovered_models_are_not_lost_after_flattening(simple_crossfer_spec):
     assert simple_crossfer_spec.flattened_spec['definitions']['pong']['x-model'] == 'pong'
+
+
+def test_specs_with_none_in_ref_spec(specs_with_none_in_ref_spec, flattened_specs_with_none_in_ref_dict):
+    assert specs_with_none_in_ref_spec.flattened_spec == flattened_specs_with_none_in_ref_dict


### PR DESCRIPTION
The goal of this PR is to make sure that reference detection takes care of the actual value of the json-pointer (value of `$ref` attribute).

This issue was noticed while debugging a recursion error that was happening while flattening specs that have `None` value in references.
While this condition is odd while writing with JSON specs it is not uncommon while working with YAML specs (we're humans and is not so weird to forget to quote a reference if it starts with `#`).
```yaml
definitions:
  mod1:
    type: object
  mod2:
    $ref: #/definitions/mod1   <- this will be rendered as {'$ref': None} as `#` in YAML represents a comment
```

Unbounded recursion during flattening is happening because `deref` will try to dereference it and it will actually succeed by getting the original object (the whole swagger specs), then descending it we will be back to the case of having `None` in `$ref` and so until we get an ugly `RecursionError`.

To makes flattening process safer for this case I did first added checks for `isinstance(obj['$ref'], six.string_types)` in flattening and model discovery.

After doing that I wanted to benchmark the performance hit that we could have if we introduce this additional check in `bravado_core.schema.is_ref` directly.
The benchmark results shows that adding the `isinstance` check is not making things slower so I decided to make sure that `is_ref` check is more accurate.

Benchmarks are available on: https://gist.github.com/macisamuele/42434160b17edaf22fcbf2415902c926

NOTE: the alternative solution is available on https://github.com/macisamuele/bravado-core/tree/maci-be-resilient-in-case-of-None-ref-no-edit-to-is_ref
