### PR TITLE
Enhance unmarshal performances

### DIFF
--- a/bravado_core/_compat.py
+++ b/bravado_core/_compat.py
@@ -5,3 +5,9 @@ if six.PY2:  # pragma: no cover  # py2
     from functools32 import wraps  # noqa: F401
 else:  # pragma: no cover  # py3+
     from functools import wraps  # noqa: F401
+
+
+try:
+    from collections.abc import Mapping  # noqa: F401  # pragma: no cover  # py3.3+
+except ImportError:
+    from collections import Mapping  # noqa: F401  # py3.2 or older

--- a/bravado_core/_decorators.py
+++ b/bravado_core/_decorators.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+"""
+The module defines useful decorators for the marshaling and unmarshaling process
+
+NOTE: The module has been marked as PRIVATE., so we are required to preserve
+      This is done to allow future modification to the defined decorators
+      without worrying about backward incompatible changes.
+"""
+from bravado_core import schema
+from bravado_core._compat import wraps
+from bravado_core.exception import SwaggerMappingError
+from bravado_core.util import memoize_by_id
+from bravado_core.util import RecursiveCallException
+
+
+@memoize_by_id
+def handle_null_value(swagger_spec, object_schema, is_nullable=False):
+    # TODO: remove is_nullable support once https://github.com/Yelp/bravado-core/issues/335 is addressed
+    """
+    Function wrapper that performs some check to the wrapped function parameter.
+
+    In case the parameter is None the decorator ensures that, according to object schema,
+    the default value is used or that the null value is properly handled.
+
+    NOTES:
+     * the decorator is meant to be used in bravado_core.marshal and bravado_core.unmarshal modules.
+     * the decorator could be used as wrapper of functions that accept a single value as parameter.
+       Such value will be used for the checks mentioned above
+     * nullable parameter is needed to ensure that x-nullable is propagated in the case it is defined
+       as sibling in a reference object (ie. `{'x-nullable': True, '$ref': '#/definitions/something'}`)
+
+    :type swagger_spec: :class:`bravado_core.spec.Spec`
+    :type object_schema: dict
+    :type is_nullable: bool
+    """
+    default_value = schema.get_default(swagger_spec, object_schema)
+    is_nullable = is_nullable or schema.is_prop_nullable(swagger_spec, object_schema)
+
+    def external_wrapper(func):
+        @wraps(func)
+        def wrapper(value):
+            if value is None:
+                value = default_value
+
+                if value is None:
+                    if is_nullable:
+                        return None
+                    else:
+                        raise SwaggerMappingError(
+                            'Spec {0} is a required value'.format(object_schema),
+                        )
+
+            return func(value)
+
+        return wrapper
+
+    return external_wrapper
+
+
+def wrap_recursive_call_exception(func):
+    """
+    The bravado_core.marshaling and bravado_core.unmarshaling modules might
+    take advantage of caching the return value of determined function calls.
+
+    In the case of higher level function, so functions that return functions
+    that are memoized it is necessary to deal with the fact that caching
+    them on the first time might not be possible (due to RecursiveCallException).
+
+    In such case the decorator takes care of returning a new callable, with
+    the same signature of the original function, that will re-execute the original
+    function in the hope that a later execution will not result into a
+    recursive-call that makes caching not feasible.
+    """
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except RecursiveCallException:
+            return lambda *new_args, **new_kawrgs: func(*args, **kwargs)(*new_args, **new_kawrgs)
+
+    return wrapper

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -1,13 +1,10 @@
 # -*- coding: utf-8 -*-
 import copy
-try:
-    from collections.abc import Mapping
-except ImportError:  # Python 3.2 or older
-    from collections import Mapping
 
 from six import iteritems
 from six import string_types
 
+from bravado_core._compat import Mapping
 from bravado_core.exception import SwaggerMappingError
 
 
@@ -188,3 +185,12 @@ def collapsed_properties(model_spec, swagger_spec):
             properties.update(more_properties)
 
     return properties
+
+
+def get_type_from_schema(swagger_spec, schema_object_spec):
+    try:
+        return schema_object_spec['type']
+    except KeyError:
+        if swagger_spec.config['default_type_to_object'] or 'allOf' in schema_object_spec:
+            return 'object'
+        return None

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -104,6 +104,7 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
         properties = collapsed_properties(deref(object_spec), swagger_spec)
     prop_spec = properties.get(prop_name)
 
+    # TODO: remove is_nullable support once https://github.com/Yelp/bravado-core/issues/335 is addressed
     if prop_spec is not None:
         result_spec = deref(prop_spec)
         # If the de-referenced specification is for a x-nullable property

--- a/bravado_core/swagger20_validator.py
+++ b/bravado_core/swagger20_validator.py
@@ -10,6 +10,8 @@ from bravado_core.model import MODEL_MARKER
 from bravado_core.schema import is_param_spec
 from bravado_core.schema import is_prop_nullable
 from bravado_core.schema import is_required
+from bravado_core.util import memoize_by_id
+
 
 """Draft4Validator is not completely compatible with Swagger 2.0 schema
 objects like parameter, etc. Swagger20Validator is an extension of
@@ -235,6 +237,7 @@ def ref_validator(validator, ref, instance, schema):
             validator.resolver.pop_scope()
 
 
+@memoize_by_id
 def get_validator_type(swagger_spec):
     """Create a custom jsonschema validator for Swagger 2.0 specs.
 

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -1,24 +1,30 @@
 # -*- coding: utf-8 -*-
+import warnings
+from functools import partial
+
 from six import iteritems
 
-from bravado_core import formatter
+from bravado_core import _decorators
 from bravado_core import schema
 from bravado_core.exception import SwaggerMappingError
-from bravado_core.model import is_model
 from bravado_core.model import MODEL_MARKER
 from bravado_core.schema import collapsed_properties
-from bravado_core.schema import get_spec_for_prop
-from bravado_core.schema import handle_null_value
+from bravado_core.schema import get_type_from_schema
 from bravado_core.schema import is_dict_like
 from bravado_core.schema import is_list_like
 from bravado_core.schema import SWAGGER_PRIMITIVES
+from bravado_core.util import memoize_by_id
+
+
+_NOT_FOUND = object()
 
 
 _NOT_FOUND = object()
 
 
 def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
-    """Unmarshal the value using the given schema object specification.
+    """
+    Unmarshal the value using the given schema object specification.
 
     Unmarshalling includes:
     - transform the value according to 'format' if available
@@ -33,42 +39,8 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
     :rtype: int, float, long, string, unicode, boolean, list, dict, object (in
         the case of a 'format' conversion', or Model type
     """
-    deref = swagger_spec.deref
-    schema_object_spec = deref(schema_object_spec)
-
-    obj_type = schema_object_spec.get('type')
-
-    if 'allOf' in schema_object_spec:
-        obj_type = 'object'
-
-    if not obj_type:
-        if swagger_spec.config['default_type_to_object']:
-            obj_type = 'object'
-        else:
-            return value
-
-    if obj_type in SWAGGER_PRIMITIVES:
-        return unmarshal_primitive(swagger_spec, schema_object_spec, value)
-
-    if obj_type == 'array':
-        return unmarshal_array(swagger_spec, schema_object_spec, value)
-
-    if swagger_spec.config['use_models'] and \
-            is_model(swagger_spec, schema_object_spec):
-        # It is important that the 'model' check comes before 'object' check.
-        # Model specs also have type 'object' but also have the additional
-        # MODEL_MARKER key for identification.
-        return unmarshal_model(swagger_spec, schema_object_spec, value)
-
-    if obj_type == 'object':
-        return unmarshal_object(swagger_spec, schema_object_spec, value)
-
-    if obj_type == 'file':
-        return value
-
-    raise SwaggerMappingError(
-        "Don't know how to unmarshal value {0} with a type of {1}".format(value, obj_type),
-    )
+    unmarshaling_method = get_unmarshaling_method(swagger_spec, schema_object_spec)
+    return unmarshaling_method(value)
 
 
 def unmarshal_primitive(swagger_spec, primitive_spec, value):
@@ -82,14 +54,14 @@ def unmarshal_primitive(swagger_spec, primitive_spec, value):
         based on 'format'
     :raises: SwaggerMappingError
     """
-    if value is None:
-        value = handle_null_value(swagger_spec, primitive_spec)
-
-    if value is None:
-        return None
-
-    value = formatter.to_python(swagger_spec, primitive_spec, value)
-    return value
+    warnings.warn(
+        'unmarshal_primitive will be deprecated in the next major release. '
+        'Please use the more general entry-point offered in unmarshal_schema_object',
+        DeprecationWarning,
+    )
+    null_decorator = _decorators.handle_null_value(swagger_spec, primitive_spec)
+    unmarshal_function = _unmarshaling_method_primitive_type(swagger_spec, primitive_spec)
+    return null_decorator(unmarshal_function)(value)
 
 
 def unmarshal_array(swagger_spec, array_spec, array_value):
@@ -101,24 +73,14 @@ def unmarshal_array(swagger_spec, array_spec, array_value):
     :rtype: list
     :raises: SwaggerMappingError
     """
-    if array_value is None:
-        array_value = handle_null_value(swagger_spec, array_spec)
-
-    if array_value is None:
-        return None
-
-    if not is_list_like(array_value):
-        raise SwaggerMappingError(
-            'Expected list like type for {0}:{1}'.format(
-                type(array_value), array_value,
-            ),
-        )
-
-    item_spec = swagger_spec.deref(array_spec).get('items')
-    return [
-        unmarshal_schema_object(swagger_spec, item_spec, item)
-        for item in array_value
-    ]
+    warnings.warn(
+        'unmarshal_array will be deprecated in the next major release. '
+        'Please use the more general entry-point offered in unmarshal_schema_object',
+        DeprecationWarning,
+    )
+    null_decorator = _decorators.handle_null_value(swagger_spec, array_spec)
+    unmarshal_function = _unmarshaling_method_array(swagger_spec, array_spec)
+    return null_decorator(unmarshal_function)(array_value)
 
 
 def unmarshal_object(swagger_spec, object_spec, object_value):
@@ -130,57 +92,14 @@ def unmarshal_object(swagger_spec, object_spec, object_value):
     :rtype: dict
     :raises: SwaggerMappingError
     """
-    deref = swagger_spec.deref
-
-    if object_value is None:
-        object_value = handle_null_value(swagger_spec, object_spec)
-
-    if object_value is None:
-        return None
-
-    if not is_dict_like(object_value):
-        raise SwaggerMappingError(
-            'Expected dict like type for {0}:{1}'.format(
-                type(object_value), object_value,
-            ),
-        )
-
-    object_spec = deref(object_spec)
-    required_fields = object_spec.get('required', [])
-    properties = collapsed_properties(object_spec, swagger_spec)
-
-    # Check if object_spec is polymorphic
-    discriminator = object_spec.get('discriminator')
-    if discriminator is not None:
-        child_model_name = object_value.get(discriminator, None)
-        child_model_type = swagger_spec.definitions.get(child_model_name, None)
-        if child_model_type and child_model_type._model_spec != object_spec:
-            # The discriminator field does targets a different model, let's unmarshal with it
-            return unmarshal_schema_object(swagger_spec, child_model_type._model_spec, object_value)
-
-    result = {}
-    for k, v in iteritems(object_value):
-        prop_spec = get_spec_for_prop(
-            swagger_spec, object_spec, object_value, k, properties,
-        )
-        if v is None and k not in required_fields and prop_spec:
-            if schema.has_default(swagger_spec, prop_spec):
-                result[k] = schema.get_default(swagger_spec, prop_spec)
-            else:
-                result[k] = None
-        elif prop_spec:
-            result[k] = unmarshal_schema_object(swagger_spec, prop_spec, v)
-        else:
-            # Don't marshal when a spec is not available - just pass through
-            result[k] = v
-
-    for prop_name, prop_spec in iteritems(properties):
-        if prop_name not in result and swagger_spec.config['include_missing_properties']:
-            result[prop_name] = None
-            if schema.has_default(swagger_spec, prop_spec):
-                result[prop_name] = schema.get_default(swagger_spec, prop_spec)
-
-    return result
+    warnings.warn(
+        'unmarshal_object will be deprecated in the next major release. '
+        'Please use the more general entry-point offered in unmarshal_schema_object',
+        DeprecationWarning,
+    )
+    null_decorator = _decorators.handle_null_value(swagger_spec, object_spec)
+    unmarshal_function = _unmarshaling_method_object(swagger_spec, object_spec, use_models=False)
+    return null_decorator(unmarshal_function)(object_value)
 
 
 def unmarshal_model(swagger_spec, model_spec, model_value):
@@ -192,17 +111,117 @@ def unmarshal_model(swagger_spec, model_spec, model_value):
     :rtype: Model instance
     :raises: SwaggerMappingError
     """
-    deref = swagger_spec.deref
-    model_name = deref(model_spec).get(MODEL_MARKER)
-    model_type = swagger_spec.definitions.get(model_name, None)
+    warnings.warn(
+        'unmarshal_model will be deprecated in the next major release. '
+        'Please use the more general entry-point offered in unmarshal_schema_object',
+        DeprecationWarning,
+    )
 
+    null_decorator = _decorators.handle_null_value(swagger_spec, model_spec)
+    unmarshal_function = _unmarshaling_method_object(swagger_spec, model_spec, use_models=True)
+    return null_decorator(unmarshal_function)(model_value)
+
+
+@_decorators.wrap_recursive_call_exception
+@memoize_by_id
+def get_unmarshaling_method(swagger_spec, object_schema, is_nullable=True):
+    # TODO: remove is_nullable support once https://github.com/Yelp/bravado-core/issues/335 is addressed
+    """
+    Determine the method needed to unmarshal values of a defined object_schema
+    The returned method will accept a single positional parameter that represent the value
+    to be unmarshaled.
+
+    :type swagger_spec: :class:`bravado_core.spec.Spec`
+    :type object_schema: dict
+    """
+    object_schema = swagger_spec.deref(object_schema)
+    null_decorator = _decorators.handle_null_value(swagger_spec, object_schema, is_nullable)
+    object_type = get_type_from_schema(swagger_spec, object_schema)
+
+    if object_type == 'array':
+        return null_decorator(_unmarshaling_method_array(swagger_spec, object_schema))
+    elif object_type == 'file':
+        return null_decorator(_unmarshaling_method_file(swagger_spec, object_schema))
+    elif object_type == 'object':
+        return null_decorator(_unmarshaling_method_object(swagger_spec, object_schema))
+    elif object_type in SWAGGER_PRIMITIVES:
+        return null_decorator(_unmarshaling_method_primitive_type(swagger_spec, object_schema))
+    elif object_type is None:
+        return _no_op_unmarshaling
+    else:
+        return partial(_unknown_type_unmarhsaling, object_type)
+
+
+def _no_op_unmarshaling(value):
+    return value
+
+
+def _unknown_type_unmarhsaling(object_type, value):
+    raise SwaggerMappingError(
+        "Don't know how to unmarshal value {0} with a type of {1}".format(
+            value, object_type,
+        ),
+    )
+
+
+def _raise_unknown_model(model_name, value):
+    raise SwaggerMappingError('Unknown model {0} when trying to unmarshal {1}'.format(model_name, value))
+
+
+def _unmarshal_array(unmarshal_array_item_function, value):
+    """
+    Unmarshal a jsonschema type of 'array' into a python list.
+
+    :type unmarshal_array_item_function: callable
+    :type value: list
+    :rtype: list
+    :raises: SwaggerMappingError
+    """
+    if not is_list_like(value):
+        raise SwaggerMappingError('Expected list like type for {0}:{1}'.format(type(value), value))
+
+    return [
+        unmarshal_array_item_function(item)
+        for item in value
+    ]
+
+
+def _unmarshaling_method_array(swagger_spec, object_schema):
+    item_schema = swagger_spec.deref(swagger_spec.deref(object_schema).get('items', _NOT_FOUND))
+    if item_schema is _NOT_FOUND:
+        return _no_op_unmarshaling
+
+    return partial(
+        _unmarshal_array,
+        get_unmarshaling_method(swagger_spec, item_schema),
+    )
+
+
+def _unmarshaling_method_file(swagger_spec, object_schema):
+    return _no_op_unmarshaling
+
+
+def _unmarshal_model(
+    properties_to_unmarshaling_function,
+    discriminator_property,
+    model_to_unmarshaling_function_mapping,
+    model_type,
+    include_missing_properties,
+    properties_to_default_value,
+    additional_properties_unmarshaling_function,
+    model_value,
+):
+    """
+    Unmarshal a dict into a Model instance or a dictionary (according to the 'use_models' swagger_spec configuration).
+
+    :type model_type: Model
+    :type model_value: dict
+
+    :rtype: Model instance
+    :raises: SwaggerMappingError
+    """
     if model_type is None:
-        raise SwaggerMappingError(
-            'Unknown model {0} when trying to unmarshal {1}'.format(model_name, model_value),
-        )
-
-    if model_value is None:
-        return handle_null_value(swagger_spec, model_spec)
+        model_type = dict
 
     if not is_dict_like(model_value):
         raise SwaggerMappingError(
@@ -210,15 +229,105 @@ def unmarshal_model(swagger_spec, model_spec, model_value):
             "Was {2} instead.".format(model_value, model_type, type(model_value)),
         )
 
-    # Check if model is polymorphic
-    discriminator = model_spec.get('discriminator')
-    if discriminator is not None:
-        child_model_name = model_value.get(discriminator, None)
-        child_model_type = swagger_spec.definitions.get(child_model_name, None)
-        if child_model_type and child_model_type != model_type:
-            # The discriminator field does targets a different model, let's unmarshal with it
-            return unmarshal_model(swagger_spec, child_model_type._model_spec, model_value)
+    unamarshaled_value = model_type()
 
-    model_as_dict = unmarshal_object(swagger_spec, model_type._model_spec, model_value)
-    model_instance = model_type._from_dict(model_as_dict)
-    return model_instance
+    if discriminator_property:
+        discriminated_model_unsmarhaling_function = model_to_unmarshaling_function_mapping.get(
+            model_value[discriminator_property],
+        )
+        if discriminated_model_unsmarhaling_function:
+            return discriminated_model_unsmarhaling_function(model_value)
+
+    for property_name, property_value in iteritems(model_value):
+        unmarshaling_function = properties_to_unmarshaling_function.get(
+            property_name, additional_properties_unmarshaling_function,
+        )
+        unamarshaled_value[property_name] = unmarshaling_function(property_value)
+
+    if include_missing_properties:
+        for property_name, unmarshaling_function in iteritems(properties_to_unmarshaling_function):
+            if property_name not in unamarshaled_value:
+                unamarshaled_value[property_name] = properties_to_default_value.get(property_name)
+
+    return unamarshaled_value
+
+
+def _unmarshaling_method_object(swagger_spec, object_schema, use_models=True):
+    # TODO: use_models parameter should be removed once unmarshal_model function is removed
+    model_type = None
+    object_schema = swagger_spec.deref(object_schema)
+    if MODEL_MARKER in object_schema:
+        model_name = object_schema[MODEL_MARKER]
+        model_type = swagger_spec.definitions.get(model_name)
+        if use_models and model_type is None:
+            return partial(_raise_unknown_model, model_name)
+        if not use_models:
+            model_type = None
+
+    additional_properties_unmarshaling_function = _no_op_unmarshaling
+    if model_type is None:
+        properties = collapsed_properties(object_schema, swagger_spec)
+        required_properties = object_schema.get('required', [])
+        if not object_schema.get('additionalProperties') is False:
+            additional_properties_schema = object_schema.get('additionalProperties', {})
+            if additional_properties_schema in ({}, True):
+                additional_properties_unmarshaling_function = _no_op_unmarshaling
+            else:
+                additional_properties_unmarshaling_function = get_unmarshaling_method(
+                    swagger_spec, additional_properties_schema,
+                )
+    else:
+        properties = model_type._properties
+        required_properties = model_type._required_properties
+        if not model_type._deny_additional_properties:
+            additional_properties_unmarshaling_function = get_unmarshaling_method(
+                swagger_spec, model_type._additional_properties_schema,
+            )
+
+    properties_to_unmarshaling_function = {}
+    for prop_name, prop_schema in iteritems(properties):
+        properties_to_unmarshaling_function[prop_name] = get_unmarshaling_method(
+            swagger_spec,
+            prop_schema,
+            prop_schema.get('x-nullable', False) or prop_name not in required_properties,
+        )
+
+    discriminator_property = object_schema.get('discriminator') if model_type is not None else None
+
+    model_to_unmarshaling_function_mapping = None
+    if discriminator_property is not None:
+        model_to_unmarshaling_function_mapping = {
+            k: get_unmarshaling_method(
+                swagger_spec,
+                v._model_spec,
+            )
+            for k, v in iteritems(swagger_spec.definitions)
+            if model_type.__name__ in v._inherits_from
+        }
+
+    properties_to_default_value = {
+        prop_name: schema.get_default(swagger_spec, prop_schema)
+        for prop_name, prop_schema in iteritems(properties)
+        if schema.has_default(swagger_spec, prop_schema)
+    }
+
+    return partial(
+        _unmarshal_model,
+        properties_to_unmarshaling_function,
+        discriminator_property,
+        model_to_unmarshaling_function_mapping,
+        model_type if model_type and model_type._use_models else None,
+        model_type._include_missing_properties if model_type else swagger_spec.config['include_missing_properties'],
+        properties_to_default_value,
+        additional_properties_unmarshaling_function,
+    )
+
+
+def _unmarshaling_method_primitive_type(swagger_spec, object_schema):
+    try:
+        swagger_format = schema.get_format(swagger_spec, object_schema)
+        if swagger_format is not None:
+            return swagger_spec.get_format(swagger_format).to_python
+    except AttributeError:
+        pass
+    return _no_op_unmarshaling

--- a/tests/model/model_test.py
+++ b/tests/model/model_test.py
@@ -37,6 +37,11 @@ def test_model_properties_iteration_allOf(cat_swagger_spec, cat_type, cat_kwargs
     )
 
 
+def test_Model__from_dict(cat_swagger_spec, cat_type, cat_kwargs):
+    cat = cat_type._from_dict(cat_kwargs)
+    assert cat._as_dict() == cat_kwargs
+
+
 def test_model_delete_property(definitions_spec, user_type, user_kwargs):
     user = user_type(**user_kwargs)
 

--- a/tests/profiling/unmarshal_profiler_test.py
+++ b/tests/profiling/unmarshal_profiler_test.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from bravado_core.unmarshal import unmarshal_schema_object
+
+
+@pytest.fixture
+def findByStatusReponseSchema(perf_petstore_spec):
+    result = perf_petstore_spec._internal_spec_dict
+
+    for part in ['paths', '/pet/findByStatus', 'get', 'responses', '200', 'schema']:
+        result = perf_petstore_spec.deref(result)[part]
+
+    return result
+
+
+def test_small_objects(benchmark, perf_petstore_spec, findByStatusReponseSchema, small_pets):
+    benchmark(
+        unmarshal_schema_object,
+        perf_petstore_spec,
+        findByStatusReponseSchema,
+        small_pets,
+    )
+
+
+def test_large_objects(benchmark, perf_petstore_spec, findByStatusReponseSchema, large_pets):
+    benchmark(
+        unmarshal_schema_object,
+        perf_petstore_spec,
+        findByStatusReponseSchema,
+        large_pets,
+    )

--- a/tests/schema/get_spec_for_prop_test.py
+++ b/tests/schema/get_spec_for_prop_test.py
@@ -123,6 +123,32 @@ def test_additionalProperties_not_dict_like(minimal_swagger_spec, address_spec, 
     assert "Don't know what to do" in str(excinfo.value)
 
 
+@pytest.mark.filterwarnings("ignore:.*with siblings that will be overwritten")
+def test_get_spec_for_prop_with_x_nullable_and_reference(minimal_swagger_dict):
+    # TODO: remove is_nullable support once https://github.com/Yelp/bravado-core/issues/335 is addressed
+    minimal_swagger_dict['definitions'] = {
+        'referenced': {
+            'type': 'string',
+        },
+        'model': {
+            'type': 'object',
+            'properties': {
+                'property': {
+                    'x-nullable': True,
+                    '$ref': '#/definitions/referenced',
+                },
+            },
+        },
+    }
+    swagger_spec = Spec.from_dict(minimal_swagger_dict)
+    assert {'x-nullable': True, 'type': 'string'} == get_spec_for_prop(
+        swagger_spec,
+        minimal_swagger_dict['definitions']['model'],
+        None,
+        'property',
+    )
+
+
 def test_composition(minimal_swagger_dict, address_spec, address, business_address_spec, business_address):
     minimal_swagger_dict['definitions']['Address'] = address_spec
     minimal_swagger_dict['definitions']['BusinessAddress'] = business_address_spec

--- a/tests/unmarshal/unmarshal_object_test.py
+++ b/tests/unmarshal/unmarshal_object_test.py
@@ -327,7 +327,7 @@ def test_object_not_dict_like_raises_error(empty_swagger_spec, address_spec):
     i_am_not_dict_like = 34
     with pytest.raises(SwaggerMappingError) as excinfo:
         unmarshal_object(empty_swagger_spec, address_spec, i_am_not_dict_like)
-    assert 'Expected dict' in str(excinfo.value)
+    assert 'Expected type to be dict' in str(excinfo.value)
 
 
 def test_mising_properties_set_to_None(empty_swagger_spec, address_spec, address):

--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,7 @@
+[pytest]
+filterwarnings =
+    ignore:.*will be deprecated in the next major release. Please use the more general entry-point offered in.*:DeprecationWarning
+
 [tox]
 envlist = py27, py35, py36, pre-commit
 


### PR DESCRIPTION
The goal of this PR is, as mentioned in the title, unmarshaling performance enhancement.
NOTE: A similar PR will be published for applying the same approach described here for the marshaling process. I would like to have this verified first in order to avoid having two massive branches open at the same time

In order to achieve unmarshaling performance boost I've _rewritten_ the whole `bravado_core.unmarshal` module.

The current, before this PR, logic of unmarshaling is:
 1. extract the type from the schema
 2. if the schema if of type x then call the appropriate unmarshaling function
     * if the schema is of type object: call the top unmarshaling function for the property (point 1)
     * if the schema is of type object: call  the top unmarshaling function for each item of the list (point 1)
     * if the schema is of primitive type: identify, each time, the right formatting function to use
 3. once the unmarshaling function is identified then perform the real unmarshaling

This PR aims to cache results of point 1 and 2 for later "cost-free" usage.

While making this changes I've noticed that there might be no real good reason to have all the unmarshaling functions public, users of the library commonly use `bravado_core.unmarshal.unmarshal_schema_object`.
In order to simplify future maintenance work I've marked all the other functions as deprecated in the next major release. Doing so will allows us to modify more, if needed, the internals of unmarshaling without worrying about breaking backward compatibility.

Be aware that:
 * `bravado_core.unmarshal.get_unmarshaling_method` is wrapped by `_decorators.wrap_recursive_call_exception` and `memoize_by_id` decorators.
    `_decorators.wrap_recursive_call_exception` decorator is needed as models could be recursive and so invoking `get_unmarshaling_method` might end up on an infinite recursion.
    In order to proactively deal with it I've modified `@memoize_by_id` decorator to raise a controlled exception if an unbounded recursion is identified (ℹ️ the interpreter would raise anyway with a `RuntimeError: maximum recursion depth exceeded`)
    `memoize_by_id` decorator is needed to speed up evaluation of the marshaling method for the same spec and schema. This effectively is one of the major performance boost (basically the expensive point 1 and 2 of the original flow become, more or less, a dictionary lookup)
 * ~unmarshaling of a polymorphic object does not raise the traditional `SwaggerMappingError`.
    ℹ️ : The change is intentional as we should not do validation if validation is disabled (and as it was it was not possible to enable/disable that validation)~ (addressed by #333 )
 * ~Add support for unmarshaling additionalProperties (it was not done previously) -> `test_unmarshal_object_with_additional_properties` test~  (addressed by #333 )
---------------
Let's get to the juicy part 😄 
Raw data on: https://gist.github.com/macisamuele/9ff23d3e5e81c40cd884425a7eae5751

This PR provides a massive performance improvement:
 * the worst performance improvement is ~46% (if in the branch takes 1 then on master takes 1.87)
 * the best performance improvement is ~70% (if in the branch takes 1 then on master takes 3.33)
 * the average performance improvement is ~60% (if the branch takes 1 then on master takes 2.57)
