### PR TITLE
Fix model discovery during flattening

### DIFF
--- a/test-data/2.0/models_referenced_by_polymorphic_models/definitions.json
+++ b/test-data/2.0/models_referenced_by_polymorphic_models/definitions.json
@@ -1,0 +1,76 @@
+{
+  "definitions": {
+    "GenericContainer": {
+      "x-model": "GenericContainer",
+      "type": "object",
+      "discriminator": "container_discriminator",
+      "properties": {
+        "container_discriminator": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "container_discriminator"
+      ]
+    },
+    "Container1": {
+      "x-model": "Container1",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/GenericContainer"
+        },
+        {
+          "properties": {
+            "referenced_polymorphic_object": {
+              "$ref": "#/definitions/GenericContent"
+            },
+            "other": {
+              "$ref": "#/definitions/ReferencedFromContainer1"
+            }
+          }
+        }
+      ]
+    },
+    "GenericContent": {
+      "x-model": "GenericContent",
+      "type": "object",
+      "discriminator": "content_discriminator",
+      "properties": {
+        "content_discriminator": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "content_discriminator"
+      ]
+    },
+    "ReferencedFromContent1": {
+      "type": "object",
+      "x-model": "ReferencedFromContent1"
+    },
+    "ReferencedFromContainer1": {
+      "type": "object",
+      "x-model": "ReferencedFromContainer1"
+    },
+    "Content1": {
+      "x-model": "Content1",
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/GenericContent"
+        },
+        {
+          "properties": {
+            "field": {
+              "type": "string"
+            },
+            "other": {
+              "$ref": "#/definitions/ReferencedFromContent1"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/test-data/2.0/models_referenced_by_polymorphic_models/swagger.json
+++ b/test-data/2.0/models_referenced_by_polymorphic_models/swagger.json
@@ -1,0 +1,21 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "0.0.0",
+    "title": ""
+  },
+  "paths": {
+    "/endpoint": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "definitions.json#/definitions/GenericContainer"
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Enhancing spec flattening done in #324 (released with bravado-core==5.12.0) did introduce a bug that caused models referenced by discriminated models to not be included in the final spec flattening.

A minimal use-case has been extracted in ` test-data/2.0/models_referenced_by_polymorphic_models/`.
The basic bug was related to the fact that `register_unflattened_models` relied on a _gobal_ variable for the `flattened_models` which was not properly updated after the model discovery.

In order to fix this issue I've made sure that the determination of the already flattened models is done in the `register_unflattened_models` context