### PR TITLE
build_http_handlers as Spec instance method (allow subclassing)

### DIFF
--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -121,7 +121,7 @@ class Spec(object):
         self.resolver = RefResolver(
             base_uri=origin_url or '',
             referrer=self.spec_dict,
-            handlers=build_http_handlers(http_client),
+            handlers=self.get_ref_handlers(),
         )
 
         # spec dict used to build resources, in case internally_dereference_refs config is enabled
@@ -183,7 +183,7 @@ class Spec(object):
             self.resolver = validator20.validate_spec(
                 spec_dict=self.spec_dict,
                 spec_url=self.origin_url or '',
-                http_handlers=build_http_handlers(self.http_client),
+                http_handlers=self.get_ref_handlers(),
             )
 
     def build(self):
@@ -207,6 +207,17 @@ class Spec(object):
 
         self.api_url = build_api_serving_url(self.spec_dict, self.origin_url,
                                              **build_api_kwargs)
+
+    def get_ref_handlers(self):
+        """Get mapping from URI schemes to handlers that takes a URI.
+
+        The handlers (callables) are used by the RefResolver to retrieve
+        remote specification $refs.
+
+        :returns: dict like {'http': callable, 'https': callable)
+        :rtype: dict
+        """
+        return build_http_handlers(self.http_client)
 
     def _force_deref(self, ref_dict):
         """Dereference ref_dict (if it is indeed a ref) and return what the

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -214,7 +214,7 @@ class Spec(object):
         The handlers (callables) are used by the RefResolver to retrieve
         remote specification $refs.
 
-        :returns: dict like {'http': callable, 'https': callable)
+        :returns: dict like {'http': callable, 'https': callable}
         :rtype: dict
         """
         return build_http_handlers(self.http_client)
@@ -368,7 +368,7 @@ def build_http_handlers(http_client):
 
     :param http_client: http_client with a request() method
 
-    :returns: dict like {'http': callable, 'https': callable)
+    :returns: dict like {'http': callable, 'https': callable}
     """
     def download(uri):
         log.debug('Downloading %s', uri)


### PR DESCRIPTION
This PR is a re-proposal of #98 
The objective is to allow users of bravado_core.spec.Spec to easily override the reference handlers, allowing to extend the set of supported protocols, formats, etc.

I wanted to re-use the original PR, but due to merge conflicts and absence of the remote fork I had to apply the patch on a new branch.

@Arkq: FYI
