### PR TITLE
Implement deepcopy support for Model instances

### DIFF
--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -3,6 +3,7 @@ import abc
 import functools
 import logging
 import re
+from copy import deepcopy
 from warnings import warn
 
 import six
@@ -426,6 +427,10 @@ class Model(object):
             if attr_name in self
         ]
         return "{0}({1})".format(self.__class__.__name__, ', '.join(s))
+
+    def __deepcopy__(self, memodict={}):
+        """Deep copy all properties, but not metadata like the Swagger or Model spec attributes."""
+        return self.__class__(**deepcopy(self.__dict))
 
     @property
     def _additional_props(self):

--- a/tests/model/model_test.py
+++ b/tests/model/model_test.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from copy import deepcopy
+
 import pytest
 from mock import Mock
 
@@ -97,6 +99,15 @@ def test_model_is_instance_inherits_from(cat_swagger_spec, pet_type, pet_spec, c
     assert isinstance(cat, cat_type)
     assert isinstance(cat, pet_type)
     assert isinstance(cat, new_pet_type)
+
+
+def test_model_deepcopy(user_type, user_kwargs):
+    user = user_type(**user_kwargs)
+    user_copy = deepcopy(user)
+
+    assert isinstance(user_copy, user_type)
+    assert user == user_copy
+    assert user._as_dict() == user_copy._as_dict()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
It was reported internally that deepcopy doesn't work on model instances and fails with an infinite recursion exception. The test I'm adding failed without my change.

In doing a deep copy we should only copy the model properties, not the metadata set on the class. All of them are stored in the `__dict` attribute.