### PR TITLE
[Fix tests] Remove spec=Draft4Validator from mock_validator

### DIFF
--- a/tests/swagger20_validator/ref_validator_test.py
+++ b/tests/swagger20_validator/ref_validator_test.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import pytest
-from jsonschema.validators import Draft4Validator
 from jsonschema.validators import RefResolver
 from mock import MagicMock
 from mock import Mock
@@ -64,7 +63,7 @@ def annotated_scope():
 
 @pytest.fixture
 def mock_validator(original_scope):
-    validator = Mock(spec=Draft4Validator)
+    validator = Mock()
     validator.resolver = Mock(spec=RefResolver)
     validator.resolver._scopes_stack = original_scope
     # Make descend() return an empty list to StopIteration.


### PR DESCRIPTION
Tests are currently failing on master
 * last green build: https://travis-ci.org/Yelp/bravado-core/jobs/646621656
 * last build: https://travis-ci.org/Yelp/bravado-core/jobs/646621656

The difference in the two builds is limited to the `mock` library:
 * `mock==3.0.5` in the green build
 * `mock==4.0.0` in the failing build

The [following code](https://github.com/testing-cabal/mock/blob/4.0.0/mock/mock.py#L493-L495) is causing the test setup to fail.
The change was introduced by https://github.com/testing-cabal/mock/pull/476/ as part of backporting the "official" `unittest.mock` back into the package.

In order to fix the test we could:
 1. modify jsonschema, which does raise the exception in purpose (deprecation related task)
 2. not define the `spec` while defining the mock
 3. limit `mock` to `mock<4`

I'm planning for approach 2 as it does not reduce our confidence around the whole interaction (especially as we have some integration tests) and does not require a lot of effort.