### PR TITLE
Fix test warnings

### DIFF
--- a/tests/model/model_test.py
+++ b/tests/model/model_test.py
@@ -104,6 +104,7 @@ def test_model_as_dict(definitions_spec, user_type, user_kwargs):
 
 
 @pytest.mark.filterwarnings('ignore:_isinstance is deprecated')
+@pytest.mark.filterwarnings('ignore:Model object methods are now prefixed')
 def test_model_isinstance_same_class(user_type, user_kwargs):
     user = user_type(**user_kwargs)
     assert user_type._isinstance(user)
@@ -117,6 +118,7 @@ def test_model_issubclass_same_class(user_type):
 
 
 @pytest.mark.filterwarnings('ignore:_isinstance is deprecated')
+@pytest.mark.filterwarnings('ignore:Model object methods are now prefixed')
 def test_model_isinstance_inherits_from(cat_swagger_spec, pet_type, pet_spec, cat_type, cat_kwargs):
     cat = cat_type(**cat_kwargs)
     assert pet_type._isinstance(cat)

--- a/tests/unmarshal/unmarshal_primitive_test.py
+++ b/tests/unmarshal/unmarshal_primitive_test.py
@@ -54,6 +54,7 @@ def test_datetime_string(minimal_swagger_spec):
     )
 
 
+@pytest.mark.filterwarnings('ignore:a-not-existing-format format is not registered')
 def test_unmarshaling_unknown_format(minimal_swagger_spec):
     value = 'some text'
     assert value == unmarshal_primitive(

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [pytest]
 filterwarnings =
+    error
     ignore:.*will be deprecated in the next major release. Please use the more general entry-point offered in.*:DeprecationWarning
 
 [tox]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [pytest]
 filterwarnings =
-    error
     ignore:.*will be deprecated in the next major release. Please use the more general entry-point offered in.*:DeprecationWarning
 
 [tox]


### PR DESCRIPTION
* Add filters for uncaught warnings in tests.
* <strike>Treat unfiltered warnings as test failures.  (Not sure about this change, is it too strict?)</strike> (This caused the Travis build to fail; reverted.)