### PR TITLE
Fix Python 3.8 issue, use separate flake8 pre-commit hook, fix tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,18 +7,22 @@ repos:
     -   id: debug-statements
     -   id: end-of-file-fixer
     -   id: fix-encoding-pragma
-    -   id: flake8
     -   id: name-tests-test
     -   id: trailing-whitespace
     -   id: requirements-txt-fixer
         files: requirements-dev.txt
 -   repo: https://github.com/pre-commit/mirrors-autopep8
-    rev: v1.4.2
+    rev: v1.4.3
     hooks:
     -   id: autopep8
         args:
         - -i
         - --ignore=E309,E501
+-   repo: https://gitlab.com/pycqa/flake8.git
+    rev: 3.7.7
+    hooks:
+    -   id: flake8
+        exclude: ^docs
 -   repo: https://github.com/asottile/reorder_python_imports
     rev: v1.3.3
     hooks:

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ docs:
 install:
 	pip install .
 
-test: install-hooks
+test:
 	tox -- tests --ignore tests/profiling
 
 tests: test
@@ -24,7 +24,7 @@ benchmark: install-hooks
 
 .PHONY: install-hooks
 install-hooks:
-	tox -e pre-commit -- install -f --install-hooks
+	tox -e pre-commit
 
 clean:
 	@rm -rf .benchmarks .tox build dist docs/build *.egg-info

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 import copy
-from collections import Mapping
+try:
+    from collections import Mapping
+except ImportError:  # Python 3.8+
+    from collections.abc import Mapping
 
 from six import iteritems
 from six import string_types

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -3,12 +3,10 @@ import json
 import logging
 import os.path
 import warnings
-from contextlib import closing
 
 import yaml
 from jsonref import JsonRef
 from jsonschema import FormatChecker
-from jsonschema.compat import urlopen
 from jsonschema.validators import RefResolver
 from six import iteritems
 from six import iterkeys
@@ -375,7 +373,7 @@ def build_http_handlers(http_client):
             return response.json()
 
     def read_file(uri):
-        with closing(urlopen(uri)) as fp:
+        with open(urlparse(uri).path, mode='rb') as fp:
             if is_yaml(uri):
                 return yaml.safe_load(fp)
             else:

--- a/tox.ini
+++ b/tox.ini
@@ -47,4 +47,5 @@ deps =
 setenv =
     LC_CTYPE=en_US.UTF-8
 commands =
+    pre-commit install --install-hooks
     pre-commit run --all-files


### PR DESCRIPTION
Starting with Python 3.8 it's not possible to import `Mapping` from `collections`, we'll need to use `collections.abc` as package.

Additionally, I'm introducing the separate flake8 pre-commit hook as well as changing things around pre-commit hook installation slightly to make sure running `tox` directly also installs them. I've also incorporated the fix from #319 with one slight modification so the tests pass on Python 3.