### PR TITLE
Use the correct msgpack dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         "six",
         "swagger-spec-validator>=2.0.1",
         "pytz",
-        "msgpack-python>=0.5.2",
+        "msgpack>=0.5.2",
     ],
     package_data={
         'bravado_core': ['py.typed'],


### PR DESCRIPTION
From the msgpack-python pypi page:

> This package is deprecated. Install msgpack instead.