### PR TITLE
Remove unneded assertion

### DIFF
--- a/tests/validate/validate_object_test.py
+++ b/tests/validate/validate_object_test.py
@@ -445,7 +445,6 @@ def test_validate_invalid_polymorphic_does_not_alter_validation_paths(polymorphi
     validation_error = excinfo.value
     assert validation_error.validator == 'required'
     assert validation_error.validator_value == ['birth_date']
-    assert validation_error.message == '\'birth_date\' is a required property'
     # as birth_date is defined on the 2nd item of the Dog allOf list the expected schema path should be allOf/1/required
     assert list(validation_error.schema_path) == ['allOf', 1, 'required']
 


### PR DESCRIPTION
We uncovered an issue with a test on Python 2.7 internally, which fails due to the error message being `u'birth_date' is a required property'` (with the leading `u` character), while the assertion didn't expect the `u` to be there.

Further debugging showed that this is not failing on travis due to us using simplejson, and its C module `_speedups.so` specifically. Using that we get `str` objects when loading JSON, while not using it (or using the stdlib `json` module) yields `unicode` strings and dictionary keys.

The Python 2 documentation for the `json` module [clearly states](https://docs.python.org/2/library/json.html) that JSON strings should be decoded into Python unicode strings. So the simplejson C module changes behavior here.

It turns out we don't need that assertion anyway, so let's remove it altogether.

Side note: PyYAML returns str when decoding YAML on Python 2, so there's a difference in behavior for us on Python 2 depending on how the specs are written.

I've opted _not_ to remove simplejson altogether since that could break a few things internally. The fact that we get `str` objects on Python 2 seems to match expectations, and on Python 3 it's not an issue anyway (we always get `str`, both for JSON and YAML, and that's what people expect).