### PR TITLE
Improve memoize by id if used with kwargs only

### DIFF
--- a/bravado_core/_compat.py
+++ b/bravado_core/_compat.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
-import six
+import sys
 
 
-if six.PY2:  # pragma: no cover  # py2
+if sys.version_info[0] == 2:  # pragma: no cover  # py2
     from functools32 import wraps  # noqa: F401
 else:  # pragma: no cover  # py3+
     from functools import wraps  # noqa: F401
@@ -12,3 +12,9 @@ try:
     from collections.abc import Mapping  # noqa: F401  # pragma: no cover  # py3.3+
 except ImportError:
     from collections import Mapping  # noqa: F401  # py3.2 or older
+
+
+if sys.version_info[0:2] <= (3, 4):  # pragma: no cover  # py3.4 or older
+    from inspect import getargspec as get_function_spec  # noqa: F401
+else:  # pragma: no cover  # py3.5+
+    from inspect import getfullargspec as get_function_spec  # noqa: F401

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -332,17 +332,17 @@ class Spec(object):
                 return obj.__subject__
             if is_dict_like(obj):
                 for key in list(iterkeys(obj)):
-                    obj[key] = descend(obj[key])
+                    obj[key] = descend(obj=obj[key])
             elif is_list_like(obj):
                 # obj is list like object provided from flattened_spec specs.
                 # This guarantees that it cannot be a tuple instance and
                 # inline object modification are allowed
                 for index in range(len(obj)):
-                    obj[index] = descend(obj[index])
+                    obj[index] = descend(obj=obj[index])
             return obj
 
         try:
-            return descend(deref_spec_dict)
+            return descend(obj=deref_spec_dict)
         finally:
             # Make sure that all memory allocated, for caching, could be released
             descend.cache.clear()

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -52,7 +52,7 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
     :rtype: int, float, long, string, unicode, boolean, list, dict, object (in
         the case of a 'format' conversion', or Model type
     """
-    unmarshaling_method = _get_unmarshaling_method(swagger_spec, schema_object_spec)
+    unmarshaling_method = _get_unmarshaling_method(swagger_spec=swagger_spec, object_schema=schema_object_spec)
     return unmarshaling_method(value)
 
 
@@ -73,7 +73,7 @@ def unmarshal_primitive(swagger_spec, primitive_spec, value):
         'Please use the more general entry-point offered in unmarshal_schema_object',
         DeprecationWarning,
     )
-    null_decorator = _decorators.handle_null_value(swagger_spec, primitive_spec)
+    null_decorator = _decorators.handle_null_value(swagger_spec=swagger_spec, object_schema=primitive_spec)
     unmarshal_function = _unmarshaling_method_primitive_type(swagger_spec, primitive_spec)
 
     return null_decorator(unmarshal_function)(value)
@@ -94,7 +94,7 @@ def unmarshal_array(swagger_spec, array_spec, array_value):
         'Please use the more general entry-point offered in unmarshal_schema_object',
         DeprecationWarning,
     )
-    null_decorator = _decorators.handle_null_value(swagger_spec, array_spec)
+    null_decorator = _decorators.handle_null_value(swagger_spec=swagger_spec, object_schema=array_spec)
     unmarshal_function = _unmarshaling_method_array(swagger_spec, array_spec)
     return null_decorator(unmarshal_function)(array_value)
 
@@ -114,7 +114,7 @@ def unmarshal_object(swagger_spec, object_spec, object_value):
         'Please use the more general entry-point offered in unmarshal_schema_object',
         DeprecationWarning,
     )
-    null_decorator = _decorators.handle_null_value(swagger_spec, object_spec)
+    null_decorator = _decorators.handle_null_value(swagger_spec=swagger_spec, object_schema=object_spec)
     unmarshal_function = _unmarshaling_method_object(swagger_spec, object_spec, use_models=False)
     return null_decorator(unmarshal_function)(object_value)
 
@@ -135,7 +135,7 @@ def unmarshal_model(swagger_spec, model_spec, model_value):
         DeprecationWarning,
     )
 
-    null_decorator = _decorators.handle_null_value(swagger_spec, model_spec)
+    null_decorator = _decorators.handle_null_value(swagger_spec=swagger_spec, object_schema=model_spec)
     unmarshal_function = _unmarshaling_method_object(swagger_spec, model_spec, use_models=True)
     return null_decorator(unmarshal_function)(model_value)
 
@@ -157,7 +157,11 @@ def _get_unmarshaling_method(swagger_spec, object_schema, is_nullable=True):
                         attribute is set to true by the "parent" schema
     """
     object_schema = swagger_spec.deref(object_schema)
-    null_decorator = _decorators.handle_null_value(swagger_spec, object_schema, is_nullable)
+    null_decorator = _decorators.handle_null_value(
+        swagger_spec=swagger_spec,
+        object_schema=object_schema,
+        is_nullable=is_nullable,
+    )
     object_type = get_type_from_schema(swagger_spec, object_schema)
 
     if object_type == 'array':
@@ -236,7 +240,7 @@ def _unmarshaling_method_array(swagger_spec, object_schema):
     def wrapper_array(value):
         # type: (typing.Any) -> typing.Any
         return _unmarshal_array(
-            unmarshal_array_item_function=_get_unmarshaling_method(swagger_spec, item_schema),
+            unmarshal_array_item_function=_get_unmarshaling_method(swagger_spec=swagger_spec, object_schema=item_schema),
             value=value,
         )
 
@@ -284,7 +288,11 @@ def _unmarshal_object(
         discriminator_value = model_value[discriminator_property]
         discriminated_model = possible_discriminated_type_name_to_model.get(discriminator_value)
         if discriminated_model is not None:
-            return _get_unmarshaling_method(swagger_spec, discriminated_model._model_spec)(model_value)
+            unmarshal_func = _get_unmarshaling_method(
+                swagger_spec=swagger_spec,
+                object_schema=discriminated_model._model_spec,
+            )
+            return unmarshal_func(model_value)
 
     unmarshaled_value = model_type()
     for property_name, property_value in iteritems(model_value):

--- a/bravado_core/validate.py
+++ b/bravado_core/validate.py
@@ -74,7 +74,7 @@ def validate_primitive(swagger_spec, primitive_spec, value):
     :param primitive_spec: spec for a swagger primitive type in dict form
     :type value: int, string, float, long, etc
     """
-    get_validator_type(swagger_spec)(
+    get_validator_type(swagger_spec=swagger_spec)(
         primitive_spec,
         format_checker=swagger_spec.format_checker,
         resolver=swagger_spec.resolver,
@@ -88,7 +88,7 @@ def validate_array(swagger_spec, array_spec, value):
     :param array_spec: spec for an 'array' type in dict form
     :type value: list
     """
-    get_validator_type(swagger_spec)(
+    get_validator_type(swagger_spec=swagger_spec)(
         array_spec,
         format_checker=swagger_spec.format_checker,
         resolver=swagger_spec.resolver,
@@ -102,7 +102,7 @@ def validate_object(swagger_spec, object_spec, value):
     :param object_spec: spec for an 'object' type in dict form
     :type value: dict
     """
-    get_validator_type(swagger_spec)(
+    get_validator_type(swagger_spec=swagger_spec)(
         object_spec,
         format_checker=swagger_spec.format_checker,
         resolver=swagger_spec.resolver,


### PR DESCRIPTION
This PR aims to improve the performances of `memoize_by_id` decorator while preserving the external signature.

By profiling the code I've noticed that a lot of time is spent into the generation of the cache key of `@memoize_by_id` decorator (specifically on the execution of`inspect.getcallargs(func, *args, **kwargs)`.

This PR adds a small optimisation on the `make_key` functionality if the function is invoked with kwargs only parameters.
In such condition we don't need to use `getcallargs` to determine the mappings between parameter names and associated values.

In order to preserve the fact that `getcallargs` resolves default attributes as well the added code does manually deal with them (it's a bit ugly but by doing so we can get additional performance improvements).

Data
----
Raw data on: https://gist.github.com/macisamuele/89fa006dbaf5c27a85200c96deb2a459

Unmarshaling performance improvement:
* the worst performance improvement is ~56% (if in the branch takes 1 then on master takes 2.30)
* the best performance improvement is ~67% (if in the branch takes 1 then on master takes 3.07)
* the average performance improvement is ~63% (if the branch takes 1 then on master takes 2.77)
