### PR TITLE
Do not assume that request body is present in case of optional body parameter

### DIFF
--- a/bravado_core/param.py
+++ b/bravado_core/param.py
@@ -178,12 +178,19 @@ def unmarshal_param(param, request):
         else:
             raw_value = cast_param(request.form.get(param.name, default_value))
     elif location == 'body':
-        # TODO: verify content-type header
         try:
+            # TODO: verify content-type header
             raw_value = request.json()
         except ValueError as json_error:
-            raise SwaggerMappingError("Error reading request body JSON: {0}".
-                                      format(str(json_error)))
+            # If the body parameter is required then we should make sure that an exception
+            # is thrown, instead if the body parameter is optional is OK-ish to assume that
+            # raw_value is the default_value
+            if param.required:
+                raise SwaggerMappingError(
+                    "Error reading request body JSON: {0}".format(str(json_error)),
+                )
+            else:
+                raw_value = default_value
     else:
         raise SwaggerMappingError(
             "Don't know how to unmarshal_param with location {0}".


### PR DESCRIPTION
Fixes: #321 

The following PR addresses the not needed assumption of body presence in case a body parameter is defined.

In case of an operation defined like
```yaml
paths:
  /endpoint:
    post:
      parameters:
      - in: body
        name: body
        required: false
        schema:
          type: object
```
a call like `curl -X POST .../endpoint` would fail with a stacktrace like
```
Traceback (most recent call last):
  File "/Users/maci/my_service/virtualenv_run/lib/python3.6/site-packages/bravado_core/param.py", line 183, in unmarshal_param
    raw_value = request.json()
  File "/Users/maci/my_service/virtualenv_run/lib/python3.6/site-packages/pyramid_swagger/tween.py", line 271, in json
    return getattr(self.request, 'json_body', {})
  File "/Users/maci/my_service/virtualenv_run/lib/python3.6/site-packages/pyramid/request.py", line 237, in json_body
    return json.loads(text_(self.body, self.charset))
  File "/usr/lib/python3.6/json/__init__.py", line 354, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.6/json/decoder.py", line 339, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.6/json/decoder.py", line 357, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/maci/my_service/virtualenv_run/lib/python3.6/site-packages/pyramid_swagger/tween.py", line 476, in _validate
    return f(*args, **kwargs)
  File "/Users/maci/my_service/virtualenv_run/lib/python3.6/site-packages/pyramid_swagger/tween.py", line 584, in swaggerize_request
    request_data = unmarshal_request(request, op)
  File "/Users/maci/my_service/virtualenv_run/lib/python3.6/site-packages/bravado_core/request.py", line 66, in unmarshal_request
    param_value = unmarshal_param(param, request)
  File "/Users/maci/my_service/virtualenv_run/lib/python3.6/site-packages/bravado_core/param.py", line 186, in unmarshal_param
    format(str(json_error)))
bravado_core.exception.SwaggerMappingError: Error reading request body JSON: Expecting value: line 1 column 1 (char 0)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/maci/my_service/virtualenv_run/lib/python3.6/site-packages/pyramid/tweens.py", line 39, in excview_tween
    response = handler(request)
  File "/Users/maci/my_service/virtualenv_run/lib/python3.6/site-packages/pyramid_swagger/tween.py", line 185, in validator_tween
    op_or_validators_map,
  File "/Users/maci/my_service/virtualenv_run/lib/python3.6/site-packages/pyramid_swagger/tween.py", line 484, in _validate
    raise e
pyramid_swagger.exceptions.RequestValidationError: Error reading request body JSON: Expecting value: line 1 column 1 (char 0)
```

NOTE: the current implementation will shallow eventual json validation errors in case the endpoint is called with a body containing invalid JSON

FYI: @erezeshkol