### PR TITLE
Drop python3.5.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ matrix:
     env: TOXENV=py35
   - python: "3.6"
     env: TOXENV=py36
+  - python: "3.7"
+    env: TOXENV=py37
   - python: "2.7"
     env: TOXENV=docs
   - python: "2.7"

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ setup(
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
     ],
@@ -56,4 +55,5 @@ setup(
         ':python_version<"3.4"': ['enum34'],
         ':python_version<"3.2"': ['functools32'],
     },
+    python_requires='!=3.0,!=3.1,!=3.2,!=3.3,!=3.4,!=3.5.0',
 )

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
     ],
     install_requires=[
         "jsonref",

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ filterwarnings =
     ignore:.*will be deprecated in the next major release. Please use the more general entry-point offered in.*:DeprecationWarning
 
 [tox]
-envlist = py27, py36, pre-commit
+envlist = py27, py36, py37, pre-commit
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ filterwarnings =
     ignore:.*will be deprecated in the next major release. Please use the more general entry-point offered in.*:DeprecationWarning
 
 [tox]
-envlist = py27, py35, py36, pre-commit
+envlist = py27, py36, pre-commit
 
 [testenv]
 deps =


### PR DESCRIPTION
This PR deprecates #362 

More details in https://github.com/Yelp/bravado-core/pull/362#issuecomment-562578356

Note: Test failures are already addressed in #365 .
Even if this will be approved as is I'll wait to have green tests before merging