### PR TITLE
Travis file update: by default use python3.7 and fix travis warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,27 @@
 language: python
-matrix:
+os: linux
+
+python: "3.7"
+
+jobs:
   include:
   - python: "2.7"
-    env: TOXENV=py27
   - python: "3.5"
-    env: TOXENV=py35
   - python: "3.6"
-    env: TOXENV=py36
   - python: "3.7"
-    env: TOXENV=py37
-  - python: "2.7"
-    env: TOXENV=docs
-  - python: "2.7"
-    env: TOXENV=pre-commit
-  - python: "3.6"
-    env: TOXENV=benchmark
-  - python: "3.6"
-    env: TOXENV=mypy
+    env: PUBLISH_COVERAGE=y
+  - env: TOXENV=docs
+  - env: TOXENV=pre-commit
+  - env: TOXENV=benchmark
+  - env: TOXENV=mypy
   allow_failures:
   - env: TOXENV=benchmark
   fast_finish: true
 
-install: pip install tox coveralls
+install: pip install tox tox-travis coveralls
 script: tox
 after_success: |
-  if [ "$TOXENV" == "py27" ]; then coveralls; fi; \
-  if [ "$TOXENV" == "benchmark" ]; then \
-    echo $(ls .benchmarks/*/0001_benchmark.json) $(cat .benchmarks/*/0001_benchmark.json | nc termbin.com 9999); \
+  if [ "${PUBLISH_COVERAGE:-n}" == "y" ]; then coveralls; fi
+  if [ "${TOXENV}" == "benchmark" ]; then
+    echo $(ls .benchmarks/*/0001_benchmark.json) $(cat .benchmarks/*/0001_benchmark.json | nc termbin.com 9999)
   fi
-sudo: false

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ filterwarnings =
     ignore:.*will be deprecated in the next major release. Please use the more general entry-point offered in.*:DeprecationWarning
 
 [tox]
-envlist = py27, py36, py37, pre-commit
+envlist = py27, py37, pre-commit
 
 [testenv]
 deps =
@@ -12,7 +12,7 @@ commands =
     python -m pytest --cov --capture=no --benchmark-skip {posargs:tests}
 
 [testenv:benchmark]
-basepython = python3.6
+basepython = python3.7
 deps =
     -rrequirements-dev.txt
 commands =
@@ -23,7 +23,7 @@ commands =
         --benchmark-histogram=.benchmarks/benchmark
 
 [testenv:mypy]
-basepython = python3.6
+basepython = python3.7
 commands =
     mypy bravado_core tests
 


### PR DESCRIPTION
The goal of this PR is to address travis configuration warnings (check [here](https://travis-ci.org/Yelp/bravado-core/builds/653928181/config)) as well as ensuring that we're using Python3.7 for the "meta-checks" of the repository.

A bonus added in this PR is related to the addition of [`tox-travis`](https://github.com/tox-dev/tox-travis) dependency that allows us to not define `TOXENV=py` or `TOXENV=py##` to run tests only on the travis provided python version.