### PR TITLE
Fix issue #359: properly validate nullable polymorphic models

### DIFF
--- a/bravado_core/swagger20_validator.py
+++ b/bravado_core/swagger20_validator.py
@@ -210,6 +210,9 @@ def discriminator_validator(
     :type schema: dict
     """
 
+    if instance is None and is_prop_nullable(swagger_spec, schema):
+        return
+
     try:
         discriminator_value = instance[discriminator_attribute]
     except KeyError:

--- a/test-data/2.0/polymorphic_specs/swagger.json
+++ b/test-data/2.0/polymorphic_specs/swagger.json
@@ -15,10 +15,7 @@
           "200": {
             "description": "Pet List",
             "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/GenericPet"
-              }
+              "$ref": "#/definitions/PetList"
             }
           }
         }

--- a/tests/model/model_test.py
+++ b/tests/model/model_test.py
@@ -247,7 +247,10 @@ def test_model_isinstance(polymorphic_spec, instance_dict, object_type, possible
 def test_ensure_polymorphic_objects_are_correctly_build_in_case_of_fully_dereferenced_specs(
     polymorphic_dict, validate_responses, use_models, internally_dereference_refs,
 ):
-    raw_response = [{'name': 'name', 'type': 'Dog', 'birth_date': '2017-11-02'}]
+    raw_response = {
+        'number_of_pets': 1,
+        'list': [{'name': 'name', 'type': 'Dog', 'birth_date': '2017-11-02'}],
+    }
     spec = Spec.from_dict(
         spec_dict=polymorphic_dict,
         config={
@@ -266,8 +269,14 @@ def test_ensure_polymorphic_objects_are_correctly_build_in_case_of_fully_derefer
     )
     unmarshaled_response = unmarshal_response(response, spec.resources['pets'].get_pets)
 
-    model_type = spec.definitions['Dog'] if use_models else dict
-    expected_response = [model_type(birth_date=datetime.date(2017, 11, 2), name='name', type='Dog')]
+    pet_list_model_type = spec.definitions['PetList'] if use_models else dict
+    dog_model_type = spec.definitions['Dog'] if use_models else dict
+    expected_response = pet_list_model_type(
+        number_of_pets=1,
+        list=[
+            dog_model_type(birth_date=datetime.date(2017, 11, 2), name='name', type='Dog'),
+        ],
+    )
     assert expected_response == unmarshaled_response
 
 

--- a/tests/response/unmarshal_response_test.py
+++ b/tests/response/unmarshal_response_test.py
@@ -9,6 +9,7 @@ from bravado_core.content_type import APP_JSON
 from bravado_core.content_type import APP_MSGPACK
 from bravado_core.response import IncomingResponse
 from bravado_core.response import unmarshal_response
+from bravado_core.spec import Spec
 
 
 @pytest.fixture
@@ -168,3 +169,27 @@ def test_unmarshal_model_polymorphic_specs_with_invalid_discriminator(polymorphi
             ),
             op=polymorphic_spec.resources['pets'].operations['get_pets'],
         )
+
+
+def test_unmarshal_model_polymorphic_specs_with_xnullable_field(polymorphic_dict):
+    # Test case to ensure no further regressions on issue #359
+    polymorphic_dict['definitions']['GenericPet']['x-nullable'] = True
+    polymorphic_spec = Spec.from_dict(polymorphic_dict)
+    PetList = polymorphic_spec.definitions['PetList']
+
+    response = unmarshal_response(
+        response=Mock(
+            spec=IncomingResponse,
+            status_code=200,
+            headers={'content-type': APP_JSON},
+            json=Mock(
+                return_value={
+                    'number_of_pets': 1,
+                    'list': [None],
+                },
+            ),
+        ),
+        op=polymorphic_spec.resources['pets'].operations['get_pets'],
+    )
+
+    assert response == PetList(number_of_pets=1, list=[None])

--- a/tests/response/unmarshal_response_test.py
+++ b/tests/response/unmarshal_response_test.py
@@ -131,14 +131,19 @@ def test_unmarshal_model_polymorphic_specs(polymorphic_spec):
             spec=IncomingResponse,
             status_code=200,
             headers={'content-type': APP_JSON},
-            json=Mock(return_value=pet_list_dicts),
+            json=Mock(
+                return_value={
+                    'number_of_pets': len(pet_list_dicts),
+                    'list': pet_list_dicts,
+                },
+            ),
         ),
         op=polymorphic_spec.resources['pets'].operations['get_pets'],
     )
 
-    assert len(pet_list_dicts) == len(pet_list_models)
+    assert len(pet_list_dicts) == len(pet_list_models.list)
 
-    for list_item_model, list_item_dict in zip(pet_list_models, pet_list_dicts):
+    for list_item_model, list_item_dict in zip(pet_list_models.list, pet_list_dicts):
         assert isinstance(list_item_model, polymorphic_spec.definitions['GenericPet'])
         assert isinstance(list_item_model, polymorphic_spec.definitions[list_item_dict['type']])
         assert list_item_model._marshal() == list_item_dict


### PR DESCRIPTION
The goal of this review is to address the validation issue that affects polymorphic models that are nullable (via `x-nullable` field).

In order to better highlight the reported issue I've modified the `polymorphic_specs` to ensure that the operation (endpoint) used for testing does return an object that is not directly the polymorphic model.

The issue was mostly caused by the fact that `discriminator` validation was not using the _usual_ safe check around nullability and so in case of `instance=None` entering `bravado_core.swagger20_validator.discriminator_validator` was not short circuiting and instead trying to extract the discriminator key from instance (which was none) and so leading to `TypeError` being thrown.

Adding the null-gate address the issue an so resolves #359 