### PR TITLE
Provide more useful error message for response header validation.

### DIFF
--- a/bravado_core/response.py
+++ b/bravado_core/response.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import msgpack
+from jsonschema import ValidationError
 from six import iteritems
 
 from bravado_core.content_type import APP_JSON
@@ -239,6 +240,10 @@ def validate_response_headers(op, response_spec, response):
 
     for header_name, header_spec in iteritems(headers_spec):
         header_spec = deref(header_spec)
-        validate_schema_object(
-            op.swagger_spec, header_spec, response.headers.get(header_name),
-        )
+        try:
+            validate_schema_object(
+                op.swagger_spec, header_spec, response.headers.get(header_name),
+            )
+        except ValidationError as e:
+            e.message = "{0} for header '{1}'".format(e.message, header_name)
+            raise e

--- a/tests/response/validate_response_headers_test.py
+++ b/tests/response/validate_response_headers_test.py
@@ -62,3 +62,4 @@ def test_invalid_headers(op):
     with pytest.raises(ValidationError) as excinfo:
         validate_response_headers(op, response_spec, response)
     assert "is not of type 'integer'" in str(excinfo.value)
+    assert "X-Foo" in str(excinfo.value)


### PR DESCRIPTION
Previously the header_name was not found in the error, which made it not very informative.

Example:
Before: `None is not of type 'string'`
After: `None is not of type 'string' for header 'X-Request-Id'`