### PR TITLE
Update Model.__eq__ logic

### DIFF
--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -471,8 +471,7 @@ class Model(object):
         Two model instances are equal if they have the same type and the same
         properties and values (including additional properties).
         """
-        # Check same type as self
-        if type(self) is not type(other):
+        if not isinstance(other, self.__class__):
             return False
 
         # Ignore any '_raw' keys

--- a/tests/model/model_test.py
+++ b/tests/model/model_test.py
@@ -131,10 +131,18 @@ def test_model_issubclass_inherits_from(pet_type, cat_type):
     assert issubclass(cat_type, pet_type)
 
 
-def test_model_isinstance_model_class_generate_by_different_Spec_object(cat_swagger_spec, cat_type, cat_kwargs):
+def test_model_isinstance_model_class_generated_by_different_Spec_object(cat_swagger_spec, cat_type, cat_kwargs):
     cat = cat_type(**cat_kwargs)
     new_cat_spec = Spec.from_dict(cat_swagger_spec.client_spec_dict)
     assert isinstance(cat, new_cat_spec.definitions['Cat'])
+
+
+def test_model_equality_if_model_class_generated_by_different_Spec_object(cat_swagger_spec, cat_type, cat_kwargs):
+    cat = cat_type(**cat_kwargs)
+    new_cat_spec = Spec.from_dict(cat_swagger_spec.client_spec_dict)
+    new_cat_type = new_cat_spec.definitions['Cat']
+    new_cat = new_cat_type(**cat_kwargs)
+    assert cat == new_cat
 
 
 def test_model_deepcopy(user_type, user_kwargs):


### PR DESCRIPTION
Model equality check was implemented by ensuring that two objects of the same class and with the same "dict" representation are considered the same.

As far as this definition is valid we might do it a bit better.
Currently, `isinstance` and `issubclass` checks do consider _equivalent_ model types generated by different `bravado_core.spec.Spec` instances if they are created out of the same specs (same url and content).
So what can happen is that
```python
instance1 = spec1.definitions['model1'](...)
instance2 = spec2.definitions['model1']model1(...)

assert isinstance(instance1, instance2.__class__)
assert isinstance(instance2, instance1.__class__)
assert instance1._as_dict() == instance2._as_dict()
assert instance1 == instance2  # This would fail with the currently released bravado-core and succeed after this PR
```
The added test, `test_model_equality_if_model_class_generated_by_different_Spec_object`, will ensure that regression will be catched if the behaviour will change and it currently fails if the changes in `bravado_core/model.py` are reverted