### PR TITLE
Increase resilience of is_model and is_object methods

### DIFF
--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -8,6 +8,7 @@ from warnings import warn
 
 from six import add_metaclass
 from six import iteritems
+from six import string_types
 from swagger_spec_validator.ref_validators import attach_scope
 
 from bravado_core.schema import collapsed_properties
@@ -645,7 +646,7 @@ def is_model(swagger_spec, schema_object_spec):
     """
     deref = swagger_spec.deref
     schema_object_spec = deref(schema_object_spec)
-    return deref(schema_object_spec.get(MODEL_MARKER)) is not None
+    return isinstance(deref(schema_object_spec.get(MODEL_MARKER)), string_types)
 
 
 def is_object(swagger_spec, object_spec, no_default_type=False):
@@ -661,7 +662,8 @@ def is_object(swagger_spec, object_spec, no_default_type=False):
     """
     deref = swagger_spec.deref
     default_type = 'object' if not no_default_type and swagger_spec.config['default_type_to_object'] else None
-    return deref(object_spec.get('type', default_type)) == 'object' or 'allOf' in object_spec
+    object_type = deref(deref(object_spec).get('type', default_type))
+    return object_type == 'object' or (object_type is None and 'allOf' in object_spec)
 
 
 def create_model_docstring(swagger_spec, model_spec):

--- a/tests/model/is_model_test.py
+++ b/tests/model/is_model_test.py
@@ -2,7 +2,6 @@
 import pytest
 
 from bravado_core.model import is_model
-from bravado_core.schema import is_required
 from bravado_core.spec import Spec
 
 
@@ -28,10 +27,18 @@ def test_true(minimal_swagger_spec, model_spec):
 
 
 def test_false(minimal_swagger_spec, object_spec):
-    assert not is_required(minimal_swagger_spec, object_spec)
+    assert not is_model(minimal_swagger_spec, object_spec)
 
 
 def test_ref(minimal_swagger_dict, model_spec):
     minimal_swagger_dict['definitions']['Foo'] = model_spec
     swagger_spec = Spec(minimal_swagger_dict)
     assert is_model(swagger_spec, {'$ref': '#/definitions/Foo'})
+
+
+def test_x_model_not_string(minimal_swagger_dict):
+    minimal_swagger_dict['definitions']['Foo'] = {
+        'x-model': {'x-vendor': 'Address'},
+    }
+    swagger_spec = Spec(minimal_swagger_dict)
+    assert not is_model(swagger_spec, minimal_swagger_dict['definitions']['Foo'])

--- a/tests/model/is_object_test.py
+++ b/tests/model/is_object_test.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from bravado_core.model import is_object
+from bravado_core.spec import Spec
+
+
+# deref = swagger_spec.deref
+# default_type = 'object' if not no_default_type and swagger_spec.config['default_type_to_object'] else None
+# object_type = deref(object_spec.get('type', default_type))
+# return object_type == 'object' or (object_type is None and 'allOf' in object_spec)
+
+
+@pytest.mark.parametrize(
+    'object_spec, config_override',
+    [
+        [{'type': 'object'}, {}],
+        [{}, {'default_type_to_object': True}],
+        [{'allOf': []}, {}],
+    ],
+)
+def test_true(minimal_swagger_spec, object_spec, config_override):
+    minimal_swagger_spec.config.update(config_override)
+    assert is_object(minimal_swagger_spec, object_spec)
+
+
+@pytest.mark.parametrize(
+    'object_spec, config_override',
+    [
+        [{'type': 'string'}, {}],
+        [{'type': 'string', 'allOf': []}, {}],
+    ],
+)
+def test_false(minimal_swagger_spec, object_spec, config_override):
+    minimal_swagger_spec.config.update(config_override)
+    assert not is_object(
+        minimal_swagger_spec, object_spec,
+    )
+
+
+def test_ref(minimal_swagger_dict):
+    minimal_swagger_dict['definitions']['Foo'] = {'type': 'object'}
+    minimal_swagger_spec = Spec.from_dict(minimal_swagger_dict)
+    assert is_object(minimal_swagger_spec, {'$ref': '#/definitions/Foo'})
+
+#
+# def test_x_model_not_string(minimal_swagger_dict):
+#     minimal_swagger_dict['definitions']['Foo'] = {
+#         'x-model': {'x-vendor': 'Address'},
+#     }
+#     swagger_spec = Spec(minimal_swagger_dict)
+#     assert not is_model(swagger_spec, minimal_swagger_dict['definitions']['Foo'])

--- a/tests/model/model_discovery_test.py
+++ b/tests/model/model_discovery_test.py
@@ -42,3 +42,25 @@ def test_model_discovery_flow_with_ref_dereference(wrap__run_post_processing, mi
     # 2. post processing on on bravado_core.spec_flattening.flattened_spec
     # 3. post processing to rebuild definitions to remove possible references in the model specs
     assert wrap__run_post_processing.call_count == 3
+
+
+@pytest.mark.parametrize(
+    'model_dict',
+    [
+        {
+            'properties': {
+                'allOf': {
+                    'type': 'string',
+                },
+                'title': {'type': 'string'},
+                'type': {'type': 'string'},
+            },
+            'type': 'object',
+        },
+    ],
+)
+def test_model_discovery_for_models_with_not_string_title_x_model(minimal_swagger_dict, model_dict):
+    # This test case has been extracted from the Kubernetes Swagger specs
+    # https://raw.githubusercontent.com/kubernetes/kubernetes/release-1.15/api/openapi-spec/swagger.json#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaProps
+    spec = Spec.from_dict(spec_dict=dict(minimal_swagger_dict, definitions={'Model': model_dict}))
+    assert set(spec.definitions) == {'Model'}


### PR DESCRIPTION
While testing the library, I've played a bit importint the kubernetes swagger specs ([link](https://raw.githubusercontent.com/kubernetes/kubernetes/release-1.15/api/openapi-spec/swagger.json)).
The specs were selected as a good example of very very big swagger specs.
During the testing I've uncovered an issue related to `is_models` and `is_object` methods.

The method do assume that `x-model` and `title` properties of the object are string, but this is not something that we could actually assume as the specs do not prevent the presence of the attribute as valid object properties.
For example
```yaml
definitions:
  model:
    properties:
      title:
        type: string
      x-model:
        type: string
```

The goal of this PR is to better handle the condition of:
 * `x-model` is not a `string`
 * `title` is not a `string`

In order to prevent future regression I extracted a small test-case that is able to trigger the issue.

The script using while testing (that helped me discovering the bug) is the one listed below
```python
import requests
from bravado_core.spec import Spec
spec_url = 'https://raw.githubusercontent.com/kubernetes/kubernetes/release-1.15/api/openapi-spec/swagger.json'
Spec.from_dict(requests.get(spec_url).json())
```