### PR TITLE
Use setattr instead on manipulating __dict__ in cached_property

### DIFF
--- a/bravado_core/util.py
+++ b/bravado_core/util.py
@@ -48,7 +48,9 @@ class cached_property(object):
     def __get__(self, obj, cls):
         if obj is None:
             return self
-        value = obj.__dict__[self.func.__name__] = self.func(obj)
+
+        value = self.func(obj)
+        setattr(obj, self.func.__name__, value)
         return value
 
 

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
+import abc
+
 import pytest
+from six import add_metaclass
 
 from bravado_core.util import AliasKeyDict
 from bravado_core.util import cached_property
@@ -34,6 +37,31 @@ def test_cached_property():
     del class_instance.property_1
     assert class_instance.property_1 == 2
     assert class_instance.calls == 2
+
+
+def test_cached_property_in_metaclasses():
+    class CustomType(abc.ABCMeta):
+        calls = 0
+        @cached_property
+        def class_property(cls):
+            cls.calls += 1
+            return cls.calls
+
+    @add_metaclass(CustomType)
+    class Class:
+        pass
+
+    assert Class.class_property == 1
+    assert Class.calls == 1
+
+    # If property is called twice no calls are received from the method
+    assert Class.class_property == 1
+    assert Class.calls == 1
+
+    # If property is deleted then the method is called again
+    del Class.class_property
+    assert Class.class_property == 2
+    assert Class.calls == 2
 
 
 def test_memoize_by_id_decorator():


### PR DESCRIPTION
The goal of this CR is to allow usage of `cached_property` as lazy evaluated and cached class attribute in case of usage in meta class.

The idea of this change is to allow definition of `Model` class attributes as lazy attribute, this could improve creation speed (not all the attributes need to be defined at init time) as well as memory consumption (only needed attributes will be evaluated).