### PR TITLE
Ensure hashability of classes with custom equality check

### DIFF
--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -465,6 +465,9 @@ class Model(object):
         else:
             del self.__dict[property_name]
 
+    def __hash__(self):
+        return id(self)
+
     def __eq__(self, other):
         """Check for equality with another instance.
 

--- a/bravado_core/operation.py
+++ b/bravado_core/operation.py
@@ -58,6 +58,9 @@ class Operation(object):
         # (key, value) = (param name, Param)
         self.params = {}
 
+    def __hash__(self):
+        return id(self)
+
     def __eq__(self, other):
         if id(self) == id(other):
             return True

--- a/bravado_core/resource.py
+++ b/bravado_core/resource.py
@@ -124,6 +124,9 @@ class Resource(object):
         """
         return self.operations.keys()
 
+    def __hash__(self):
+        return id(self)
+
     def __eq__(self, other):
         if id(self) == id(other):
             return True

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -137,6 +137,9 @@ class Spec(object):
         # it will be overridden by the dereferenced specs (by build method). More context in PR#263
         self._internal_spec_dict = spec_dict
 
+    def __hash__(self):
+        return id(self)
+
     def __eq__(self, other):
         if id(self) == id(other):
             return True

--- a/tests/model/model_test.py
+++ b/tests/model/model_test.py
@@ -145,6 +145,12 @@ def test_model_equality_if_model_class_generated_by_different_Spec_object(cat_sw
     assert cat == new_cat
 
 
+def test_model_hashability(cat_type, cat_kwargs):
+    # The test wants to ensure that a Model instance is hashable.
+    # If calling hash does not throw an exception than we've validated the assumption
+    hash(cat_type(**cat_kwargs))
+
+
 def test_model_deepcopy(user_type, user_kwargs):
     user = user_type(**user_kwargs)
     user_copy = deepcopy(user)

--- a/tests/operation/equality_test.py
+++ b/tests/operation/equality_test.py
@@ -17,3 +17,9 @@ def test_equality_of_different_instances_returns_True_if_the_specs_are_the_same(
 
 def test_equality_of_different_instances_returns_False_if_the_specs_are_the_different(petstore_spec, getPetByIdPetstoreOperation):
     assert getPetByIdPetstoreOperation != petstore_spec.resources['pet'].operations['addPet']
+
+
+def test_operation_hashability(getPetByIdPetstoreOperation):
+    # The test wants to ensure that a Operation instance is hashable.
+    # If calling hash does not throw an exception than we've validated the assumption
+    hash(getPetByIdPetstoreOperation)

--- a/tests/resource/equality_test.py
+++ b/tests/resource/equality_test.py
@@ -24,3 +24,9 @@ def test_equality_of_different_instances_returns_True_if_the_specs_are_the_same(
 
 def test_equality_of_different_instances_returns_False_if_the_specs_are_the_different(petstore_spec, petPetstoreResource):
     assert petPetstoreResource != petstore_spec.resources['user']
+
+
+def test_resource_hashability(petPetstoreResource):
+    # The test wants to ensure that a Resource instance is hashable.
+    # If calling hash does not throw an exception than we've validated the assumption
+    hash(petPetstoreResource)

--- a/tests/spec/Spec/equality_test.py
+++ b/tests/spec/Spec/equality_test.py
@@ -25,3 +25,9 @@ def test_equality_of_different_instances_returns_False_if_attributes_are_not_mat
 
 def test_equality_of_different_instances_returns_False_if_the_specs_are_the_different(petstore_spec, polymorphic_spec):
     assert petstore_spec != polymorphic_spec
+
+
+def test_spec_hashability(petstore_spec):
+    # The test wants to ensure that a Spec instance is hashable.
+    # If calling hash does not throw an exception than we've validated the assumption
+    hash(petstore_spec)


### PR DESCRIPTION
Ensure hashability of classes with custom equality check.

The issue has been noticed because [Yelp/swagger-spec-compatibility](https://github.com/Yelp/swagger-spec-compatibility) tests are broken (due to the fact that `bravado_core.spec.Spec` instances are not hashable).

In #360 equality methods have been added in order to increase testing coverage of deepcopy of instances.

Objects inheriting from `object` (aka all) have:
 * `__eq__` implemented as always returning `False`
 * `__hash__` implemented as returning a unique identifier of the specific instance (aka result of `id`)

Unfortunately, on Python, if you override one `__eq__` method then the "default" `__hash__` implementation is not is use, and so to make the object hashable again you need to implement `__hash__` yourself (what this CR does). ([Documentation reference](https://docs.python.org/3/reference/datamodel.html#object.__hash__))
