### PR TITLE
Fix test failure

### DIFF
--- a/tests/model/model_test.py
+++ b/tests/model/model_test.py
@@ -46,11 +46,12 @@ def test_model_delete_property(definitions_spec, user_type, user_kwargs):
     # deleting a property defined in the spec should set the value to None
     assert user.id is None
 
-    assert all(
-        user[property] == user_kwargs.get(property)
-        for property in definitions_spec['User']['properties']
-        if property != 'id'
-    )
+    properties_with_not_matching_values = {
+        prop_name
+        for prop_name in definitions_spec['User']['properties']
+        if prop_name != 'id' and user[prop_name] != user_kwargs.get(prop_name)
+    }
+    assert not properties_with_not_matching_values
 
 
 def test_model_delete_not_existing_property(user_type, user_kwargs):


### PR DESCRIPTION
``tests/model/model_test.py::test_model_delete_property`` test is failing on master.

The issue is most probably caused by some changes on pytest 4.6.x release.
https://github.com/pytest-dev/pytest/pull/5103

In order to get the test green again I've modified it to not use `all` in the assertion