### PR TITLE
Enhance unmarshaling of additional properties and defaults

### DIFF
--- a/bravado_core/_compat.py
+++ b/bravado_core/_compat.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+import six
+
+if six.PY2:  # pragma: no cover  # py2
+    from functools32 import wraps  # noqa: F401
+else:  # pragma: no cover  # py3+
+    from functools import wraps  # noqa: F401

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -83,7 +83,10 @@ def unmarshal_primitive(swagger_spec, primitive_spec, value):
     :raises: SwaggerMappingError
     """
     if value is None:
-        return handle_null_value(swagger_spec, primitive_spec)
+        value = handle_null_value(swagger_spec, primitive_spec)
+
+    if value is None:
+        return None
 
     value = formatter.to_python(swagger_spec, primitive_spec, value)
     return value
@@ -99,7 +102,10 @@ def unmarshal_array(swagger_spec, array_spec, array_value):
     :raises: SwaggerMappingError
     """
     if array_value is None:
-        return handle_null_value(swagger_spec, array_spec)
+        array_value = handle_null_value(swagger_spec, array_spec)
+
+    if array_value is None:
+        return None
 
     if not is_list_like(array_value):
         raise SwaggerMappingError(
@@ -127,7 +133,10 @@ def unmarshal_object(swagger_spec, object_spec, object_value):
     deref = swagger_spec.deref
 
     if object_value is None:
-        return handle_null_value(swagger_spec, object_spec)
+        object_value = handle_null_value(swagger_spec, object_spec)
+
+    if object_value is None:
+        return None
 
     if not is_dict_like(object_value):
         raise SwaggerMappingError(

--- a/bravado_core/util.py
+++ b/bravado_core/util.py
@@ -2,12 +2,12 @@
 import copy
 import inspect
 import re
-from functools import wraps
 
 from enum import Enum
 from six import iteritems
 from six import iterkeys
 
+from bravado_core._compat import wraps
 from bravado_core.schema import is_dict_like
 from bravado_core.schema import is_list_like
 

--- a/bravado_core/validate.py
+++ b/bravado_core/validate.py
@@ -5,12 +5,12 @@ as the single point of entry for validations should we need to further
 customize the behavior.
 """
 import sys
-from functools import wraps
 
 import jsonschema
 from six import itervalues
 from six import reraise
 
+from bravado_core._compat import wraps
 from bravado_core.exception import SwaggerMappingError
 from bravado_core.exception import SwaggerSecurityValidationError
 from bravado_core.model import is_object

--- a/setup.py
+++ b/setup.py
@@ -51,5 +51,6 @@ setup(
     install_requires=install_requires,
     extras_require={
         ':python_version<"3.4"': ['enum34'],
+        ':python_version<"3.2"': ['functools32'],
     },
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -225,6 +225,10 @@ def node_spec():
     return {
         'type': 'object',
         'properties': {
+            'date': {
+                'type': 'string',
+                'format': 'date',
+            },
             'name': {
                 'type': 'string',
             },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ import yaml
 from six.moves.urllib import parse as urlparse
 from six.moves.urllib.request import pathname2url
 from six.moves.urllib.request import url2pathname
+from swagger_spec_validator.common import SwaggerValidationWarning
 
 from bravado_core.spec import Spec
 
@@ -205,7 +206,8 @@ def specs_with_none_in_ref_dict(specs_with_none_in_ref_abspath):
 
 @pytest.fixture
 def specs_with_none_in_ref_spec(specs_with_none_in_ref_dict, specs_with_none_in_ref_abspath):
-    return Spec.from_dict(specs_with_none_in_ref_dict, origin_url=get_url(specs_with_none_in_ref_abspath))
+    with pytest.warns(SwaggerValidationWarning):
+        return Spec.from_dict(specs_with_none_in_ref_dict, origin_url=get_url(specs_with_none_in_ref_abspath))
 
 
 @pytest.fixture

--- a/tests/model/model_test.py
+++ b/tests/model/model_test.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import datetime
 from copy import deepcopy
 
 import pytest
@@ -206,7 +207,6 @@ def test_ensure_polymorphic_objects_are_correctly_build_in_case_of_fully_derefer
     polymorphic_dict, validate_responses, use_models, internally_dereference_refs,
 ):
     raw_response = [{'name': 'name', 'type': 'Dog', 'birth_date': '2017-11-02'}]
-
     spec = Spec.from_dict(
         spec_dict=polymorphic_dict,
         config={
@@ -223,12 +223,11 @@ def test_ensure_polymorphic_objects_are_correctly_build_in_case_of_fully_derefer
         headers={'content-type': APP_JSON},
         json=Mock(return_value=raw_response),
     )
-
     unmarshaled_response = unmarshal_response(response, spec.resources['pets'].get_pets)
-    if use_models:
-        assert repr(unmarshaled_response) == "[Dog(birth_date=datetime.date(2017, 11, 2), name='name', type='Dog')]"
-    else:
-        assert unmarshaled_response == raw_response
+
+    model_type = spec.definitions['Dog'] if use_models else dict
+    expected_response = [model_type(birth_date=datetime.date(2017, 11, 2), name='name', type='Dog')]
+    assert expected_response == unmarshaled_response
 
 
 def test_ensure_model_spec_contains_reference_if_fully_dereference_is_not_enabled(polymorphic_dict):

--- a/tests/response/unmarshal_response_test.py
+++ b/tests/response/unmarshal_response_test.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import msgpack
 import pytest
+from jsonschema import ValidationError
 from mock import Mock
 from mock import patch
 
@@ -110,3 +111,55 @@ def test_performs_validation(empty_swagger_spec, response_spec):
             op = Mock(swagger_spec=empty_swagger_spec)
             unmarshal_response(response, op)
             assert val_schem.call_count == 1
+
+
+def test_unmarshal_model_polymorphic_specs(polymorphic_spec):
+    pet_list_dicts = [
+        {
+            'name': 'a dog name',
+            'type': 'Dog',
+            'birth_date': '2017-03-09',
+        },
+        {
+            'name': 'a cat name',
+            'type': 'Cat',
+            'color': 'white',
+        },
+    ]
+    pet_list_models = unmarshal_response(
+        response=Mock(
+            spec=IncomingResponse,
+            status_code=200,
+            headers={'content-type': APP_JSON},
+            json=Mock(return_value=pet_list_dicts),
+        ),
+        op=polymorphic_spec.resources['pets'].operations['get_pets'],
+    )
+
+    assert len(pet_list_dicts) == len(pet_list_models)
+
+    for list_item_model, list_item_dict in zip(pet_list_models, pet_list_dicts):
+        assert isinstance(list_item_model, polymorphic_spec.definitions['GenericPet'])
+        assert isinstance(list_item_model, polymorphic_spec.definitions[list_item_dict['type']])
+        assert list_item_model._marshal() == list_item_dict
+
+
+def test_unmarshal_model_polymorphic_specs_with_invalid_discriminator(polymorphic_spec):
+    pet_list_dicts = [
+        {
+            'name': 'a dog name',
+            'type': 'a-random-value',
+            'birth_date': '2017-03-09',
+        },
+    ]
+    with pytest.raises(ValidationError):
+        # Expecting validation error as "a-random-value" is not a valid type
+        unmarshal_response(
+            response=Mock(
+                spec=IncomingResponse,
+                status_code=200,
+                headers={'content-type': APP_JSON},
+                json=Mock(return_value=pet_list_dicts),
+            ),
+            op=polymorphic_spec.resources['pets'].operations['get_pets'],
+        )

--- a/tests/schema/collapsed_properties_test.py
+++ b/tests/schema/collapsed_properties_test.py
@@ -105,6 +105,7 @@ def test_recursive_ref(node_spec, recursive_swagger_spec):
 
     expected_props = {
         'name': {'type': 'string'},
+        'date': {'type': 'string', 'format': 'date'},
         'child': {'$ref': '#/definitions/Node'},
     }
     assert props == expected_props

--- a/tests/spec/Spec/deref_flattened_spec_test.py
+++ b/tests/spec/Spec/deref_flattened_spec_test.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import pytest
 from six import iterkeys
 from six import itervalues
 
@@ -38,7 +37,6 @@ def _equivalent(spec, obj1, obj2):
         return obj1 == obj2
 
 
-@pytest.mark.xfail(reason='Flaky test, issue #219')
 def test_deref_flattened_spec_not_recursive_specs(petstore_spec):
     spec_dict = petstore_spec.spec_dict
     deref_spec_dict = petstore_spec.deref_flattened_spec

--- a/tests/spec/from_dict_test.py
+++ b/tests/spec/from_dict_test.py
@@ -84,7 +84,7 @@ def test_yaml_files(my_dir):
     )
 
     with open(swagger_yaml_path) as f:
-        swagger_yaml_content = yaml.load(f)
+        swagger_yaml_content = yaml.safe_load(f)
 
     swagger_yaml_url = get_url(swagger_yaml_path)
     spec = Spec.from_dict(swagger_yaml_content, swagger_yaml_url)

--- a/tests/unmarshal/unmarshal_array_test.py
+++ b/tests/unmarshal/unmarshal_array_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import copy
+import datetime
 
 import pytest
 
@@ -26,6 +27,22 @@ def test_primitive_array(empty_swagger_spec, int_array_spec):
 def test_empty_array(empty_swagger_spec, int_array_spec):
     result = unmarshal_array(empty_swagger_spec, int_array_spec, [])
     assert [] == result
+
+
+def test_default_with_format(empty_swagger_spec):
+    result = unmarshal_array(
+        empty_swagger_spec,
+        {
+            'type': 'array',
+            'items': {
+                'type': 'string',
+                'format': 'date',
+            },
+            'default': ['2019-05-22'],
+        },
+        None,
+    )
+    assert [datetime.date(2019, 5, 22)] == result
 
 
 def test_type_not_array_raises_error(empty_swagger_spec, int_array_spec):

--- a/tests/unmarshal/unmarshal_model_test.py
+++ b/tests/unmarshal/unmarshal_model_test.py
@@ -134,6 +134,7 @@ def test_value_is_not_dict_like_raises_error(petstore_dict):
     assert 'Expected type to be dict' in str(excinfo.value)
 
 
+@pytest.mark.filterwarnings("ignore:.*with siblings that will be overwritten")
 def test_nullable_object_properties(petstore_dict, pet_dict):
     pet_spec_dict = petstore_dict['definitions']['Pet']
     pet_spec_dict['required'].append('category')

--- a/tests/unmarshal/unmarshal_object_test.py
+++ b/tests/unmarshal/unmarshal_object_test.py
@@ -589,3 +589,21 @@ def test_unmarshal_object_with_additional_properties(minimal_swagger_dict, addit
     spec = Spec.from_dict(minimal_swagger_dict)
     MyModel = spec.definitions['MyModel']
     assert MyModel._unmarshal(value)._as_dict() == expected
+
+
+def test_default_with_format(empty_swagger_spec):
+    result = unmarshal_object(
+        empty_swagger_spec,
+        {
+            'type': 'object',
+            'properties': {
+                'item': {
+                    'type': 'string',
+                    'format': 'date',
+                },
+            },
+            'default': {'item': '2019-05-22'},
+        },
+        None,
+    )
+    assert {'item': datetime.date(2019, 5, 22)} == result

--- a/tests/unmarshal/unmarshal_object_test.py
+++ b/tests/unmarshal/unmarshal_object_test.py
@@ -531,7 +531,7 @@ def test_unmarshal_object_polymorphic_specs(polymorphic_spec):
                 'type': 'Cat',
                 'color': 'white',
             },
-        ]
+        ],
     }
 
 
@@ -558,12 +558,11 @@ def test_unmarshal_object_polymorphic_specs(polymorphic_spec):
             {'property': '2018-05-21T00:00:00+00:00', 'other': '2018-05-21'},
             {'property': datetime.datetime(2018, 5, 21, tzinfo=tzutc()), 'other': '2018-05-21'},
         ),
-        pytest.param(
+        (
             False,
             {'property': '2018-05-21T00:00:00+00:00', 'other': '2018-05-21'},
             # Unmarshaling does not do validation
             {'property': datetime.datetime(2018, 5, 21, tzinfo=tzutc()), 'other': '2018-05-21'},
-            marks=pytest.mark.xfail(reason='Unmarshaling should not perform validation, but this is the case for now'),
         ),
         (
             {'type': 'string', 'format': 'date'},
@@ -587,8 +586,7 @@ def test_unmarshal_object_with_additional_properties(minimal_swagger_dict, addit
         MyModel_spec['additionalProperties'] = additionalProperties
     minimal_swagger_dict['definitions']['MyModel'] = MyModel_spec
     spec = Spec.from_dict(minimal_swagger_dict)
-    MyModel = spec.definitions['MyModel']
-    assert MyModel._unmarshal(value)._as_dict() == expected
+    assert unmarshal_object(spec, MyModel_spec, value) == expected
 
 
 def test_default_with_format(empty_swagger_spec):

--- a/tests/unmarshal/unmarshal_primitive_test.py
+++ b/tests/unmarshal/unmarshal_primitive_test.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import datetime
+
 import pytest
 
 from bravado_core.exception import SwaggerMappingError
@@ -78,6 +80,16 @@ def test_default(minimal_swagger_spec):
     }
 
     assert 42 == unmarshal_primitive(minimal_swagger_spec, integer_spec, None)
+
+
+def test_default_with_format(minimal_swagger_spec):
+    integer_spec = {
+        'type': 'string',
+        'format': 'date',
+        'default': '2019-05-22',
+    }
+
+    assert datetime.date(2019, 5, 22) == unmarshal_primitive(minimal_swagger_spec, integer_spec, None)
 
 
 def test_ref(minimal_swagger_dict):

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import mock
 import pytest
 
 from bravado_core.util import AliasKeyDict
@@ -7,6 +8,7 @@ from bravado_core.util import determine_object_type
 from bravado_core.util import lazy_class_attribute
 from bravado_core.util import memoize_by_id
 from bravado_core.util import ObjectType
+from bravado_core.util import RecursiveCallException
 from bravado_core.util import sanitize_name
 from bravado_core.util import strip_xscope
 
@@ -55,6 +57,19 @@ def test_class_cached_property():
     assert class_instance_2.calls == 1
     assert class_instance_2.prop == 1
     assert class_instance_2.calls == 1
+
+
+def test_memoize_by_id_decorator_recursive_call():
+    calls = []
+
+    @memoize_by_id
+    def function(a):
+        calls.append(a)
+        return function(a)
+
+    with pytest.raises(RecursiveCallException):
+        function(mock.sentinel.A)
+    assert calls == [mock.sentinel.A]
 
 
 def test_memoize_by_id_decorator():


### PR DESCRIPTION
The goal of the PR is to fix issues spotted while working on #331.

Namely I noticed that:
 * unmarshaling is not unmarshaling additional properties.
    Unmarshaling `{"key1": "2019-05-22"}` against the following schema
    `{"type": "object", "additionalProperties": {"type": "string", "format": "date"}}`
    would result into `{'key1': '2019-05-22'}` (master) instead of `{'key1': datetime.date(2019, 5, 22)}` (after this PR)
 * when default values are used they are not unmarshaled.
  Unmarshaling `{}` against the following schema
    `{"type": "object", "property": {"key1": {"type": "string", "format": "date", "default": "2019-05-22"}}}`
    would result into `{'key1': '2019-05-22'}` (master) instead of `{'key1': datetime.date(2019, 5, 22)}` (after this PR)
 * ~unmarshaling a polymorphic object into a dictionary (`unmarshal_object`) does not keep into account the identified polymorphic object and this misaligns `unmarshal_object` from `unmarshal_model`
  NOTE: respect #331 this PR still raises `SwaggerMappingError` in case of not found model (even if validation is disabled). This will be addressed on a separate PR~
 * unmarshaling a polymorphic object into a dictionary (`unmarshal_object`) does not keep into account the identified polymorphic object and this misaligns `unmarshal_object` from `unmarshal_model`
  NOTE: this PR removes the raise `SwaggerMappingError` in case of not found model as validation will take care of this (added test to ensure that this is the case)
