### PR TITLE
Enhance typing annotations

### DIFF
--- a/bravado_core/exception.py
+++ b/bravado_core/exception.py
@@ -2,6 +2,11 @@
 import sys
 
 import six
+import typing
+
+
+if getattr(typing, 'TYPE_CHECKING', False):
+    from bravado_core._compat_typing import FuncType
 
 
 class SwaggerError(Exception):
@@ -40,13 +45,16 @@ class SwaggerSecurityValidationError(SwaggerValidationError):
 
 
 def wrap_exception(exception_class):
+    # type: (typing.Type[BaseException]) -> typing.Callable[[FuncType], FuncType]
     """Helper decorator method to modify the raised exception class to
     `exception_class` but keeps the message and trace intact.
 
     :param exception_class: class to wrap raised exception with
     """
     def generic_exception(method):
+        # type: (FuncType) -> FuncType
         def wrapper(*args, **kwargs):
+            # type: (typing.Any, typing.Any) -> typing.Any
             try:
                 return method(*args, **kwargs)
             except Exception as e:
@@ -55,5 +63,6 @@ def wrap_exception(exception_class):
                     exception_class(str(e)),
                     sys.exc_info()[2],
                 )
-        return wrapper
+        return wrapper  # type: ignore  # ignoring type to avoiding typing.cast call
+
     return generic_exception

--- a/bravado_core/formatter.py
+++ b/bravado_core/formatter.py
@@ -3,6 +3,8 @@
 Support for the 'format' key in the swagger spec as outlined in
 https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#dataTypeFormat
 """
+from __future__ import unicode_literals
+
 import base64
 import functools
 
@@ -139,10 +141,8 @@ def return_true_wrapper(validate_func):
 BASE64_BYTE_FORMAT = SwaggerFormat(
     format='byte',
     # Note: In Python 3, this requires a bytes-like object as input
-    to_wire=lambda b: six.ensure_str(base64.b64encode(b), encoding='ascii'),
-    to_python=lambda s: base64.b64decode(
-        six.ensure_binary(s, encoding='ascii'),
-    ),
+    to_wire=lambda b: six.ensure_str(base64.b64encode(b), encoding=str('ascii')),
+    to_python=lambda s: base64.b64decode(six.ensure_binary(s, encoding=str('ascii'))),
     validate=NO_OP,  # jsonschema validates string
     description='Converts [wire]string:byte <=> python bytes',
 )

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -26,6 +26,7 @@ if getattr(typing, 'TYPE_CHECKING', False):
     from bravado_core._compat_typing import JSONDict
     from bravado_core.spec import Spec
 
+
 log = logging.getLogger(__name__)
 
 # Models in #/definitions are tagged with this key so that they can be
@@ -679,7 +680,12 @@ def is_model(swagger_spec, schema_object_spec):
     return isinstance(deref(schema_object_spec.get(MODEL_MARKER)), string_types)
 
 
-def is_object(swagger_spec, object_spec, no_default_type=False):
+def is_object(
+    swagger_spec,  # type: Spec
+    object_spec,  # type: JSONDict
+    no_default_type=False,  # type: bool
+):
+    # type: (...) -> bool
     """
     A schema definition is of type object if its type is object or if it uses
     model composition (i.e. it has an allOf property).

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -9,6 +9,11 @@ from bravado_core._compat import Mapping
 from bravado_core.exception import SwaggerMappingError
 
 
+if getattr(typing, 'TYPE_CHECKING', False):
+    from bravado_core.spec import Spec
+    from bravado_core._compat_typing import JSONDict
+
+
 # 'object' and 'array' are omitted since this should really be read as
 # "Swagger types that map to python primitives"
 SWAGGER_PRIMITIVES = (
@@ -21,34 +26,42 @@ SWAGGER_PRIMITIVES = (
 
 
 def has_default(swagger_spec, schema_object_spec):
+    # type: (Spec, JSONDict) -> bool
     return 'default' in swagger_spec.deref(schema_object_spec)
 
 
 def get_default(swagger_spec, schema_object_spec):
+    # type: (Spec, JSONDict) -> typing.Any
     return swagger_spec.deref(schema_object_spec).get('default')
 
 
 def is_required(swagger_spec, schema_object_spec):
+    # type: (Spec, JSONDict) -> bool
     return swagger_spec.deref(schema_object_spec).get('required', False)
 
 
 def has_format(swagger_spec, schema_object_spec):
+    # type: (Spec, JSONDict) -> bool
     return 'format' in swagger_spec.deref(schema_object_spec)
 
 
 def get_format(swagger_spec, schema_object_spec):
+    # type: (Spec, JSONDict) -> typing.Any
     return swagger_spec.deref(schema_object_spec).get('format')
 
 
 def is_param_spec(swagger_spec, schema_object_spec):
+    # type: (Spec, JSONDict) -> bool
     return 'in' in swagger_spec.deref(schema_object_spec)
 
 
 def is_prop_nullable(swagger_spec, schema_object_spec):
+    # type: (Spec, JSONDict) -> bool
     return swagger_spec.deref(schema_object_spec).get('x-nullable', False)
 
 
-def is_ref(spec):  # type: (typing.Any) -> bool
+def is_ref(spec):
+    # type: (typing.Any) -> bool
     """ Check if the given spec is a Mapping and contains a $ref.
 
     FYI: This function gets called A LOT during unmarshalling and is_dict_like
@@ -64,7 +77,8 @@ def is_ref(spec):  # type: (typing.Any) -> bool
         return False
 
 
-def is_dict_like(spec):  # type: (typing.Any) -> bool
+def is_dict_like(spec):
+    # type: (typing.Any) -> bool
     """
     :param spec: swagger object specification in dict form
     :rtype: boolean
@@ -76,7 +90,8 @@ def is_dict_like(spec):  # type: (typing.Any) -> bool
     return isinstance(spec, (dict, Mapping))
 
 
-def is_list_like(spec):  # type: (typing.Any) -> bool
+def is_list_like(spec):
+    # type: (typing.Any) -> bool
     """
     :param spec: swagger object specification in dict form
     :rtype: boolean
@@ -84,7 +99,14 @@ def is_list_like(spec):  # type: (typing.Any) -> bool
     return isinstance(spec, (list, tuple))
 
 
-def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, properties=None):
+def get_spec_for_prop(
+    swagger_spec,  # type: Spec
+    object_spec,  # type: JSONDict
+    object_value,  # type: typing.Any
+    prop_name,  # type: typing.Text
+    properties=None,  # type: typing.Optional[typing.Mapping[typing.Text, JSONDict]]
+):
+    # type: (...) -> typing.Optional[JSONDict]
     """Given a jsonschema object spec and value, retrieve the spec for the
      given property taking 'additionalProperties' into consideration.
 
@@ -137,6 +159,7 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
 
 
 def handle_null_value(swagger_spec, schema_object_spec):
+    # type: (Spec, JSONDict) -> typing.Any
     """Handle a null value for the associated schema object spec. Checks the
      x-nullable attribute in the spec to see if it is allowed and returns None
      if so and raises an exception otherwise.
@@ -159,6 +182,7 @@ def handle_null_value(swagger_spec, schema_object_spec):
 
 
 def collapsed_properties(model_spec, swagger_spec):
+    # type: (JSONDict, Spec) -> typing.Mapping[typing.Text, JSONDict]
     """Processes model spec and outputs dictionary with attributes
     as the keys and attribute spec as the value for the model.
 
@@ -190,6 +214,7 @@ def collapsed_properties(model_spec, swagger_spec):
 
 
 def collapsed_required(model_spec, swagger_spec):
+    # type: (JSONDict, Spec) -> typing.Set[typing.Text]
     """
     Processes model spec and outputs a set of required properties for the model.
 
@@ -213,6 +238,7 @@ def collapsed_required(model_spec, swagger_spec):
 
 
 def get_type_from_schema(swagger_spec, schema_object_spec):
+    # type: (Spec, JSONDict) -> typing.Optional[typing.Text]
     try:
         return schema_object_spec['type']
     except KeyError:

--- a/bravado_core/security_definition.py
+++ b/bravado_core/security_definition.py
@@ -2,6 +2,14 @@
 import logging
 from copy import deepcopy
 
+import typing
+
+
+if getattr(typing, 'TYPE_CHECKING', False):
+    from bravado_core._compat_typing import JSONDict
+    from bravado_core.spec import Spec
+
+
 log = logging.getLogger(__name__)
 
 
@@ -14,10 +22,12 @@ class SecurityDefinition(object):
     """
 
     def __init__(self, swagger_spec, security_definition_spec):
+        # type: (Spec, JSONDict) -> None
         self.swagger_spec = swagger_spec
         self.security_definition_spec = swagger_spec.deref(security_definition_spec)
 
     def __deepcopy__(self, memo=None):
+        # type: (typing.Optional[typing.Dict[int, typing.Any]]) -> 'SecurityDefinition'
         if memo is None:
             memo = {}
         return self.__class__(
@@ -27,31 +37,43 @@ class SecurityDefinition(object):
 
     @property
     def location(self):
+        # type: () -> typing.Optional[typing.Text]
         # not using 'in' as the name since it is a keyword in python
         return self.security_definition_spec.get('in')
 
     @property
     def type(self):
+        # type: () -> typing.Text
         return self.security_definition_spec['type']
 
     @property
     def name(self):
+        # type: () -> typing.Optional[typing.Text]
         return self.security_definition_spec.get('name')
 
     @property
     def flow(self):
+        # type: () -> typing.Optional[typing.Text]
         return self.security_definition_spec.get('flow')
 
     @property
     def scopes(self):
+        # type: () -> typing.Optional[typing.List[typing.Text]]
         return self.security_definition_spec.get('scopes')
 
     @property
     def authorizationUrl(self):
+        # type: () -> typing.Optional[typing.Text]
         return self.security_definition_spec.get('authorizationUrl')
 
     @property
+    def tokenUrl(self):
+        # type: () -> typing.Optional[typing.Text]
+        return self.security_definition_spec.get('tokenUrl')
+
+    @property
     def parameter_representation_dict(self):
+        # type: () -> typing.Optional[JSONDict]
         if self.type == 'apiKey':
             return {
                 'required': False,
@@ -60,3 +82,5 @@ class SecurityDefinition(object):
                 'name': self.name,
                 'in': self.location,
             }
+        else:
+            return None

--- a/bravado_core/security_requirement.py
+++ b/bravado_core/security_requirement.py
@@ -41,7 +41,7 @@ class SecurityRequirement(object):
 
     @property
     def security_definitions(self):
-        # type: () -> typing.Mapping[typing.Text, SecurityDefinition]
+        # type: () -> typing.Dict[typing.Text, SecurityDefinition]
         return {
             security_name: self.swagger_spec.security_definitions[security_name]
             for security_name in six.iterkeys(self.security_requirement_spec)
@@ -49,7 +49,7 @@ class SecurityRequirement(object):
 
     @property
     def security_scopes(self):
-        # type: () -> typing.Mapping[typing.Text, typing.Mapping[typing.Text, typing.List[typing.Text]]]
+        # type: () -> typing.Dict[typing.Text, typing.Mapping[typing.Text, typing.List[typing.Text]]]
         return {
             security_name: self.security_requirement_spec[security_name]
             for security_name in six.iterkeys(self.security_requirement_spec)

--- a/bravado_core/security_requirement.py
+++ b/bravado_core/security_requirement.py
@@ -2,8 +2,17 @@
 import logging
 
 import six
+import typing
 
 from bravado_core.exception import SwaggerSchemaError
+
+if getattr(typing, 'TYPE_CHECKING', False):
+    from bravado_core._compat_typing import JSONDict
+    from bravado_core.security_definition import SecurityDefinition
+    from bravado_core.spec import Spec
+
+    T = typing.TypeVar('T')
+
 
 log = logging.getLogger(__name__)
 
@@ -18,6 +27,7 @@ class SecurityRequirement(object):
     """
 
     def __init__(self, swagger_spec, security_requirement_spec):
+        # type: (Spec, typing.Mapping[typing.Text, typing.Mapping[typing.Text, typing.List[typing.Text]]]) -> None
         self.swagger_spec = swagger_spec
         self.security_requirement_spec = swagger_spec.deref(security_requirement_spec)
         for security_definition in six.iterkeys(security_requirement_spec):
@@ -31,20 +41,23 @@ class SecurityRequirement(object):
 
     @property
     def security_definitions(self):
-        return dict(
-            (security_name, self.swagger_spec.security_definitions[security_name])
+        # type: () -> typing.Mapping[typing.Text, SecurityDefinition]
+        return {
+            security_name: self.swagger_spec.security_definitions[security_name]
             for security_name in six.iterkeys(self.security_requirement_spec)
-        )
+        }
 
     @property
     def security_scopes(self):
-        return dict(
-            (security_name, self.security_requirement_spec[security_name])
+        # type: () -> typing.Mapping[typing.Text, typing.Mapping[typing.Text, typing.List[typing.Text]]]
+        return {
+            security_name: self.security_requirement_spec[security_name]
             for security_name in six.iterkeys(self.security_requirement_spec)
-        )
+        }
 
     @property
     def parameters_representation_dict(self):
+        # type: () -> typing.List[JSONDict]
         return [
             definition.parameter_representation_dict
             for definition in six.itervalues(self.security_definitions)
@@ -52,4 +65,5 @@ class SecurityRequirement(object):
         ]
 
     def __iter__(self):
+        # type: () -> typing.Iterable[SecurityDefinition]
         return six.itervalues(self.security_definitions)

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -6,6 +6,7 @@ import warnings
 from copy import deepcopy
 from itertools import chain
 
+import typing
 import yaml
 from jsonref import JsonRef
 from jsonschema import FormatChecker
@@ -33,6 +34,10 @@ from bravado_core.spec_flattening import flattened_spec
 from bravado_core.util import cached_property
 from bravado_core.util import memoize_by_id
 from bravado_core.util import strip_xscope
+
+
+if getattr(typing, 'TYPE_CHECKING', False):
+    from bravado_core.formatter import SwaggerFormat
 
 
 log = logging.getLogger(__name__)
@@ -273,6 +278,7 @@ class Spec(object):
         return build_http_handlers(self.http_client)
 
     def _force_deref(self, ref_dict):
+        # type: (typing.Any) -> typing.Any
         """Dereference ref_dict (if it is indeed a ref) and return what the
         ref points to.
 
@@ -329,6 +335,7 @@ class Spec(object):
         self.format_checker.checks(name, raises=(SwaggerValidationError,))(validate)
 
     def get_format(self, name):
+        # type: (typing.Text) -> SwaggerFormat
         """
         :param name: Name of the format to retrieve
         :rtype: :class:`bravado_core.formatter.SwaggerFormat`

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -39,6 +39,8 @@ from bravado_core.util import strip_xscope
 if getattr(typing, 'TYPE_CHECKING', False):
     from bravado_core.formatter import SwaggerFormat
 
+    T = typing.TypeVar('T')
+
 
 log = logging.getLogger(__name__)
 
@@ -278,7 +280,7 @@ class Spec(object):
         return build_http_handlers(self.http_client)
 
     def _force_deref(self, ref_dict):
-        # type: (typing.Any) -> typing.Any
+        # type: (T) -> T
         """Dereference ref_dict (if it is indeed a ref) and return what the
         ref points to.
 
@@ -293,7 +295,8 @@ class Spec(object):
         # resolver doesn't have a traversal history (accumulated scope_stack)
         # when asked to resolve.
         with in_scope(self.resolver, ref_dict):
-            _, target = self.resolver.resolve(ref_dict['$ref'])
+            reference_value = ref_dict['$ref']  # type: ignore
+            _, target = self.resolver.resolve(reference_value)
             return target
 
     # NOTE: deref gets overridden, if internally_dereference_refs is enabled, after calling build

--- a/bravado_core/validate.py
+++ b/bravado_core/validate.py
@@ -7,6 +7,7 @@ customize the behavior.
 import sys
 
 import jsonschema
+import typing
 from six import itervalues
 from six import reraise
 
@@ -18,9 +19,18 @@ from bravado_core.schema import SWAGGER_PRIMITIVES
 from bravado_core.swagger20_validator import get_validator_type
 
 
+if getattr(typing, 'TYPE_CHECKING', False):
+    from bravado_core._compat_typing import JSONDict
+    from bravado_core._compat_typing import FuncType
+    from bravado_core.operation import Operation
+    from bravado_core.spec import Spec
+
+
 def scrub_sensitive_value(func):
+    # type: (FuncType) -> FuncType
     @wraps(func)
     def scrubbed(*args, **kwargs):
+        # type: (typing.Any, typing.Any) -> typing.Any
         try:
             return func(*args, **kwargs)
         except jsonschema.ValidationError as e:
@@ -32,10 +42,15 @@ def scrub_sensitive_value(func):
                 e.instance = '***'
             reraise(*sys.exc_info())
 
-    return scrubbed
+    return scrubbed  # type: ignore  # ignoring type to avoiding typing.cast call
 
 
-def validate_schema_object(swagger_spec, schema_object_spec, value):
+def validate_schema_object(
+    swagger_spec,  # type: Spec
+    schema_object_spec,  # type: JSONDict
+    value,  # type: typing.Any
+):
+    # type: (...) -> None
     """
     :raises ValidationError: when jsonschema validation fails.
     :raises SwaggerMappingError: on invalid Swagger `type`.
@@ -68,7 +83,12 @@ def validate_schema_object(swagger_spec, schema_object_spec, value):
 
 
 @scrub_sensitive_value
-def validate_primitive(swagger_spec, primitive_spec, value):
+def validate_primitive(
+    swagger_spec,  # type: Spec
+    primitive_spec,  # type: JSONDict
+    value,  # type: typing.Any
+):
+    # type: (...) -> None
     """
     :type swagger_spec: :class:`bravado_core.spec.Spec`
     :param primitive_spec: spec for a swagger primitive type in dict form
@@ -82,7 +102,12 @@ def validate_primitive(swagger_spec, primitive_spec, value):
 
 
 @scrub_sensitive_value
-def validate_array(swagger_spec, array_spec, value):
+def validate_array(
+    swagger_spec,  # type: Spec
+    array_spec,  # type: JSONDict
+    value,  # type: typing.Any
+):
+    # type: (...) -> None
     """
     :type swagger_spec: :class:`bravado_core.spec.Spec`
     :param array_spec: spec for an 'array' type in dict form
@@ -96,7 +121,12 @@ def validate_array(swagger_spec, array_spec, value):
 
 
 @scrub_sensitive_value
-def validate_object(swagger_spec, object_spec, value):
+def validate_object(
+    swagger_spec,  # type: Spec
+    object_spec,  # type: JSONDict
+    value,  # type: typing.Any
+):
+    # type: (...) -> None
     """
     :type swagger_spec: :class:`bravado_core.spec.Spec`
     :param object_spec: spec for an 'object' type in dict form
@@ -109,7 +139,11 @@ def validate_object(swagger_spec, object_spec, value):
     ).validate(value)
 
 
-def validate_security_object(op, request_data):
+def validate_security_object(
+    op,  # type: Operation
+    request_data,  # type: JSONDict
+):
+    # type: (...) -> None
     """
     Checks that one security option is used at time.
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -4,6 +4,8 @@ python_version = 2.7
 strict_optional = True
 warn_redundant_casts = True
 disallow_untyped_calls = False
+
+[mypy-bravado_core.exception.*]
 check_untyped_defs = False
 disallow_untyped_defs = False
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -15,6 +15,10 @@ disallow_untyped_defs = True
 check_untyped_defs = True
 disallow_untyped_defs = True
 
+[mypy-bravado_core._compat_typing.*]
+check_untyped_defs = True
+disallow_untyped_defs = True
+
 [mypy-bravado_core._decorators.*]
 check_untyped_defs = True
 disallow_untyped_defs = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -21,6 +21,10 @@ disallow_untyped_defs = True
 check_untyped_defs = True
 disallow_untyped_defs = True
 
+[mypy-bravado_core.security_requirement.*]
+check_untyped_defs = True
+disallow_untyped_defs = True
+
 [mypy-bravado_core.swagger20_validator.*]
 check_untyped_defs = True
 disallow_untyped_defs = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -21,6 +21,10 @@ disallow_untyped_defs = True
 check_untyped_defs = True
 disallow_untyped_defs = True
 
+[mypy-bravado_core.security_definition.*]
+check_untyped_defs = True
+disallow_untyped_defs = True
+
 [mypy-bravado_core.security_requirement.*]
 check_untyped_defs = True
 disallow_untyped_defs = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -6,8 +6,8 @@ warn_redundant_casts = True
 disallow_untyped_calls = False
 
 [mypy-bravado_core.exception.*]
-check_untyped_defs = False
-disallow_untyped_defs = False
+check_untyped_defs = True
+disallow_untyped_defs = True
 
 [mypy-bravado_core.marshal.*]
 check_untyped_defs = True
@@ -18,6 +18,10 @@ check_untyped_defs = True
 disallow_untyped_defs = True
 
 [mypy-bravado_core.unmarshal.*]
+check_untyped_defs = True
+disallow_untyped_defs = True
+
+[mypy-bravado_core.util.*]
 check_untyped_defs = True
 disallow_untyped_defs = True
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -3,45 +3,54 @@ ignore_missing_imports = True
 python_version = 2.7
 strict_optional = True
 warn_redundant_casts = True
-disallow_untyped_calls = False
+disallow_untyped_calls = True
 check_untyped_defs = True
 disallow_untyped_defs = True
 
 # # This is needed to allow gradual typing of the library
 # # Remove the exceptions defined below once the module is completely typed
 [mypy-bravado_core.docstring.*]
+disallow_untyped_calls = False
 check_untyped_defs = False
 disallow_untyped_defs = False
 
 [mypy-bravado_core.model.*]
+disallow_untyped_calls = False
 check_untyped_defs = False
 disallow_untyped_defs = False
 
 [mypy-bravado_core.operation.*]
+disallow_untyped_calls = False
 check_untyped_defs = False
 disallow_untyped_defs = False
 
 [mypy-bravado_core.param.*]
+disallow_untyped_calls = False
 check_untyped_defs = False
 disallow_untyped_defs = False
 
 [mypy-bravado_core.request.*]
+disallow_untyped_calls = False
 check_untyped_defs = False
 disallow_untyped_defs = False
 
 [mypy-bravado_core.resource.*]
+disallow_untyped_calls = False
 check_untyped_defs = False
 disallow_untyped_defs = False
 
 [mypy-bravado_core.response.*]
+disallow_untyped_calls = False
 check_untyped_defs = False
 disallow_untyped_defs = False
 
 [mypy-bravado_core.spec.*]
+disallow_untyped_calls = False
 check_untyped_defs = False
 disallow_untyped_defs = False
 
 [mypy-bravado_core.spec_flattening.*]
+disallow_untyped_calls = False
 check_untyped_defs = False
 disallow_untyped_defs = False
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -4,54 +4,52 @@ python_version = 2.7
 strict_optional = True
 warn_redundant_casts = True
 disallow_untyped_calls = False
-
-[mypy-bravado_core.exception.*]
-check_untyped_defs = True
-disallow_untyped_defs = True
-
-[mypy-bravado_core.formatter.*]
-check_untyped_defs = True
-disallow_untyped_defs = True
-
-[mypy-bravado_core.marshal.*]
-check_untyped_defs = True
-disallow_untyped_defs = True
-
-[mypy-bravado_core.schema.*]
-check_untyped_defs = True
-disallow_untyped_defs = True
-
-[mypy-bravado_core.security_definition.*]
-check_untyped_defs = True
-disallow_untyped_defs = True
-
-[mypy-bravado_core.security_requirement.*]
-check_untyped_defs = True
-disallow_untyped_defs = True
-
-[mypy-bravado_core.swagger20_validator.*]
-check_untyped_defs = True
-disallow_untyped_defs = True
-
-[mypy-bravado_core.unmarshal.*]
-check_untyped_defs = True
-disallow_untyped_defs = True
-
-[mypy-bravado_core.util.*]
-check_untyped_defs = True
-disallow_untyped_defs = True
-
-[mypy-bravado_core._compat_typing.*]
-check_untyped_defs = True
-disallow_untyped_defs = True
-
-[mypy-bravado_core._decorators.*]
 check_untyped_defs = True
 disallow_untyped_defs = True
 
 # # This is needed to allow gradual typing of the library
-# # Add a section as the one mentioned below for modules that have been fully typed
-# # Once all the modules (or the majority) are typed we might moved to a blacklist approach
-# [mypy-<fully_typed_module>.*]
-# check_untyped_defs = True
-# disallow_untyped_defs = True
+# # Remove the exceptions defined below once the module is completely typed
+[mypy-bravado_core.docstring.*]
+check_untyped_defs = False
+disallow_untyped_defs = False
+
+[mypy-bravado_core.model.*]
+check_untyped_defs = False
+disallow_untyped_defs = False
+
+[mypy-bravado_core.operation.*]
+check_untyped_defs = False
+disallow_untyped_defs = False
+
+[mypy-bravado_core.param.*]
+check_untyped_defs = False
+disallow_untyped_defs = False
+
+[mypy-bravado_core.request.*]
+check_untyped_defs = False
+disallow_untyped_defs = False
+
+[mypy-bravado_core.resource.*]
+check_untyped_defs = False
+disallow_untyped_defs = False
+
+[mypy-bravado_core.response.*]
+check_untyped_defs = False
+disallow_untyped_defs = False
+
+[mypy-bravado_core.spec.*]
+check_untyped_defs = False
+disallow_untyped_defs = False
+
+[mypy-bravado_core.spec_flattening.*]
+check_untyped_defs = False
+disallow_untyped_defs = False
+
+[mypy-bravado_core.validate.*]
+check_untyped_defs = False
+disallow_untyped_defs = False
+
+[mypy-tests.*]
+disallow_untyped_calls = False
+check_untyped_defs = False
+disallow_untyped_defs = False

--- a/mypy.ini
+++ b/mypy.ini
@@ -11,6 +11,10 @@ disallow_untyped_defs = False
 check_untyped_defs = True
 disallow_untyped_defs = True
 
+[mypy-bravado_core.schema.*]
+check_untyped_defs = True
+disallow_untyped_defs = True
+
 [mypy-bravado_core.unmarshal.*]
 check_untyped_defs = True
 disallow_untyped_defs = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -9,6 +9,10 @@ disallow_untyped_calls = False
 check_untyped_defs = True
 disallow_untyped_defs = True
 
+[mypy-bravado_core.formatter.*]
+check_untyped_defs = True
+disallow_untyped_defs = True
+
 [mypy-bravado_core.marshal.*]
 check_untyped_defs = True
 disallow_untyped_defs = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -17,6 +17,10 @@ disallow_untyped_defs = True
 check_untyped_defs = True
 disallow_untyped_defs = True
 
+[mypy-bravado_core.swagger20_validator.*]
+check_untyped_defs = True
+disallow_untyped_defs = True
+
 [mypy-bravado_core.unmarshal.*]
 check_untyped_defs = True
 disallow_untyped_defs = True


### PR DESCRIPTION
This PR does extract part of the work done in #314.

Not all the models have yet typing so mypy has been configured to be strict on all the typed modules and more relaxed on the non-typed ones (bravado_core.docstring, bravado_core.model, bravado_core.operation, bravado_core.param, bravado_core.request, bravado_core.resource, bravado_core.response, bravado_core.spec, bravado_core.spec_flattening)