### PR TITLE
Use lazy attributes on model

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,31 +1,40 @@
-.PHONY: all install test tests clean docs benchmark
 
+.PHONY: all
 all: test
 
+.PHONY: build
 build:
 	./setup.py bdist_egg
 
+.PHONY: dev
 dev: clean
 	./setup.py develop
 
+.PHONY: docs
 docs:
 	tox -e docs
 
+.PHONY: install
 install:
 	pip install .
 
+.PHONY: test
 test:
 	tox -- tests --ignore tests/profiling
 
+.PHONY: tests
 tests: test
+	@true
 
-benchmark: install-hooks
+.PHONY: benchmark
+benchmark:
 	tox -e benchmark
 
 .PHONY: install-hooks
 install-hooks:
 	tox -e pre-commit
 
+.PHONY: clean
 clean:
 	@rm -rf .benchmarks .tox build dist docs/build *.egg-info
 	find . -name '*.pyc' -delete

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -234,7 +234,7 @@ class ModelMeta(abc.ABCMeta):
         if not isinstance(type(instance), type(self)):
             return False
 
-        if not hasattr(self, '_model_spec'):
+        if type(self) == ModelMeta:
             # This is the base Model class
             return True
 
@@ -319,6 +319,14 @@ class Model(object):
     # been possible to use the instance's __dict__ itself except that then
     # __getattribute__ would have to have been overridden instead of
     # __getattr__.
+
+    # Use slots to reduce memory footprint of the Model instance
+    __slots__ = (
+        '_json_reference',
+        '_swagger_spec',
+        '_model_spec',
+        '_Model__dict',  # Note the name mangling!
+    )
 
     def __init__(self, **kwargs):
         """Initialize from property values in keyword arguments.

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -6,7 +6,7 @@ import re
 from copy import deepcopy
 from warnings import warn
 
-import six
+from six import add_metaclass
 from six import iteritems
 from swagger_spec_validator.ref_validators import attach_scope
 
@@ -16,6 +16,7 @@ from bravado_core.schema import is_list_like
 from bravado_core.schema import is_ref
 from bravado_core.schema import SWAGGER_PRIMITIVES
 from bravado_core.util import determine_object_type
+from bravado_core.util import lazy_class_attribute
 from bravado_core.util import ObjectType
 from bravado_core.util import strip_xscope
 
@@ -246,7 +247,7 @@ class ModelMeta(abc.ABCMeta):
         return self.__name__ in type(instance)._inherits_from
 
 
-@six.add_metaclass(ModelMeta)
+@add_metaclass(ModelMeta)
 class Model(object):
     """Base class for Swagger models.
 
@@ -258,7 +259,7 @@ class Model(object):
     the names of attributes used in the Python implementation of the model
     (methods, etc.). The solution here is to have all non-property attributes
     making up the public API of this class prefixed by a single underscore
-    (this is done with the :func:`collections.namedtuple` type factory, which
+    (this is how :func:`collections.namedtuple` type factory works, which
     also uses property values with arbitrary names). There may still be name
     conflicts but only if the property name also begins with an underscore,
     which is uncommon. Truly private attributes are prefixed with double
@@ -280,14 +281,36 @@ class Model(object):
 
     .. attribute:: _model_spec
 
-        Class attribute that must be assigned on subclasses. JSON-like dict
-        that describes the model.
+        Class attribute that must be assigned on subclasses.
+        JSON-like dict that describes the model.
 
     .. attribute:: _properties
 
-        Class attribute that must be assigned on subclasses. Dict mapping
-        property names to their specs. See
+        Class attribute that must be assigned on subclasses.
+        Dict mapping property names to their specs. See
         :func:`bravado_core.schema.collapsed_properties`.
+
+    .. attribute:: _inherits_from
+
+        Class attribute that must be assigned on subclasses.
+        List of the models from which the current model inherits from.
+        (The list will be not empty only for schemas with allOf)
+
+
+    .. attribute:: _deny_additional_properties
+
+        Class attribute that must be assigned on subclasses.
+        Flag that specifies if the model can or cannot allow additional
+        properties. NOTE: If _deny_additional_properties is set to True
+        then any operation (get, set or delete) of undefined properties
+        will raise an AttributeError or a KeyError
+
+    .. attribute:: _include_missing_properties
+
+        Class attribute that must be assigned on subclasses.
+        Flag that specified if the model will hold the content of all the
+        parameters even if not explicitly passed. NOTE: the automatically
+        added parameters will be added with `None` value.
     """
 
     # Implementation details:
@@ -319,7 +342,7 @@ class Model(object):
         # Additional property names in dct
         additional = set(dct).difference(self._properties)
 
-        if additional and not self._model_spec.get('additionalProperties', True):
+        if additional and self._deny_additional_properties:
             raise AttributeError(
                 "Model {0} does not have attributes for: {1}"
                 .format(type(self), list(additional))
@@ -333,6 +356,31 @@ class Model(object):
         # we've got additionalProperties to set on the model
         for attr_name in additional:
             self.__dict[attr_name] = dct[attr_name]
+
+    @lazy_class_attribute
+    def _properties(self):
+        return collapsed_properties(self._model_spec, self._swagger_spec)
+
+    @lazy_class_attribute
+    def _inherits_from(self):
+        inherits_from_generator = (
+            _get_model_name(self._swagger_spec.deref(schema))
+            for schema in self._model_spec.get('allOf', [])
+        )
+
+        return [
+            inherits_from
+            for inherits_from in inherits_from_generator
+            if inherits_from is not None
+        ]
+
+    @lazy_class_attribute
+    def _deny_additional_properties(self):
+        return self._model_spec.get('additionalProperties') is False
+
+    @lazy_class_attribute
+    def _include_missing_properties(self):
+        return self._swagger_spec.config['include_missing_properties']
 
     def __contains__(self, obj):
         """Has a property set (including additional)."""
@@ -489,7 +537,7 @@ class Model(object):
         model = object.__new__(cls)
         model.__init_from_dict(
             dct=dct,
-            include_missing_properties=cls._swagger_spec.config['include_missing_properties'],
+            include_missing_properties=cls._include_missing_properties,
         )
         return model
 
@@ -586,19 +634,10 @@ def create_model_type(swagger_spec, model_name, model_spec, bases=(Model,), json
     :rtype: type
     """
 
-    inherits_from = []
-    if 'allOf' in model_spec:
-        for schema in model_spec['allOf']:
-            inherited_name = _get_model_name(swagger_spec.deref(schema))
-            if inherited_name:
-                inherits_from.append(inherited_name)
-
     return type(str(model_name), bases, dict(
         __doc__=ModelDocstring(),
         _swagger_spec=swagger_spec,
         _model_spec=model_spec,
-        _properties=collapsed_properties(model_spec, swagger_spec),
-        _inherits_from=inherits_from,
         _json_reference=json_reference,
     ))
 

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -294,13 +294,13 @@ class Model(object):
 
         Class attribute that must be assigned on subclasses.
         List of the models from which the current model inherits from.
-        (The list will be not empty only for schemas with allOf)
+        The list will be non-empty only for schemas with allOf
 
 
     .. attribute:: _deny_additional_properties
 
         Class attribute that must be assigned on subclasses.
-        Flag that specifies if the model can or cannot allow additional
+        Flag that specifies if the model does or does not allow additional
         properties. NOTE: If _deny_additional_properties is set to True
         then any operation (get, set or delete) of undefined properties
         will raise an AttributeError or a KeyError

--- a/bravado_core/util.py
+++ b/bravado_core/util.py
@@ -54,6 +54,24 @@ class cached_property(object):
         return value
 
 
+class lazy_class_attribute(object):
+    """
+    An attribute that is computed once per class.
+
+    WARNING: once the attribute has been evaluated is not possible to modify it
+    """
+
+    def __init__(self, func):
+        self.__doc__ = getattr(func, '__doc__')
+        self.func = func
+        super(lazy_class_attribute, self).__init__()
+
+    def __get__(self, obj, cls):
+        value = self.func(cls)
+        setattr(cls, self.func.__name__, value)
+        return value
+
+
 def memoize_by_id(func):
     cache = func.cache = {}
     _CACHE_MISS = object()

--- a/bravado_core/util.py
+++ b/bravado_core/util.py
@@ -48,9 +48,7 @@ class cached_property(object):
     def __get__(self, obj, cls):
         if obj is None:
             return self
-
-        value = self.func(obj)
-        setattr(obj, self.func.__name__, value)
+        value = obj.__dict__[self.func.__name__] = self.func(obj)
         return value
 
 

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -7,6 +7,7 @@ from six import add_metaclass
 from bravado_core.util import AliasKeyDict
 from bravado_core.util import cached_property
 from bravado_core.util import determine_object_type
+from bravado_core.util import lazy_class_attribute
 from bravado_core.util import memoize_by_id
 from bravado_core.util import ObjectType
 from bravado_core.util import sanitize_name
@@ -62,6 +63,26 @@ def test_cached_property_in_metaclasses():
     del Class.class_property
     assert Class.class_property == 2
     assert Class.calls == 2
+
+
+def test_class_cached_property():
+    class Class(object):
+        calls = 0
+
+        @lazy_class_attribute
+        def prop(cls):
+            cls.calls += 1
+            return cls.calls
+
+    class_instance_1 = Class()
+    assert class_instance_1.calls == 0
+    assert class_instance_1.prop == 1
+    assert class_instance_1.calls == 1
+
+    class_instance_2 = Class()
+    assert class_instance_2.calls == 1
+    assert class_instance_2.prop == 1
+    assert class_instance_2.calls == 1
 
 
 def test_memoize_by_id_decorator():

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
-import abc
-
 import pytest
-from six import add_metaclass
 
 from bravado_core.util import AliasKeyDict
 from bravado_core.util import cached_property
@@ -38,31 +35,6 @@ def test_cached_property():
     del class_instance.property_1
     assert class_instance.property_1 == 2
     assert class_instance.calls == 2
-
-
-def test_cached_property_in_metaclasses():
-    class CustomType(abc.ABCMeta):
-        calls = 0
-        @cached_property
-        def class_property(cls):
-            cls.calls += 1
-            return cls.calls
-
-    @add_metaclass(CustomType)
-    class Class:
-        pass
-
-    assert Class.class_property == 1
-    assert Class.calls == 1
-
-    # If property is called twice no calls are received from the method
-    assert Class.class_property == 1
-    assert Class.calls == 1
-
-    # If property is deleted then the method is called again
-    del Class.class_property
-    assert Class.class_property == 2
-    assert Class.calls == 2
 
 
 def test_class_cached_property():


### PR DESCRIPTION
The goal of this PR is to use lazy evaluated and cached attributes on the model class.
By doing so we can avoid to pre-evaluate, for all the models, certain features like `_properties` or `_inherits_from` which could be time consuming.

Thanks to the usage of `@lazy_class_attribute` we do evaluate the property only once per model type and reuse the evaluation result for the following calls.

An other change done by this PR is to use `slots` in the `Model`, thanks to this we can reduce the memory footprint of the model instances without negatively impacting the performances.


NOTE: PR #329 objective was only to extend `@cached_property` to be used in meta classes, the extension has not be used here because we would have had to override `__getattribute__` as well causing a performance hit of ~7-9%.
