### PR TITLE
Ensure that unmarshal uses the format only if defined

### DIFF
--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -396,8 +396,9 @@ def _unmarshaling_method_primitive_type(swagger_spec, object_schema):
     :param swagger_spec: Spec object
     :param object_schema: Schema of the primitive type
     """
-    swagger_format = schema.get_format(swagger_spec, object_schema)
+    format_name = schema.get_format(swagger_spec, object_schema)
+    swagger_format = swagger_spec.get_format(format_name) if format_name is not None else None
     if swagger_format is not None:
-        return swagger_spec.get_format(swagger_format).to_python
+        return swagger_format.to_python
     else:
         return _no_op_unmarshaling

--- a/tests/unmarshal/unmarshal_primitive_test.py
+++ b/tests/unmarshal/unmarshal_primitive_test.py
@@ -40,7 +40,6 @@ def test_number(minimal_swagger_spec):
 
 
 def test_datetime_string(minimal_swagger_spec):
-    from datetime import datetime
     date_spec = {
         'type': 'string',
         'format': 'date-time',
@@ -48,10 +47,22 @@ def test_datetime_string(minimal_swagger_spec):
     # the validator requires a time zone, but that's a pain to scaffold:
     # this just tests that naive date parsing happens as expected
     input_date = "2016-06-07T20:59:00.480"
-    expected_date = datetime(2016, 6, 7, 20, 59, 0, 480000)
+    expected_date = datetime.datetime(2016, 6, 7, 20, 59, 0, 480000)
     assert expected_date == unmarshal_primitive(
         minimal_swagger_spec,
         date_spec, input_date,
+    )
+
+
+def test_unmarshaling_unknown_format(minimal_swagger_spec):
+    value = 'some text'
+    assert value == unmarshal_primitive(
+        minimal_swagger_spec,
+        {
+            'type': 'string',
+            'format': 'a-not-existing-format',
+        },
+        value,
     )
 
 


### PR DESCRIPTION
Changes in the unmarshaling logic (PR #336) revealed a new bug being introduced while working with primitive types, which uses a format that is unknown to bravado-core.

This was observed while trying to integrate the library into an internal service.

The goal of this PR is to address the issue and to create a dedicated test that would help to catch this type of error in the future.

If you run the test on the original codebase (current Yelp/master) the test would fail, but running it with the changes in bravado_core/unmarshal.py proposed by this PR the test would be green.

NOTE: This approach is already used in the marshaling flow (PR #339)