### PR TITLE
Ensure that spec is deep copiable

### DIFF
--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -493,9 +493,11 @@ class Model(object):
         ]
         return "{0}({1})".format(self.__class__.__name__, ', '.join(s))
 
-    def __deepcopy__(self, memodict={}):
+    def __deepcopy__(self, memo=None):
         """Deep copy all properties, but not metadata like the Swagger or Model spec attributes."""
-        return self.__class__(**deepcopy(self.__dict))
+        if memo is None:
+            memo = {}
+        return self.__class__(**deepcopy(self.__dict, memo=memo))
 
     @property
     def _additional_props(self):

--- a/bravado_core/operation.py
+++ b/bravado_core/operation.py
@@ -59,11 +59,11 @@ class Operation(object):
         self.params = {}
 
     def __eq__(self, other):
-        if not isinstance(other, self.__class__):
-            return False
-
         if id(self) == id(other):
             return True
+
+        if not isinstance(other, self.__class__):
+            return False
 
         return (
             self.path_name == other.path_name and

--- a/bravado_core/operation.py
+++ b/bravado_core/operation.py
@@ -58,6 +58,15 @@ class Operation(object):
         # (key, value) = (param name, Param)
         self.params = {}
 
+    def __eq__(self, other):
+        return (
+            isinstance(other, self.__class__) and
+            self.path_name == other.path_name and
+            self.http_method == other.http_method and
+            self.op_spec == other.op_spec and
+            self.swagger_spec == other.swagger_spec
+        )
+
     @cached_property
     def consumes(self):
         """Note that the operation can override the value defined globally

--- a/bravado_core/operation.py
+++ b/bravado_core/operation.py
@@ -59,8 +59,13 @@ class Operation(object):
         self.params = {}
 
     def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return False
+
+        if id(self) == id(other):
+            return True
+
         return (
-            isinstance(other, self.__class__) and
             self.path_name == other.path_name and
             self.http_method == other.http_method and
             self.op_spec == other.op_spec and

--- a/bravado_core/resource.py
+++ b/bravado_core/resource.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import logging
 from collections import defaultdict
+from copy import deepcopy
 
 from six import iteritems
 
@@ -95,6 +96,14 @@ class Resource(object):
         log.debug(u"Building resource '%s'", name)
         self.name = name
         self.operations = ops
+
+    def __deepcopy__(self, memo=None):
+        if memo is None:
+            memo = {}
+        return self.__class__(
+            name=deepcopy(self.name, memo=memo),
+            ops=deepcopy(self.operations, memo=memo),
+        )
 
     def __repr__(self):
         return u"%s(%s)" % (self.__class__.__name__, self.name)

--- a/bravado_core/resource.py
+++ b/bravado_core/resource.py
@@ -125,8 +125,13 @@ class Resource(object):
         return self.operations.keys()
 
     def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return False
+
+        if id(self) == id(other):
+            return True
+
         return (
-            isinstance(other, self.__class__) and
             self.name == other.name and
             self.operations == other.operations
         )

--- a/bravado_core/resource.py
+++ b/bravado_core/resource.py
@@ -125,11 +125,11 @@ class Resource(object):
         return self.operations.keys()
 
     def __eq__(self, other):
-        if not isinstance(other, self.__class__):
-            return False
-
         if id(self) == id(other):
             return True
+
+        if not isinstance(other, self.__class__):
+            return False
 
         return (
             self.name == other.name and

--- a/bravado_core/resource.py
+++ b/bravado_core/resource.py
@@ -123,3 +123,10 @@ class Resource(object):
         :return: list of operation names
         """
         return self.operations.keys()
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, self.__class__) and
+            self.name == other.name and
+            self.operations == other.operations
+        )

--- a/bravado_core/security_definition.py
+++ b/bravado_core/security_definition.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
+from copy import deepcopy
 
 log = logging.getLogger(__name__)
 
@@ -15,6 +16,14 @@ class SecurityDefinition(object):
     def __init__(self, swagger_spec, security_definition_spec):
         self.swagger_spec = swagger_spec
         self.security_definition_spec = swagger_spec.deref(security_definition_spec)
+
+    def __deepcopy__(self, memo=None):
+        if memo is None:
+            memo = {}
+        return self.__class__(
+            swagger_spec=deepcopy(self.swagger_spec, memo=memo),
+            security_definition_spec=deepcopy(self.security_definition_spec, memo=memo),
+        )
 
     @property
     def location(self):

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -138,11 +138,11 @@ class Spec(object):
         self._internal_spec_dict = spec_dict
 
     def __eq__(self, other):
-        if not isinstance(other, self.__class__):
-            return False
-
         if id(self) == id(other):
             return True
+
+        if not isinstance(other, self.__class__):
+            return False
 
         # If self and other are of the same type but not pointing to the same memory location then we're going to inspect
         # all the attributes.

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os.path
 import warnings
+from copy import deepcopy
 
 import yaml
 from jsonref import JsonRef
@@ -134,6 +135,24 @@ class Spec(object):
         # spec dict used to build resources, in case internally_dereference_refs config is enabled
         # it will be overridden by the dereferenced specs (by build method). More context in PR#263
         self._internal_spec_dict = spec_dict
+
+    def __deepcopy__(self, memo=None):
+        if memo is None:
+            memo = {}
+
+        copied_self = self.__class__(
+            spec_dict=deepcopy(self.spec_dict, memo=memo),
+            origin_url=deepcopy(self.origin_url, memo=memo),
+            http_client=deepcopy(self.http_client, memo=memo),
+            config=deepcopy(self.config, memo=memo),
+        )
+
+        # Copy the attributes that are built via Spec.build
+        for attr_name, attr_value in iteritems(self.__dict__):
+            if attr_value != copied_self.__dict__.get(attr_name):
+                setattr(copied_self, attr_name, deepcopy(attr_value, memo=memo))
+
+        return copied_self
 
     @cached_property
     def client_spec_dict(self):

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -151,17 +151,12 @@ class Spec(object):
         if memo is None:
             memo = {}
 
-        copied_self = self.__class__(
-            spec_dict=deepcopy(self.spec_dict, memo=memo),
-            origin_url=deepcopy(self.origin_url, memo=memo),
-            http_client=deepcopy(self.http_client, memo=memo),
-            config=deepcopy(self.config, memo=memo),
-        )
+        copied_self = self.__class__(spec_dict=None)
+        memo[id(self)] = copied_self
 
         # Copy the attributes that are built via Spec.build
         for attr_name, attr_value in iteritems(self.__dict__):
-            if attr_value != copied_self.__dict__.get(attr_name):
-                setattr(copied_self, attr_name, deepcopy(attr_value, memo=memo))
+            setattr(copied_self, attr_name, deepcopy(attr_value, memo=memo))
 
         return copied_self
 

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -136,6 +136,17 @@ class Spec(object):
         # it will be overridden by the dereferenced specs (by build method). More context in PR#263
         self._internal_spec_dict = spec_dict
 
+    def __eq__(self, other):
+        return (
+            isinstance(other, self.__class__) and
+            self.spec_dict == other.spec_dict and
+            self.origin_url == other.origin_url and
+            self.http_client == other.http_client and
+            self.config == other.config and
+            self.api_url == other.api_url and
+            self.definitions == other.definitions
+        )
+
     def __deepcopy__(self, memo=None):
         if memo is None:
             memo = {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -135,6 +135,11 @@ def petstore_spec(petstore_dict, petstore_abspath):
 
 
 @pytest.fixture
+def getPetByIdPetstoreOperation(petstore_spec):
+    return petstore_spec.resources['pet'].operations['getPetById']
+
+
+@pytest.fixture
 def polymorphic_abspath(my_dir):
     return os.path.join(os.path.dirname(my_dir), 'test-data', '2.0', 'polymorphic_specs', 'swagger.json')
 

--- a/tests/operation/equality_test.py
+++ b/tests/operation/equality_test.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from bravado_core.spec import Spec
+from tests.conftest import get_url
+
+
+def test_equality_of_the_same_object_returns_True(getPetByIdPetstoreOperation):
+    assert getPetByIdPetstoreOperation == getPetByIdPetstoreOperation
+
+
+def test_equality_of_different_instances_returns_True_if_the_specs_are_the_same(
+    getPetByIdPetstoreOperation, petstore_dict, petstore_abspath,
+):
+    other_petstore_spec = Spec.from_dict(petstore_dict, origin_url=get_url(petstore_abspath))
+    other_getPetByIdPetstoreOperation = other_petstore_spec.resources['pet'].operations['getPetById']
+    assert getPetByIdPetstoreOperation == other_getPetByIdPetstoreOperation
+
+
+def test_equality_of_different_instances_returns_False_if_the_specs_are_the_different(petstore_spec, getPetByIdPetstoreOperation):
+    assert getPetByIdPetstoreOperation != petstore_spec.resources['pet'].operations['addPet']

--- a/tests/operation/security_object_test.py
+++ b/tests/operation/security_object_test.py
@@ -94,25 +94,23 @@ def test_op_with_security_in_root_with_empty_security_spec(specs_with_security_o
     assert len(operation.security_requirements) == 0
 
 
-def test_correct_request_with_apiKey_security(petstore_spec):
+def test_correct_request_with_apiKey_security(getPetByIdPetstoreOperation):
     request = Mock(
         spec=IncomingRequest,
         path={'petId': '1234'},
         headers={'api-key': 'key1'},
     )
-    op = petstore_spec.resources['pet'].operations['getPetById']
-    unmarshal_request(request, op)
+    unmarshal_request(request, getPetByIdPetstoreOperation)
 
 
-def test_wrong_request_with_apiKey_security(petstore_spec):
+def test_wrong_request_with_apiKey_security(getPetByIdPetstoreOperation):
     request = Mock(
         spec=IncomingRequest,
         path={'petId': '1234'},
         headers={},
     )
-    op = petstore_spec.resources['pet'].operations['getPetById']
     with pytest.raises(SwaggerSecurityValidationError):
-        unmarshal_request(request, op)
+        unmarshal_request(request, getPetByIdPetstoreOperation)
 
 
 @pytest.mark.parametrize(

--- a/tests/request/unmarshal_request_test.py
+++ b/tests/request/unmarshal_request_test.py
@@ -8,15 +8,14 @@ from bravado_core.request import IncomingRequest
 from bravado_core.request import unmarshal_request
 
 
-def test_request_with_path_parameter(petstore_spec):
+def test_request_with_path_parameter(getPetByIdPetstoreOperation):
     request = Mock(
         spec=IncomingRequest,
         path={'petId': '1234'},
         headers={'api-key': 'key1'},
     )
     # /pet/{pet_id} fits the bill
-    op = petstore_spec.resources['pet'].operations['getPetById']
-    request_data = unmarshal_request(request, op)
+    request_data = unmarshal_request(request, getPetByIdPetstoreOperation)
     assert request_data['petId'] == 1234
     assert request_data['api-key'] == 'key1'
 

--- a/tests/resource/deepcopy_test.py
+++ b/tests/resource/deepcopy_test.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from tests.conftest import check_object_deepcopy
+
+
+@pytest.fixture
+def pet_resource(petstore_spec):
+    return petstore_spec.resources['pet']
+
+
+def test_resource_instance_is_deep_copyable(pet_resource):
+    check_object_deepcopy(pet_resource)

--- a/tests/resource/equality_test.py
+++ b/tests/resource/equality_test.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from bravado_core.spec import Spec
+from tests.conftest import get_url
+
+
+@pytest.fixture
+def petPetstoreResource(petstore_spec):
+    return petstore_spec.resources['pet']
+
+
+def test_equality_of_the_same_object_returns_True(petPetstoreResource):
+    assert petPetstoreResource == petPetstoreResource
+
+
+def test_equality_of_different_instances_returns_True_if_the_specs_are_the_same(
+    petPetstoreResource, petstore_dict, petstore_abspath,
+):
+    other_petstore_spec = Spec.from_dict(petstore_dict, origin_url=get_url(petstore_abspath))
+    other_petPetstoreResource = other_petstore_spec.resources['pet']
+    assert petPetstoreResource == other_petPetstoreResource
+
+
+def test_equality_of_different_instances_returns_False_if_the_specs_are_the_different(petstore_spec, petPetstoreResource):
+    assert petPetstoreResource != petstore_spec.resources['user']

--- a/tests/spec/Spec/build_test.py
+++ b/tests/spec/Spec/build_test.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from copy import deepcopy
-
 import pytest
 from mock import Mock
 from mock import patch
@@ -295,7 +293,3 @@ def test_build_raises_in_case_of_duplicated_models_between_paths_and_definitions
     )
 
     assert expected_exception_string == str(exinfo.value)
-
-
-def test_spec_instance_is_deep_copaible(petstore_spec):
-    assert petstore_spec == deepcopy(petstore_spec)

--- a/tests/spec/Spec/build_test.py
+++ b/tests/spec/Spec/build_test.py
@@ -298,8 +298,4 @@ def test_build_raises_in_case_of_duplicated_models_between_paths_and_definitions
 
 
 def test_spec_instance_is_deep_copaible(petstore_spec):
-    """
-    The test should be considered successful if calling deepcopy on a
-    Spec instance does not raise exceptions.
-    """
-    deepcopy(petstore_spec)
+    assert petstore_spec == deepcopy(petstore_spec)

--- a/tests/spec/Spec/build_test.py
+++ b/tests/spec/Spec/build_test.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from copy import deepcopy
+
 import pytest
 from mock import Mock
 from mock import patch
@@ -293,3 +295,11 @@ def test_build_raises_in_case_of_duplicated_models_between_paths_and_definitions
     )
 
     assert expected_exception_string == str(exinfo.value)
+
+
+def test_spec_instance_is_deep_copaible(petstore_spec):
+    """
+    The test should be considered successful if calling deepcopy on a
+    Spec instance does not raise exceptions.
+    """
+    deepcopy(petstore_spec)

--- a/tests/spec/Spec/deepcopy_test.py
+++ b/tests/spec/Spec/deepcopy_test.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+from tests.conftest import check_object_deepcopy
+
+
+def test_spec_instance_is_deep_copyable(petstore_spec):
+    check_object_deepcopy(petstore_spec)

--- a/tests/spec/Spec/equality_test.py
+++ b/tests/spec/Spec/equality_test.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+from bravado_core.spec import Spec
+from tests.conftest import get_url
+
+
+def test_equality_of_the_same_object_returns_True(petstore_spec):
+    assert petstore_spec == petstore_spec
+
+
+def test_equality_of_different_instances_returns_True_if_the_specs_are_the_same(petstore_spec, petstore_dict, petstore_abspath):
+    other_petstore_spec_instance = Spec.from_dict(petstore_dict, origin_url=get_url(petstore_abspath))
+    assert petstore_spec == other_petstore_spec_instance
+
+
+def test_equality_of_different_instances_returns_False_if_the_specs_are_the_different(petstore_spec, polymorphic_spec):
+    assert petstore_spec != polymorphic_spec

--- a/tests/spec/Spec/equality_test.py
+++ b/tests/spec/Spec/equality_test.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import pytest
+
 from bravado_core.spec import Spec
 from tests.conftest import get_url
 
@@ -10,6 +12,15 @@ def test_equality_of_the_same_object_returns_True(petstore_spec):
 def test_equality_of_different_instances_returns_True_if_the_specs_are_the_same(petstore_spec, petstore_dict, petstore_abspath):
     other_petstore_spec_instance = Spec.from_dict(petstore_dict, origin_url=get_url(petstore_abspath))
     assert petstore_spec == other_petstore_spec_instance
+
+
+@pytest.mark.parametrize('attribute_value', [None, 42])
+def test_equality_of_different_instances_returns_False_if_attributes_are_not_matching(
+    petstore_spec, petstore_dict, petstore_abspath, attribute_value,
+):
+    other_petstore_spec_instance = Spec.from_dict(petstore_dict, origin_url=get_url(petstore_abspath))
+    setattr(other_petstore_spec_instance, 'a-new-attribute', attribute_value)
+    assert petstore_spec != other_petstore_spec_instance
 
 
 def test_equality_of_different_instances_returns_False_if_the_specs_are_the_different(petstore_spec, polymorphic_spec):

--- a/tests/spec/Spec/get_op_for_request_test.py
+++ b/tests/spec/Spec/get_op_for_request_test.py
@@ -16,9 +16,9 @@ def test_not_found_with_no_basepath(petstore_dict):
     assert op is None
 
 
-def test_found_with_basepath(petstore_spec):
+def test_found_with_basepath(petstore_spec, getPetByIdPetstoreOperation):
     op = petstore_spec.get_op_for_request('GET', '/v2/pet/{petId}')
-    assert op == petstore_spec.resources['pet'].operations['getPetById']
+    assert op == getPetByIdPetstoreOperation
 
 
 def test_found_with_basepath_containing_trailing_slash(petstore_dict):


### PR DESCRIPTION
A `bravado_core.spec.Spec` instance is currently not deep copiable.
So running something like `deepcopy(Spec.from_dict(<valid_specs>))` results on an unbounded recursion error.

The goal of this PR is to address this issue by defining  the `__deepcopy__` dunder method.