### PR TITLE
marshal and unmarshal flow uses a flow specific handle_null_value function 

### DIFF
--- a/bravado_core/marshal.py
+++ b/bravado_core/marshal.py
@@ -27,6 +27,10 @@ if getattr(typing, 'TYPE_CHECKING', False):
 
 
 _NOT_FOUND = object()
+_handle_null_value = partial(
+    _decorators.handle_null_value,
+    is_marshaling_operation=True,
+)
 
 
 def marshal_schema_object(swagger_spec, schema_object_spec, value):
@@ -67,10 +71,9 @@ def marshal_primitive(swagger_spec, primitive_spec, value):
         DeprecationWarning,
     )
 
-    null_decorator = _decorators.handle_null_value(
+    null_decorator = _handle_null_value(
         swagger_spec=swagger_spec,
         object_schema=primitive_spec,
-        is_marshaling_operation=True,
     )
     marshal_function = _marshaling_method_primitive_type(swagger_spec=swagger_spec, object_schema=primitive_spec)
     return null_decorator(marshal_function)(value)
@@ -91,10 +94,9 @@ def marshal_array(swagger_spec, array_spec, array_value):
         'Please use the more general entry-point offered in marshal_schema_object',
         DeprecationWarning,
     )
-    null_decorator = _decorators.handle_null_value(
+    null_decorator = _handle_null_value(
         swagger_spec=swagger_spec,
         object_schema=array_spec,
-        is_marshaling_operation=True,
     )
     marshal_function = _marshaling_method_array(swagger_spec=swagger_spec, object_schema=array_spec)
     return null_decorator(marshal_function)(array_value)
@@ -116,10 +118,9 @@ def marshal_object(swagger_spec, object_spec, object_value):
         'Please use the more general entry-point offered in marshal_schema_object',
         DeprecationWarning,
     )
-    null_decorator = _decorators.handle_null_value(
+    null_decorator = _handle_null_value(
         swagger_spec=swagger_spec,
         object_schema=object_spec,
-        is_marshaling_operation=True,
     )
     marshal_function = _marshaling_method_object(swagger_spec=swagger_spec, object_schema=object_spec)
     return null_decorator(marshal_function)(object_value)
@@ -140,10 +141,9 @@ def marshal_model(swagger_spec, model_spec, model_value):
         'Please use the more general entry-point offered in marshal_schema_object',
         DeprecationWarning,
     )
-    null_decorator = _decorators.handle_null_value(
+    null_decorator = _handle_null_value(
         swagger_spec=swagger_spec,
         object_schema=model_spec,
-        is_marshaling_operation=True,
     )
     marshal_function = _marshaling_method_object(swagger_spec=swagger_spec, object_schema=model_spec)
     return null_decorator(marshal_function)(model_value)
@@ -162,11 +162,10 @@ def _get_marshaling_method(swagger_spec, object_schema, required=False):
     :type object_schema: dict
     """
     object_schema = swagger_spec.deref(object_schema)
-    null_decorator = _decorators.handle_null_value(
+    null_decorator = _handle_null_value(
         swagger_spec=swagger_spec,
         object_schema=object_schema,
         is_nullable=not required,
-        is_marshaling_operation=True,
     )
     object_type = get_type_from_schema(swagger_spec, object_schema)
 

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -32,6 +32,10 @@ if getattr(typing, 'TYPE_CHECKING', False):
 
 
 _NOT_FOUND = object()
+_handle_null_value = partial(
+    _decorators.handle_null_value,
+    is_marshaling_operation=False,
+)
 
 
 def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
@@ -73,7 +77,7 @@ def unmarshal_primitive(swagger_spec, primitive_spec, value):
         'Please use the more general entry-point offered in unmarshal_schema_object',
         DeprecationWarning,
     )
-    null_decorator = _decorators.handle_null_value(swagger_spec=swagger_spec, object_schema=primitive_spec)
+    null_decorator = _handle_null_value(swagger_spec=swagger_spec, object_schema=primitive_spec)
     unmarshal_function = _unmarshaling_method_primitive_type(swagger_spec, primitive_spec)
 
     return null_decorator(unmarshal_function)(value)
@@ -94,7 +98,7 @@ def unmarshal_array(swagger_spec, array_spec, array_value):
         'Please use the more general entry-point offered in unmarshal_schema_object',
         DeprecationWarning,
     )
-    null_decorator = _decorators.handle_null_value(swagger_spec=swagger_spec, object_schema=array_spec)
+    null_decorator = _handle_null_value(swagger_spec=swagger_spec, object_schema=array_spec)
     unmarshal_function = _unmarshaling_method_array(swagger_spec, array_spec)
     return null_decorator(unmarshal_function)(array_value)
 
@@ -114,7 +118,7 @@ def unmarshal_object(swagger_spec, object_spec, object_value):
         'Please use the more general entry-point offered in unmarshal_schema_object',
         DeprecationWarning,
     )
-    null_decorator = _decorators.handle_null_value(swagger_spec=swagger_spec, object_schema=object_spec)
+    null_decorator = _handle_null_value(swagger_spec=swagger_spec, object_schema=object_spec)
     unmarshal_function = _unmarshaling_method_object(swagger_spec, object_spec, use_models=False)
     return null_decorator(unmarshal_function)(object_value)
 
@@ -135,7 +139,7 @@ def unmarshal_model(swagger_spec, model_spec, model_value):
         DeprecationWarning,
     )
 
-    null_decorator = _decorators.handle_null_value(swagger_spec=swagger_spec, object_schema=model_spec)
+    null_decorator = _handle_null_value(swagger_spec=swagger_spec, object_schema=model_spec)
     unmarshal_function = _unmarshaling_method_object(swagger_spec, model_spec, use_models=True)
     return null_decorator(unmarshal_function)(model_value)
 
@@ -157,7 +161,7 @@ def _get_unmarshaling_method(swagger_spec, object_schema, is_nullable=True):
                         attribute is set to true by the "parent" schema
     """
     object_schema = swagger_spec.deref(object_schema)
-    null_decorator = _decorators.handle_null_value(
+    null_decorator = _handle_null_value(
         swagger_spec=swagger_spec,
         object_schema=object_schema,
         is_nullable=is_nullable,


### PR DESCRIPTION
As agreed on #339 we should make sure that we have a single entrypoint to `_decorators.handle_null_value` as it is easy to forget setting the appropriate `is_marshaling_operation` flag.

The goal of this PR is to address this by using partials as unique usage of `_handle_null_value` in the different modules.
