### PR TITLE
Update tests pre unmarshaling performance enhancements

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,25 @@
 # -*- coding: utf-8 -*-
 import os
+from copy import deepcopy
 
 import pytest
 import simplejson as json
 import yaml
+from mock import Mock
 from six.moves.urllib import parse as urlparse
 from six.moves.urllib.request import pathname2url
 from six.moves.urllib.request import url2pathname
 from swagger_spec_validator.common import SwaggerValidationWarning
 
+from bravado_core.spec import CONFIG_DEFAULTS
 from bravado_core.spec import Spec
+
+
+@pytest.fixture
+def mock_spec():
+    m = Mock(spec=Spec)
+    m.config = deepcopy(CONFIG_DEFAULTS)
+    return m
 
 
 @pytest.fixture

--- a/tests/model/conftest.py
+++ b/tests/model/conftest.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import pytest
-from mock import Mock
 
 from bravado_core.model import create_model_type
 from bravado_core.spec import Spec
@@ -125,11 +124,11 @@ def user_spec(definitions_spec):
 
 
 @pytest.fixture
-def user_type(user_spec):
+def user_type(mock_spec, user_spec):
     """
     :rtype: User
     """
-    return create_model_type(Mock(spec=Spec), 'User', user_spec)
+    return create_model_type(mock_spec, 'User', user_spec)
 
 
 @pytest.fixture
@@ -141,9 +140,9 @@ def user(user_type):
 
 
 @pytest.fixture
-def tag_model(definitions_spec):
+def tag_model(mock_spec, definitions_spec):
     tag_spec = definitions_spec['Tag']
-    return create_model_type(Mock(spec=Spec), 'Tag', tag_spec)
+    return create_model_type(mock_spec, 'Tag', tag_spec)
 
 
 @pytest.fixture

--- a/tests/unmarshal/unmarshal_object_test.py
+++ b/tests/unmarshal/unmarshal_object_test.py
@@ -214,8 +214,7 @@ def test_with_model_composition(business_address_swagger_spec, address_spec, bus
         expected_business_address.update(floor=None, name=None)
 
     business_address = unmarshal_object(
-        business_address_swagger_spec, business_address_spec,
-        business_address_dict,
+        business_address_swagger_spec, business_address_spec, business_address_dict,
     )
     assert expected_business_address == business_address
 
@@ -486,9 +485,7 @@ def test_non_nullable_none_value(empty_swagger_spec, property_type):
 @pytest.mark.parametrize('property_type', ['string', 'object', 'array'])
 def test_non_required_none_value(empty_swagger_spec, property_type):
     content_spec = nullable_spec_factory(
-        required=False,
-        nullable=False,
-        property_type=property_type,
+        required=False, nullable=False, property_type=property_type,
     )
     value = {'x': None}
     result = unmarshal_object(empty_swagger_spec, content_spec, value)

--- a/tests/unmarshal/unmarshal_schema_object_test.py
+++ b/tests/unmarshal/unmarshal_schema_object_test.py
@@ -104,6 +104,29 @@ def test_missing_object_spec_defaulting_on(petstore_dict):
         )
 
 
+@pytest.mark.parametrize(
+    'value',
+    [
+        {'id': {'foo': 'bar'}, 'name': 'short-hair'},
+        {'id': 'blahblah', 'name': 'short-hair'},
+    ],
+)
+def test_missing_object_spec_defaulting_off(petstore_dict, value):
+    """When default_type_to_object config option is set to True,
+    then missing types default to object
+    """
+    category_spec = petstore_dict['definitions']['Category']
+    category_spec['properties']['id'].pop('type')
+    petstore_spec = Spec.from_dict(petstore_dict, config={'use_models': False, 'default_type_to_object': False})
+
+    # In case of missing type the unmarshaling is equivalent no a no-op
+    assert value == unmarshal_schema_object(
+        petstore_spec,
+        category_spec,
+        value,
+    )
+
+
 def test_invalid_type(petstore_dict):
     category_spec = petstore_dict['definitions']['Category']
     category_spec['properties']['id']['type'] = 'notAValidType'


### PR DESCRIPTION
This PR is meant to update some tests in order to allow the removal of test changes in #331 .

The idea to remove test related changes in #331 is mostly lead by the fact that modifying tests there might reduce the confidence that such changes are valid and not changing the library behaviour.
