### PR TITLE
Enhance equality checks

### DIFF
--- a/bravado_core/_compat.py
+++ b/bravado_core/_compat.py
@@ -10,7 +10,7 @@ else:  # pragma: no cover  # py3+
 
 try:
     from collections.abc import Mapping  # noqa: F401  # pragma: no cover  # py3.3+
-except ImportError:
+except ImportError:  # pragma: no cover
     from collections import Mapping  # noqa: F401  # py3.2 or older
 
 

--- a/bravado_core/formatter.py
+++ b/bravado_core/formatter.py
@@ -30,7 +30,7 @@ if six.PY3:
     long = int
 
 
-def NO_OP(x):
+def NO_OP(x):  # pragma: no cover
     # type: (T) -> T
     return x
 

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -496,7 +496,7 @@ class Model(object):
 
     def __deepcopy__(self, memo=None):
         """Deep copy all properties, but not metadata like the Swagger or Model spec attributes."""
-        if memo is None:
+        if memo is None:  # pragma: no cover  # This should never happening, but better safe than sorry
             memo = {}
         return self.__class__(**deepcopy(self.__dict, memo=memo))
 

--- a/bravado_core/operation.py
+++ b/bravado_core/operation.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import logging
 
+import typing
 from six import iteritems
 
 from bravado_core.exception import SwaggerSchemaError
@@ -59,8 +60,19 @@ class Operation(object):
         self.params = {}
 
     def is_equal(self, other, ignore_swagger_spec=False):
-        # Not implemented as __eq__ otherwise we would need to implement __hash__ to preserve
-        # hashability of the class and it would not necessarily be performance effective
+        # type: (typing.Any, bool) -> bool
+        """
+        Compare self with `other`
+
+        NOTE: Not implemented as __eq__ otherwise we would need to implement __hash__ to preserve
+            hashability of the class and it would not necessarily be performance effective
+
+        :param other: instance to compare self against
+        :param ignore_swagger_spec: skip equality check of swagger_spec attribute.
+            This is useful as equality checks do not play well with recursive definitions.
+
+        :return: True if self and other are the same, False otherwise
+        """
         if id(self) == id(other):
             return True
 

--- a/bravado_core/operation.py
+++ b/bravado_core/operation.py
@@ -58,7 +58,7 @@ class Operation(object):
         # (key, value) = (param name, Param)
         self.params = {}
 
-    def is_equal(self, other):
+    def is_equal(self, other, ignore_swagger_spec=False):
         # Not implemented as __eq__ otherwise we would need to implement __hash__ to preserve
         # hashability of the class and it would not necessarily be performance effective
         if id(self) == id(other):
@@ -71,7 +71,7 @@ class Operation(object):
             self.path_name == other.path_name and
             self.http_method == other.http_method and
             self.op_spec == other.op_spec and
-            self.swagger_spec.is_equal(other.swagger_spec)
+            (ignore_swagger_spec or self.swagger_spec.is_equal(other.swagger_spec))
         )
 
     @cached_property

--- a/bravado_core/resource.py
+++ b/bravado_core/resource.py
@@ -101,7 +101,8 @@ class Resource(object):
         self.operations = ops
 
     def __deepcopy__(self, memo=None):
-        if memo is None:
+        # type: (typing.Optional[typing.Dict[int, typing.Any]]) -> 'Resource'
+        if memo is None:  # pragma: no cover  # This should never happening, but better safe than sorry
             memo = {}
         return self.__class__(
             name=deepcopy(self.name, memo=memo),

--- a/bravado_core/resource.py
+++ b/bravado_core/resource.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 from copy import deepcopy
 from itertools import chain
 
+import typing
 from six import iteritems
 from six import iterkeys
 
@@ -127,8 +128,19 @@ class Resource(object):
         return self.operations.keys()
 
     def is_equal(self, other, ignore_swagger_spec=False):
-        # Not implemented as __eq__ otherwise we would need to implement __hash__ to preserve
-        # hashability of the class and it would not necessarily be performance effective
+        # type: (typing.Any, bool) -> bool
+        """
+        Compare self with `other`
+
+        NOTE: Not implemented as __eq__ otherwise we would need to implement __hash__ to preserve
+            hashability of the class and it would not necessarily be performance effective
+
+        :param other: instance to compare self against
+        :param ignore_swagger_spec: skip equality check of swagger_spec attribute.
+            This is useful as equality checks do not play well with recursive definitions.
+
+        :return: True if self and other are the same, False otherwise
+        """
         if id(self) == id(other):
             return True
 

--- a/bravado_core/resource.py
+++ b/bravado_core/resource.py
@@ -126,7 +126,7 @@ class Resource(object):
         """
         return self.operations.keys()
 
-    def is_equal(self, other):
+    def is_equal(self, other, ignore_swagger_spec=False):
         # Not implemented as __eq__ otherwise we would need to implement __hash__ to preserve
         # hashability of the class and it would not necessarily be performance effective
         if id(self) == id(other):
@@ -135,10 +135,14 @@ class Resource(object):
         if not isinstance(other, self.__class__):
             return False
 
-        return (
-            self.name == other.name and
-            all(
-                operation_id in self.operations and self.operations.get(operation_id).is_equal(other.operations.get(operation_id))
-                for operation_id in set(chain(iterkeys(self.operations), iterkeys(other.operations)))
-            )
-        )
+        if self.name != other.name:
+            return False
+
+        for operation_id in set(chain(iterkeys(self.operations), iterkeys(other.operations))):
+            operation = self.operations.get(operation_id)
+            if operation is None or not operation.is_equal(
+                other.operations.get(operation_id), ignore_swagger_spec=ignore_swagger_spec,
+            ):
+                return False
+
+        return True

--- a/bravado_core/security_definition.py
+++ b/bravado_core/security_definition.py
@@ -28,7 +28,7 @@ class SecurityDefinition(object):
 
     def __deepcopy__(self, memo=None):
         # type: (typing.Optional[typing.Dict[int, typing.Any]]) -> 'SecurityDefinition'
-        if memo is None:
+        if memo is None:  # pragma: no cover  # This should never happening, but better safe than sorry
             memo = {}
         return self.__class__(
             swagger_spec=deepcopy(self.swagger_spec, memo=memo),

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -180,7 +180,6 @@ class Spec(object):
 
             # Few attributes have recursive references to Spec
             if attr_name in {
-                'definitions',  # Recursively point back to self (Spec instance). It is built via Spec.build so we're ignoring it
                 '_security_definitions',  # It is a private cached_property so ignore it as users should not be "touching" it
             }:
                 continue
@@ -195,14 +194,21 @@ class Spec(object):
             if attr_name == 'resources':
                 if not is_dict_like(self_attr) or not is_dict_like(other_attr):
                     return False
-
                 for key in set(chain(iterkeys(self_attr), iterkeys(other_attr))):
                     try:
                         if not self_attr[key].is_equal(other_attr[key], ignore_swagger_spec=True):
                             return False
                     except KeyError:
                         return False
-
+            elif attr_name == 'definitions':
+                if not is_dict_like(self_attr) or not is_dict_like(other_attr):
+                    return False
+                for key in set(chain(iterkeys(self_attr), iterkeys(other_attr))):
+                    try:
+                        if not issubclass(other_attr[key], self_attr[key]):
+                            return False
+                    except KeyError:
+                        return False
             elif self_attr != other_attr:
                 return False
 

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -178,10 +178,9 @@ class Spec(object):
             }:
                 continue
 
-            # Few attributes have recursive references to Spec
-            if attr_name in {
-                '_security_definitions',  # It is a private cached_property so ignore it as users should not be "touching" it
-            }:
+            # It has recursive references to Spec and it is not straight-forward defining an equality check to ignore it
+            # As it is a private cached_property we can ignore it as users should not be "touching" it.
+            if attr_name == '_security_definitions':
                 continue
 
             try:

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -229,7 +229,7 @@ class Spec(object):
         return True
 
     def __deepcopy__(self, memo=None):
-        if memo is None:
+        if memo is None:  # pragma: no cover  # This should never happening, but better safe than sorry
             memo = {}
 
         copied_self = self.__class__(spec_dict=None)

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -95,6 +95,11 @@ CONFIG_DEFAULTS = {
 }
 
 
+def _identity(obj):
+    # type: (T) -> T
+    return obj
+
+
 class Spec(object):
     """Represents a Swagger Specification for a service.
 
@@ -256,7 +261,7 @@ class Spec(object):
 
         if self.config['internally_dereference_refs']:
             # Avoid to evaluate is_ref every time, no references are possible at this time
-            self.deref = lambda ref_dict: ref_dict
+            self.deref = _identity
             self._internal_spec_dict = self.deref_flattened_spec
 
         for user_defined_format in self.config['formats']:

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -24,6 +24,7 @@ from bravado_core import formatter
 from bravado_core.exception import SwaggerSchemaError
 from bravado_core.exception import SwaggerValidationError
 from bravado_core.formatter import return_true_wrapper
+from bravado_core.model import Model
 from bravado_core.model import model_discovery
 from bravado_core.resource import build_resources
 from bravado_core.schema import is_dict_like
@@ -216,7 +217,9 @@ class Spec(object):
                     return False
                 for key in set(chain(iterkeys(self_attr), iterkeys(other_attr))):
                     try:
-                        if not issubclass(other_attr[key], self_attr[key]):
+                        self_definition = self_attr[key]
+                        other_definition = other_attr[key]
+                        if not issubclass(self_definition, Model) or not issubclass(other_definition, self_definition):
                             return False
                     except KeyError:
                         return False

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -181,7 +181,6 @@ class Spec(object):
             # Few attributes have recursive references to Spec
             if attr_name in {
                 'definitions',  # Recursively point back to self (Spec instance). It is built via Spec.build so we're ignoring it
-                'resources',  # Recursively point back to self (Spec instance). It is built via Spec.build so we're ignoring it
                 '_security_definitions',  # It is a private cached_property so ignore it as users should not be "touching" it
             }:
                 continue
@@ -192,7 +191,19 @@ class Spec(object):
             except AttributeError:
                 return False
 
-            if self_attr != other_attr:
+            # Define some special exception handling for attributes that have recursive reference to self.
+            if attr_name == 'resources':
+                if not is_dict_like(self_attr) or not is_dict_like(other_attr):
+                    return False
+
+                for key in set(chain(iterkeys(self_attr), iterkeys(other_attr))):
+                    try:
+                        if not self_attr[key].is_equal(other_attr[key], ignore_swagger_spec=True):
+                            return False
+                    except KeyError:
+                        return False
+
+            elif self_attr != other_attr:
                 return False
 
         return True

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -150,8 +150,20 @@ class Spec(object):
         self._internal_spec_dict = spec_dict
 
     def is_equal(self, other):
-        # Not implemented as __eq__ otherwise we would need to implement __hash__ to preserve
-        # hashability of the class and it would not necessarily be performance effective
+        # type: (typing.Any) -> bool
+        """
+        Compare self with `other`
+
+        NOTE: Not implemented as __eq__ otherwise we would need to implement __hash__ to preserve
+            hashability of the class and it would not necessarily be performance effective
+
+        WARNING: This method operates in "best-effort" mode in the sense that certain attributes are not implementing
+            any equality check and so we're might be ignoring checking them
+
+        :param other: instance to compare self against
+
+        :return: True if self and other are the same, False otherwise
+        """
         if id(self) == id(other):
             return True
 

--- a/tests/formatter/to_wire_test.py
+++ b/tests/formatter/to_wire_test.py
@@ -2,10 +2,12 @@
 from datetime import date
 from datetime import datetime
 
+import pytest
 import six
 from mock import patch
 from pytz import timezone
 
+from bravado_core.exception import SwaggerMappingError
 from bravado_core.formatter import SwaggerFormat
 from bravado_core.formatter import to_wire
 from bravado_core.spec import Spec
@@ -162,3 +164,8 @@ def test_override(minimal_swagger_dict):
     assert '8bits' == result
     assert isinstance(result, str)
     assert type(result) is StringType
+
+
+def test_to_wire_with_wrong_format(minimal_swagger_spec):
+    with pytest.raises(SwaggerMappingError, match="Error while marshalling value=random-test to type=string/date."):
+        to_wire(minimal_swagger_spec, {'type': 'string', 'format': 'date'}, 'random-test')

--- a/tests/operation/equality_test.py
+++ b/tests/operation/equality_test.py
@@ -21,6 +21,10 @@ def test_equality_of_different_instances_returns_False_if_the_specs_are_the_diff
     assert not getPetByIdPetstoreOperation.is_equal(petstore_spec.resources['pet'].operations['addPet'])
 
 
+def test_equality_of_different_instances_returns_False_if_different_types(getPetByIdPetstoreOperation):
+    assert not getPetByIdPetstoreOperation.is_equal(None)
+
+
 def test_operation_hashability(getPetByIdPetstoreOperation):
     # The test wants to ensure that a Operation instance is hashable.
     # If calling hash does not throw an exception than we've validated the assumption

--- a/tests/operation/equality_test.py
+++ b/tests/operation/equality_test.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import pytest
+
 from bravado_core.spec import Spec
 from tests.conftest import get_url
 
@@ -23,3 +25,15 @@ def test_operation_hashability(getPetByIdPetstoreOperation):
     # The test wants to ensure that a Operation instance is hashable.
     # If calling hash does not throw an exception than we've validated the assumption
     hash(getPetByIdPetstoreOperation)
+
+
+@pytest.mark.parametrize('ignore_swagger_spec', [True, False])
+def test_equality_honors_ignore_swagger_spec_parameters(
+    getPetByIdPetstoreOperation, petstore_dict, petstore_abspath, ignore_swagger_spec,
+):
+    other_petstore_spec = Spec.from_dict(petstore_dict, origin_url=get_url(petstore_abspath))
+    other_getPetByIdPetstoreOperation = other_petstore_spec.resources['pet'].operations['getPetById']
+    other_getPetByIdPetstoreOperation.swagger_spec = None
+    assert getPetByIdPetstoreOperation.is_equal(
+        other_getPetByIdPetstoreOperation, ignore_swagger_spec=ignore_swagger_spec,
+    ) is ignore_swagger_spec

--- a/tests/resource/equality_test.py
+++ b/tests/resource/equality_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import pytest
+from six import itervalues
 
 from bravado_core.spec import Spec
 from tests.conftest import get_url
@@ -30,3 +31,18 @@ def test_resource_hashability(petPetstoreResource):
     # The test wants to ensure that a Resource instance is hashable.
     # If calling hash does not throw an exception than we've validated the assumption
     hash(petPetstoreResource)
+
+
+@pytest.mark.parametrize('ignore_swagger_spec', [True, False])
+def test_equality_honors_ignore_swagger_spec_parameters(
+    petPetstoreResource, petstore_dict, petstore_abspath, ignore_swagger_spec,
+):
+    other_petstore_spec = Spec.from_dict(petstore_dict, origin_url=get_url(petstore_abspath))
+    other_petPetstoreResource = other_petstore_spec.resources['pet']
+
+    for op in itervalues(other_petPetstoreResource.operations):
+        op.swagger_spec = None
+
+    assert petPetstoreResource.is_equal(
+        other_petPetstoreResource, ignore_swagger_spec=ignore_swagger_spec,
+    ) is ignore_swagger_spec

--- a/tests/spec/Spec/equality_test.py
+++ b/tests/spec/Spec/equality_test.py
@@ -70,3 +70,31 @@ def test_equality_of_specs_with_recursive_definition(minimal_swagger_dict, minim
         )
 
     assert new_spec().is_equal(new_spec())
+
+
+@pytest.mark.parametrize(
+    '__dict__',
+    [
+        {'resources': []},
+        {'resources': {'tag': None}},
+        {'definitions': []},
+        {'definitions': {'model': Exception}},
+    ],
+)
+def test_equality_early_exit(
+    minimal_swagger_dict, minimal_swagger_abspath, __dict__,
+):
+    # This test is mostly meant to ensure that early exit points of Spec.is_equal are triggered during tests.
+    minimal_swagger_dict['definitions'] = {'model': {'type': 'object'}}
+    minimal_swagger_dict['paths']['/new/path'] = {
+        'get': {
+            'responses': {
+                'default': {'description': ''},
+            },
+            'tags': ['tag'],
+        },
+    }
+    spec = Spec.from_dict(minimal_swagger_dict, origin_url=get_url(minimal_swagger_abspath))
+    other_spec = Spec.from_dict(minimal_swagger_dict, origin_url=get_url(minimal_swagger_abspath))
+    other_spec.__dict__.update(__dict__)
+    assert not spec.is_equal(other_spec)

--- a/tests/spec/Spec/equality_test.py
+++ b/tests/spec/Spec/equality_test.py
@@ -31,3 +31,42 @@ def test_spec_hashability(petstore_spec):
     # The test wants to ensure that a Spec instance is hashable.
     # If calling hash does not throw an exception than we've validated the assumption
     hash(petstore_spec)
+
+
+def test_equality_checks_for_definitions(petstore_spec, petstore_dict, petstore_abspath):
+    petstore_dict['definitions']['new_model'] = {'type': 'object'}
+    other_petstore_spec_instance = Spec.from_dict(petstore_dict, origin_url=get_url(petstore_abspath))
+    assert not petstore_spec.is_equal(other_petstore_spec_instance)
+
+
+def test_equality_checks_for_resources(petstore_spec, petstore_dict, petstore_abspath):
+    petstore_dict['paths']['/new/path'] = {
+        'get': {
+            'responses': {
+                'default': {'description': ''},
+            },
+        },
+    }
+    other_petstore_spec_instance = Spec.from_dict(petstore_dict, origin_url=get_url(petstore_abspath))
+    assert not petstore_spec.is_equal(other_petstore_spec_instance)
+
+
+@pytest.mark.parametrize('internally_dereference_refs', [True, False])
+def test_equality_of_specs_with_recursive_definition(minimal_swagger_dict, minimal_swagger_abspath, internally_dereference_refs):
+    minimal_swagger_dict['definitions']['recursive_definition'] = {
+        'type': 'object',
+        'properties': {
+            'property': {
+                '$ref': '#/definitions/recursive_definition',
+            },
+        },
+    }
+
+    def new_spec():
+        return Spec.from_dict(
+            spec_dict=minimal_swagger_dict,
+            origin_url=get_url(minimal_swagger_abspath),
+            config={'internally_dereference_refs': internally_dereference_refs},
+        )
+
+    assert new_spec().is_equal(new_spec())


### PR DESCRIPTION
While working on a branch related to #370 I've noticed that the implemented equality checks are good but not  enough ;)

Currently the checks are making some assumptions on the state of certain attributes:
 * "It is built via Spec.build so we're ignoring it", but it is on the public interface so users might just modify it
 * fully skipping the check around resources and operations due to recursive Spec references
 * not considering that in the case of `internally_dereference_refs: true` the check (as it was implemented) would have had an unbounded recursion

The goal of this PR is to address those issues (still the checks are not perfect, but they should be more accurate) as well as providing a sort of method documentation.
