### PR TITLE
Replace __eq__ with is_equal to allow hashability

### DIFF
--- a/bravado_core/operation.py
+++ b/bravado_core/operation.py
@@ -58,7 +58,9 @@ class Operation(object):
         # (key, value) = (param name, Param)
         self.params = {}
 
-    def __eq__(self, other):
+    def is_equal(self, other):
+        # Not implemented as __eq__ otherwise we would need to implement __hash__ to preserve
+        # hashability of the class and it would not necessarily be performance effective
         if id(self) == id(other):
             return True
 
@@ -69,7 +71,7 @@ class Operation(object):
             self.path_name == other.path_name and
             self.http_method == other.http_method and
             self.op_spec == other.op_spec and
-            self.swagger_spec == other.swagger_spec
+            self.swagger_spec.is_equal(other.swagger_spec)
         )
 
     @cached_property

--- a/bravado_core/resource.py
+++ b/bravado_core/resource.py
@@ -2,8 +2,10 @@
 import logging
 from collections import defaultdict
 from copy import deepcopy
+from itertools import chain
 
 from six import iteritems
+from six import iterkeys
 
 from bravado_core.exception import SwaggerMappingError
 from bravado_core.operation import Operation
@@ -124,7 +126,9 @@ class Resource(object):
         """
         return self.operations.keys()
 
-    def __eq__(self, other):
+    def is_equal(self, other):
+        # Not implemented as __eq__ otherwise we would need to implement __hash__ to preserve
+        # hashability of the class and it would not necessarily be performance effective
         if id(self) == id(other):
             return True
 
@@ -133,5 +137,8 @@ class Resource(object):
 
         return (
             self.name == other.name and
-            self.operations == other.operations
+            all(
+                operation_id in self.operations and self.operations.get(operation_id).is_equal(other.operations.get(operation_id))
+                for operation_id in set(chain(iterkeys(self.operations), iterkeys(other.operations)))
+            )
         )

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -137,7 +137,9 @@ class Spec(object):
         # it will be overridden by the dereferenced specs (by build method). More context in PR#263
         self._internal_spec_dict = spec_dict
 
-    def __eq__(self, other):
+    def is_equal(self, other):
+        # Not implemented as __eq__ otherwise we would need to implement __hash__ to preserve
+        # hashability of the class and it would not necessarily be performance effective
         if id(self) == id(other):
             return True
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -285,7 +285,7 @@ def check_object_deepcopy(obj):
     obj_copy = deepcopy(obj)
 
     assert isinstance(obj_copy, obj.__class__)
-    assert obj == obj_copy
+    assert obj.is_equal(obj_copy)
 
     # Ideally, if we deep copied properly an object we should have
     # * different memory allocation of the object

--- a/tests/operation/equality_test.py
+++ b/tests/operation/equality_test.py
@@ -17,3 +17,9 @@ def test_equality_of_different_instances_returns_True_if_the_specs_are_the_same(
 
 def test_equality_of_different_instances_returns_False_if_the_specs_are_the_different(petstore_spec, getPetByIdPetstoreOperation):
     assert not getPetByIdPetstoreOperation.is_equal(petstore_spec.resources['pet'].operations['addPet'])
+
+
+def test_operation_hashability(getPetByIdPetstoreOperation):
+    # The test wants to ensure that a Operation instance is hashable.
+    # If calling hash does not throw an exception than we've validated the assumption
+    hash(getPetByIdPetstoreOperation)

--- a/tests/operation/equality_test.py
+++ b/tests/operation/equality_test.py
@@ -4,7 +4,7 @@ from tests.conftest import get_url
 
 
 def test_equality_of_the_same_object_returns_True(getPetByIdPetstoreOperation):
-    assert getPetByIdPetstoreOperation == getPetByIdPetstoreOperation
+    assert getPetByIdPetstoreOperation.is_equal(getPetByIdPetstoreOperation)
 
 
 def test_equality_of_different_instances_returns_True_if_the_specs_are_the_same(
@@ -12,8 +12,8 @@ def test_equality_of_different_instances_returns_True_if_the_specs_are_the_same(
 ):
     other_petstore_spec = Spec.from_dict(petstore_dict, origin_url=get_url(petstore_abspath))
     other_getPetByIdPetstoreOperation = other_petstore_spec.resources['pet'].operations['getPetById']
-    assert getPetByIdPetstoreOperation == other_getPetByIdPetstoreOperation
+    assert getPetByIdPetstoreOperation.is_equal(other_getPetByIdPetstoreOperation)
 
 
 def test_equality_of_different_instances_returns_False_if_the_specs_are_the_different(petstore_spec, getPetByIdPetstoreOperation):
-    assert getPetByIdPetstoreOperation != petstore_spec.resources['pet'].operations['addPet']
+    assert not getPetByIdPetstoreOperation.is_equal(petstore_spec.resources['pet'].operations['addPet'])

--- a/tests/resource/equality_test.py
+++ b/tests/resource/equality_test.py
@@ -11,7 +11,7 @@ def petPetstoreResource(petstore_spec):
 
 
 def test_equality_of_the_same_object_returns_True(petPetstoreResource):
-    assert petPetstoreResource == petPetstoreResource
+    assert petPetstoreResource.is_equal(petPetstoreResource)
 
 
 def test_equality_of_different_instances_returns_True_if_the_specs_are_the_same(
@@ -19,8 +19,8 @@ def test_equality_of_different_instances_returns_True_if_the_specs_are_the_same(
 ):
     other_petstore_spec = Spec.from_dict(petstore_dict, origin_url=get_url(petstore_abspath))
     other_petPetstoreResource = other_petstore_spec.resources['pet']
-    assert petPetstoreResource == other_petPetstoreResource
+    assert petPetstoreResource.is_equal(other_petPetstoreResource)
 
 
 def test_equality_of_different_instances_returns_False_if_the_specs_are_the_different(petstore_spec, petPetstoreResource):
-    assert petPetstoreResource != petstore_spec.resources['user']
+    assert not petPetstoreResource.is_equal(petstore_spec.resources['user'])

--- a/tests/resource/equality_test.py
+++ b/tests/resource/equality_test.py
@@ -24,3 +24,9 @@ def test_equality_of_different_instances_returns_True_if_the_specs_are_the_same(
 
 def test_equality_of_different_instances_returns_False_if_the_specs_are_the_different(petstore_spec, petPetstoreResource):
     assert not petPetstoreResource.is_equal(petstore_spec.resources['user'])
+
+
+def test_resource_hashability(petPetstoreResource):
+    # The test wants to ensure that a Resource instance is hashable.
+    # If calling hash does not throw an exception than we've validated the assumption
+    hash(petPetstoreResource)

--- a/tests/spec/Spec/equality_test.py
+++ b/tests/spec/Spec/equality_test.py
@@ -25,3 +25,9 @@ def test_equality_of_different_instances_returns_False_if_attributes_are_not_mat
 
 def test_equality_of_different_instances_returns_False_if_the_specs_are_the_different(petstore_spec, polymorphic_spec):
     assert not petstore_spec.is_equal(polymorphic_spec)
+
+
+def test_spec_hashability(petstore_spec):
+    # The test wants to ensure that a Spec instance is hashable.
+    # If calling hash does not throw an exception than we've validated the assumption
+    hash(petstore_spec)

--- a/tests/spec/Spec/equality_test.py
+++ b/tests/spec/Spec/equality_test.py
@@ -6,12 +6,12 @@ from tests.conftest import get_url
 
 
 def test_equality_of_the_same_object_returns_True(petstore_spec):
-    assert petstore_spec == petstore_spec
+    assert petstore_spec.is_equal(petstore_spec)
 
 
 def test_equality_of_different_instances_returns_True_if_the_specs_are_the_same(petstore_spec, petstore_dict, petstore_abspath):
     other_petstore_spec_instance = Spec.from_dict(petstore_dict, origin_url=get_url(petstore_abspath))
-    assert petstore_spec == other_petstore_spec_instance
+    assert petstore_spec.is_equal(other_petstore_spec_instance)
 
 
 @pytest.mark.parametrize('attribute_value', [None, 42])
@@ -20,8 +20,8 @@ def test_equality_of_different_instances_returns_False_if_attributes_are_not_mat
 ):
     other_petstore_spec_instance = Spec.from_dict(petstore_dict, origin_url=get_url(petstore_abspath))
     setattr(other_petstore_spec_instance, 'a-new-attribute', attribute_value)
-    assert petstore_spec != other_petstore_spec_instance
+    assert not petstore_spec.is_equal(other_petstore_spec_instance)
 
 
 def test_equality_of_different_instances_returns_False_if_the_specs_are_the_different(petstore_spec, polymorphic_spec):
-    assert petstore_spec != polymorphic_spec
+    assert not petstore_spec.is_equal(polymorphic_spec)


### PR DESCRIPTION
This PR deprecates #363 
As users of the library might be using hashability of `bravado_core.spec.Spec` and we don't have a strong need to have equality checks (other than for testing) I'm proposing to preserve the default equality checks and move the customly defined ones (PR #360) into a different method `is_equal` such that we can have an entry point of equality checks without altering the hashability properties of the objects.

NOTE: In #363 I was trying to define an `__hash__` method were needed.
Unfortunately defining hash functions is not a trivial task as it might be computationally expensive and grows with the size of the specs (which is usually when you'd like to use it even more).

---

From #363

> The issue has been noticed because [Yelp/swagger-spec-compatibility](https://github.com/Yelp/swagger-spec-compatibility) tests are broken (due to the fact that `bravado_core.spec.Spec` instances are not hashable).
> 
> In #360 equality methods have been added in order to increase testing coverage of deepcopy of instances.
> 
> Objects inheriting from `object` (aka all) have:
>  * `__eq__` implemented as always returning `False`
>  * `__hash__` implemented as returning a unique identifier of the specific instance (aka result of `id`)
> 
> Unfortunately, on Python, if you override one `__eq__` method then the "default" `__hash__` implementation is not is use, and so to make the object hashable again you need to implement `__hash__` yourself. ([Documentation reference](https://docs.python.org/3/reference/datamodel.html#object.__hash__))