### PR TITLE
Default to importing collections.abc instead of collections

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+5.12.1 (2019-??-??)
+-------------------
+- Prevent ``DeprecationWarning`` in Python 3.7
+
 5.12.0 (2019-04-10)
 -------------------
 - Allow ``Spec`` subclasses to provide their own ``$ref`` handlers - PR #323

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 import copy
 try:
-    from collections import Mapping
-except ImportError:  # Python 3.8+
     from collections.abc import Mapping
+except ImportError:  # Python 3.2 or older
+    from collections import Mapping
 
 from six import iteritems
 from six import string_types


### PR DESCRIPTION
I'm working a Python 3.7 project internally and I get `DeprecationWarning`s in Python 3.7 to switch to `collections.abc`. This change changes the default to collections.abc so that we stop getting the warning messages.

This should safe for all Python versions, since if a Python version doesn't have `collections.abc`, we'll fallback to `collections`.