### PR TITLE
Add option to automatically encode/decode strings with byte format

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,8 @@ Changelog
 =========
 .. Make sure to link Issue and PR information as `(PR|Issue) #xxx`_ and with a link at the bottom of the document
 
+- Add option to automatically base64-encode/decode strings with byte format - `PR #351`_
+
 5.13.2 (2019-09-04)
 -------------------
 - Improve header validation error message - `PR #347`_ Thanks brycedrennan for your contribution!
@@ -534,6 +536,7 @@ Changelog
 .. _PR #345: https://github.com/Yelp/bravado-core/pull/345
 .. _PR #347: https://github.com/Yelp/bravado-core/pull/347
 .. _PR #350: https://github.com/Yelp/bravado-core/pull/350
+.. _PR #351: https://github.com/Yelp/bravado-core/pull/351
 
 
 .. Link To Documentation pages

--- a/bravado_core/formatter.py
+++ b/bravado_core/formatter.py
@@ -112,7 +112,8 @@ BASE64_BYTE_FORMAT = SwaggerFormat(
     # Note: In Python 3, this requires a bytes-like object as input
     to_wire=lambda b: six.ensure_str(base64.b64encode(b), encoding='ascii'),
     to_python=lambda s: base64.b64decode(
-        six.ensure_binary(s, encoding='ascii')),
+        six.ensure_binary(s, encoding='ascii'),
+    ),
     validate=NO_OP,  # jsonschema validates string
     description='Converts [wire]string:byte <=> python bytes',
 )

--- a/bravado_core/formatter.py
+++ b/bravado_core/formatter.py
@@ -3,6 +3,7 @@
 Support for the 'format' key in the swagger spec as outlined in
 https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#dataTypeFormat
 """
+import base64
 import functools
 from collections import namedtuple
 
@@ -105,6 +106,16 @@ def return_true_wrapper(validate_func):
 
     return wrapper
 
+
+BASE64_BYTE_FORMAT = SwaggerFormat(
+    format='byte',
+    # Note: In Python 3, this requires a bytes-like object as input
+    to_wire=lambda b: six.ensure_str(base64.b64encode(b), encoding='ascii'),
+    to_python=lambda s: base64.b64decode(
+        six.ensure_binary(s, encoding='ascii')),
+    validate=NO_OP,  # jsonschema validates string
+    description='Converts [wire]string:byte <=> python bytes',
+)
 
 DEFAULT_FORMATS = {
     'byte': SwaggerFormat(

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -79,6 +79,10 @@ CONFIG_DEFAULTS = {
     # If True, use the 'path' element of the URL the spec was retrieved from
     # If False, set basePath to '/' (conforms to Swagger 2.0 specification)
     'use_spec_url_for_base_path': False,
+
+    # If False, use str() function for 'byte' format
+    # If True, encode/decode base64 data for 'byte' format
+    'use_base64_for_byte_format': False,
 }
 
 
@@ -285,6 +289,8 @@ class Spec(object):
         user_defined_format = self.user_defined_formats.get(name)
         if user_defined_format is None:
             user_defined_format = formatter.DEFAULT_FORMATS.get(name)
+            if name == 'byte' and self.config['use_base64_for_byte_format']:
+                user_defined_format = formatter.BASE64_BYTE_FORMAT
 
         if user_defined_format is None:
             warnings.warn(

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -55,4 +55,7 @@ Config key                    Type            Default   Description
                                                         | spec was retrieved from.
                                                         | If disabled, set `basePath` to `/` (conforms to
                                                         | the Swagger 2.0 specification)
+----------------------------- --------------- --------- ----------------------------------------------------
+*use_base64_for_byte_format*  boolean         False     | If true, base64-encode binary data to wire and
+                                                        | base64-decode from wire for data with byte format.
 ============================= =============== ========= ====================================================

--- a/tests/formatter/to_python_test.py
+++ b/tests/formatter/to_python_test.py
@@ -96,7 +96,8 @@ def test_byte(minimal_swagger_spec):
 
 def test_byte_base64(minimal_swagger_dict):
     swagger_spec = Spec.from_dict(
-        minimal_swagger_dict, config={'use_base64_for_byte_format': True})
+        minimal_swagger_dict, config={'use_base64_for_byte_format': True},
+    )
     schema = {'type': 'string', 'format': 'byte'}
     result = to_python(swagger_spec, schema, 'YWJj/w==')
     assert b'abc\xff' == result

--- a/tests/formatter/to_python_test.py
+++ b/tests/formatter/to_python_test.py
@@ -94,6 +94,15 @@ def test_byte(minimal_swagger_spec):
     assert isinstance(result, str)
 
 
+def test_byte_base64(minimal_swagger_dict):
+    swagger_spec = Spec.from_dict(
+        minimal_swagger_dict, config={'use_base64_for_byte_format': True})
+    schema = {'type': 'string', 'format': 'byte'}
+    result = to_python(swagger_spec, schema, 'YWJj/w==')
+    assert b'abc\xff' == result
+    assert isinstance(result, bytes)
+
+
 def test_ref(minimal_swagger_dict):
     minimal_swagger_dict['definitions']['Int32'] = {
         'type': 'integer', 'format': 'int32',

--- a/tests/formatter/to_wire_test.py
+++ b/tests/formatter/to_wire_test.py
@@ -114,6 +114,15 @@ def test_byte_unicode(minimal_swagger_spec):
     assert isinstance(result, str)
 
 
+def test_byte_base64(minimal_swagger_dict):
+    swagger_spec = Spec.from_dict(
+        minimal_swagger_dict, config={'use_base64_for_byte_format': True})
+    schema = {'type': 'string', 'format': 'byte'}
+    result = to_wire(swagger_spec, schema, b'abc\xff')
+    assert 'YWJj/w==' == result
+    assert isinstance(result, str)
+
+
 def test_ref(minimal_swagger_dict):
     minimal_swagger_dict['definitions']['Int32'] = {
         'type': 'integer', 'format': 'int32',

--- a/tests/formatter/to_wire_test.py
+++ b/tests/formatter/to_wire_test.py
@@ -116,7 +116,8 @@ def test_byte_unicode(minimal_swagger_spec):
 
 def test_byte_base64(minimal_swagger_dict):
     swagger_spec = Spec.from_dict(
-        minimal_swagger_dict, config={'use_base64_for_byte_format': True})
+        minimal_swagger_dict, config={'use_base64_for_byte_format': True},
+    )
     schema = {'type': 'string', 'format': 'byte'}
     result = to_wire(swagger_spec, schema, b'abc\xff')
     assert 'YWJj/w==' == result


### PR DESCRIPTION
Define a `SwaggerFormat` for the "byte" string format that  base64-encodes binary data to wire and base64-decodes from wire to a Python `bytes` object.

This behavior is not backward-compatible so I added a config option to enable it, disabled by default.

Related: #146