### PR TITLE
Fix deepcopy issue on Python3.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ matrix:
   include:
   - python: "2.7"
     env: TOXENV=py27
+  - env: TOXENV=py35
+    # we'll use Python 3.5.0 here to make sure we don't use any typing
+    # features that break on older Python 3.5 releases.
+    python: "3.5.0"
+    dist: trusty
   - python: "3.5"
     env: TOXENV=py35
   - python: "3.6"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ Changelog
 -------------------
 - Add equality and deepcopy support for Spec objects - `PR #360`_
 
+**WARNING**: Deep Copy might not work properly on CPython 3.5.0. More details on `PR #362`_ and `Issue25447 <https://bugs.python.org/issue25447>`_
+
 5.15.0 (2019-11-15)
 -------------------
 - Properly build the list of required properties for a schema with ``allOf`` from the sub-schemas - `PR #358`_ - Thanks nickgaya for your contribution!
@@ -557,6 +559,7 @@ Changelog
 .. _PR #356: https://github.com/Yelp/bravado-core/pull/356
 .. _PR #358: https://github.com/Yelp/bravado-core/pull/358
 .. _PR #360: https://github.com/Yelp/bravado-core/pull/360
+.. _PR #362: https://github.com/Yelp/bravado-core/pull/362
 
 .. Link To Documentation pages
 .. _Configure: https://bravado-core.readthedocs.org/en/latest/config.html

--- a/tests/resource/deepcopy_test.py
+++ b/tests/resource/deepcopy_test.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import sys
+
 import pytest
 
 from tests.conftest import check_object_deepcopy
@@ -9,5 +11,12 @@ def pet_resource(petstore_spec):
     return petstore_spec.resources['pet']
 
 
+@pytest.mark.xfail(
+    condition=sys.version_info[:3] == (3, 5, 0),
+    reason=(
+        "Deepcopy of lru_cache-ed items does not work properly "
+        "on Python 3.5.0. https://bugs.python.org/issue25447",
+    ),
+)
 def test_resource_instance_is_deep_copyable(pet_resource):
     check_object_deepcopy(pet_resource)

--- a/tests/spec/Spec/deepcopy_test.py
+++ b/tests/spec/Spec/deepcopy_test.py
@@ -1,6 +1,17 @@
 # -*- coding: utf-8 -*-
+import sys
+
+import pytest
+
 from tests.conftest import check_object_deepcopy
 
 
+@pytest.mark.xfail(
+    condition=sys.version_info[:3] == (3, 5, 0),
+    reason=(
+        "Deepcopy of lru_cache-ed items does not work properly "
+        "on Python 3.5.0. https://bugs.python.org/issue25447",
+    ),
+)
 def test_spec_instance_is_deep_copyable(petstore_spec):
     check_object_deepcopy(petstore_spec)


### PR DESCRIPTION
While working on https://github.com/Yelp/bravado/pull/445, I've noticed that the deepcopy support added in #360 seems to not be working on Python3.5.0.

The goal of this PR is to fix the issue.

**NOTE**: This PR is still in draft as the issue is not solved, but as least we can  reproduce it via travis