### PR TITLE
Update build_http_handlers.read_file to avoid usage of jsonschema.compact.urlopen

### DIFF
--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -3,12 +3,10 @@ import json
 import logging
 import os.path
 import warnings
-from contextlib import closing
 
 import yaml
 from jsonref import JsonRef
 from jsonschema import FormatChecker
-from jsonschema.compat import urlopen
 from jsonschema.validators import RefResolver
 from six import iteritems
 from six import iterkeys
@@ -375,7 +373,7 @@ def build_http_handlers(http_client):
             return response.json()
 
     def read_file(uri):
-        with closing(urlopen(uri)) as fp:
+        with open(urlparse(uri).path) as fp:
             if is_yaml(uri):
                 return yaml.safe_load(fp)
             else:


### PR DESCRIPTION
The objective of this PR is to remove bravado-core dependency on `jsonschema.compact.urlopen` as it is breaking python 2.7 tests.

The breaking change has been introduced by `jsonschema>=3.0.0`, specifically on https://github.com/Julian/jsonschema/pull/472/files which alters the behaviour of `jsonschema.compact.urlopen` on python2.
The alteration consist of wrapping the result of `urlopen` into a `closing` which leads to closing an object that does not have `close` attribute and consequently making the tests failures.

Starting from `bravado-core>=5.10.0` we should be supporting `jsonschema>=3.0.0` but this specific change was not announced on the [CHANGELOG](https://github.com/Julian/jsonschema/blob/master/CHANGELOG.rst#v300) even if it was changing a public interface

Once this PR is approved we should be releasing a new version making explicit the fact that this is the first version that properly works with `jsonschema>=3.0.0`