### PR TITLE
Pickling support

### DIFF
--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -925,7 +925,7 @@ def model_discovery(swagger_spec):
         swagger_spec.definitions = tmp_spec.definitions
 
 
-def to_pickleable_representation(model_name, model_type):
+def _to_pickleable_representation(model_name, model_type):
     # type: (typing.Text, typing.Type[Model]) -> typing.Dict[typing.Text, typing.Any]
     """
     Extract a pickleable representation of the input Model type.
@@ -933,7 +933,7 @@ def to_pickleable_representation(model_name, model_type):
     Model types are runtime created types and so they are not pickleable.
     In order to workaround this limitation we extract a representation,
     which is pickleable such that we can re-create the input Model type
-    (via ``from_pickleable_representation``).
+    (via ``_from_pickleable_representation``).
 
     NOTE:   This API should not be considered a public API and is meant
             only to be used by bravado_core.spec.Spec.__getstate__ .
@@ -947,11 +947,11 @@ def to_pickleable_representation(model_name, model_type):
     }
 
 
-def from_pickleable_representation(model_pickleable_representation):
+def _from_pickleable_representation(model_pickleable_representation):
     # type: (typing.Dict[typing.Text, typing.Any]) -> typing.Type[Model]
     """
     Re-Create Model type form its pickleable representation
-    ``model_pickleable_representation`` is supposed to be the output of ``to_pickleable_representation``.
+    ``model_pickleable_representation`` is supposed to be the output of ``_to_pickleable_representation``.
 
     NOTE:   This API should not be considered a public API and is meant
             only to be used by bravado_core.spec.Spec.__getstate__ .

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -925,15 +925,15 @@ def model_discovery(swagger_spec):
         swagger_spec.definitions = tmp_spec.definitions
 
 
-def to_pickable_representation(model_name, model_type):
+def to_pickleable_representation(model_name, model_type):
     # type: (typing.Text, typing.Type[Model]) -> typing.Dict[typing.Text, typing.Any]
     """
-    Extract a pickable representation of the input Model type.
+    Extract a pickleable representation of the input Model type.
 
-    Model types are runtime created types and so they are not pickable.
+    Model types are runtime created types and so they are not pickleable.
     In order to workaround this limitation we extract a representation,
-    which is pickable such that we can re-create the input Model type
-    (via ``from_pickable_representation``).
+    which is pickleable such that we can re-create the input Model type
+    (via ``from_pickleable_representation``).
 
     NOTE:   This API should not be considered a public API and is meant
             only to be used by bravado_core.spec.Spec.__getstate__ .
@@ -947,13 +947,13 @@ def to_pickable_representation(model_name, model_type):
     }
 
 
-def from_pickable_representation(model_pickable_representation):
+def from_pickleable_representation(model_pickleable_representation):
     # type: (typing.Dict[typing.Text, typing.Any]) -> typing.Type[Model]
     """
-    Re-Create Model type form its pickable representation
-    ``model_pickable_representation`` is supposed to be the output of ``to_pickable_representation``.
+    Re-Create Model type form its pickleable representation
+    ``model_pickleable_representation`` is supposed to be the output of ``to_pickleable_representation``.
 
     NOTE:   This API should not be considered a public API and is meant
             only to be used by bravado_core.spec.Spec.__getstate__ .
     """
-    return create_model_type(**model_pickable_representation)
+    return create_model_type(**model_pickleable_representation)

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -923,3 +923,37 @@ def model_discovery(swagger_spec):
         # this ensures that the generated models have no references
         _run_post_processing(tmp_spec)
         swagger_spec.definitions = tmp_spec.definitions
+
+
+def to_pickable_representation(model_name, model_type):
+    # type: (typing.Text, typing.Type[Model]) -> typing.Dict[typing.Text, typing.Any]
+    """
+    Extract a pickable representation of the input Model type.
+
+    Model types are runtime created types and so they are not pickable.
+    In order to workaround this limitation we extract a representation,
+    which is pickable such that we can re-create the input Model type
+    (via ``from_pickable_representation``).
+
+    NOTE:   This API should not be considered a public API and is meant
+            only to be used by bravado_core.spec.Spec.__getstate__ .
+    """
+    return {
+        'swagger_spec': model_type._swagger_spec,
+        'model_name': model_name,
+        'model_spec': model_type._model_spec,
+        'bases': model_type.__bases__,
+        'json_reference': model_type._json_reference,
+    }
+
+
+def from_pickable_representation(model_pickable_representation):
+    # type: (typing.Dict[typing.Text, typing.Any]) -> typing.Type[Model]
+    """
+    Re-Create Model type form its pickable representation
+    ``model_pickable_representation`` is supposed to be the output of ``to_pickable_representation``.
+
+    NOTE:   This API should not be considered a public API and is meant
+            only to be used by bravado_core.spec.Spec.__getstate__ .
+    """
+    return create_model_type(**model_pickable_representation)

--- a/bravado_core/resource.py
+++ b/bravado_core/resource.py
@@ -110,9 +110,11 @@ class Resource(object):
         )
 
     def __getstate__(self):
+        # type: () -> typing.Dict[str, typing.Any]
         return self.__dict__
 
     def __setstate__(self, state):
+        # type: (typing.Dict[str, typing.Any]) -> None
         self.__dict__.clear()
         self.__dict__.update(state)
 

--- a/bravado_core/resource.py
+++ b/bravado_core/resource.py
@@ -109,6 +109,13 @@ class Resource(object):
             ops=deepcopy(self.operations, memo=memo),
         )
 
+    def __getstate__(self):
+        return self.__dict__
+
+    def __setstate__(self, state):
+        self.__dict__.clear()
+        self.__dict__.update(state)
+
     def __repr__(self):
         return u"%s(%s)" % (self.__class__.__name__, self.name)
 

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -25,10 +25,10 @@ from bravado_core import version as _version
 from bravado_core.exception import SwaggerSchemaError
 from bravado_core.exception import SwaggerValidationError
 from bravado_core.formatter import return_true_wrapper
-from bravado_core.model import from_pickleable_representation
+from bravado_core.model import _from_pickleable_representation
+from bravado_core.model import _to_pickleable_representation
 from bravado_core.model import Model
 from bravado_core.model import model_discovery
-from bravado_core.model import to_pickleable_representation
 from bravado_core.resource import build_resources
 from bravado_core.schema import is_dict_like
 from bravado_core.schema import is_list_like
@@ -259,7 +259,7 @@ class Spec(object):
                 'resolver',
                 # Exclude definitions because it contain runtime defined type and those
                 # are not directly pickleable.
-                # Check bravado_core.model.to_pickleable_representation for details.
+                # Check bravado_core.model._to_pickleable_representation for details.
                 'definitions',
             )
         }
@@ -269,7 +269,7 @@ class Spec(object):
         # To avoid model discovery we store a pickleable representation of the Model types
         # such that we can re-create them.
         state['definitions'] = {
-            model_name: to_pickleable_representation(model_name, model_type)
+            model_name: _to_pickleable_representation(model_name, model_type)
             for model_name, model_type in iteritems(self.definitions)
         }
         # Store the bravado-core version used to create the Spec state
@@ -292,7 +292,7 @@ class Spec(object):
 
         # Re-create Model types, avoiding model discovery
         state['definitions'] = {
-            model_name: from_pickleable_representation(pickleable_representation)
+            model_name: _from_pickleable_representation(pickleable_representation)
             for model_name, pickleable_representation in iteritems(state['definitions'])
         }
         self.__dict__.clear()

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -21,6 +21,7 @@ from swagger_spec_validator import validator20
 from swagger_spec_validator.ref_validators import in_scope
 
 from bravado_core import formatter
+from bravado_core import version as _version
 from bravado_core.exception import SwaggerSchemaError
 from bravado_core.exception import SwaggerValidationError
 from bravado_core.formatter import return_true_wrapper
@@ -271,10 +272,24 @@ class Spec(object):
             model_name: to_pickable_representation(model_name, model_type)
             for model_name, model_type in iteritems(self.definitions)
         }
-
+        # Store the bravado-core version used to create the Spec state
+        state['__bravado_core_version__'] = _version
         return state
 
     def __setstate__(self, state):
+        state_version = state.pop('__bravado_core_version__')
+        if state_version != _version:
+            warnings.warn(
+                'You are creating a Spec instance from a state created by a different '
+                'bravado-core version. We are not going to guarantee that the created '
+                'Spec instance will be correct. '
+                'State created by version {state_version}, current version {_version}'.format(
+                    state_version=state_version,
+                    _version=_version,
+                ),
+                category=UserWarning,
+            )
+
         # Re-create Model types, avoiding model discovery
         state['definitions'] = {
             model_name: from_pickable_representation(pickable_representation)

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -25,10 +25,10 @@ from bravado_core import version as _version
 from bravado_core.exception import SwaggerSchemaError
 from bravado_core.exception import SwaggerValidationError
 from bravado_core.formatter import return_true_wrapper
-from bravado_core.model import from_pickable_representation
+from bravado_core.model import from_pickleable_representation
 from bravado_core.model import Model
 from bravado_core.model import model_discovery
-from bravado_core.model import to_pickable_representation
+from bravado_core.model import to_pickleable_representation
 from bravado_core.resource import build_resources
 from bravado_core.schema import is_dict_like
 from bravado_core.schema import is_list_like
@@ -252,24 +252,24 @@ class Spec(object):
             k: v
             for k, v in iteritems(self.__dict__)
             if k not in (
-                # Exclude resolver as it is not easily pickable. As there are no real
+                # Exclude resolver as it is not easily pickleable. As there are no real
                 # benefits on re-using the same Resolver respect to build a new one
                 # we're going to ignore the field and eventually re-create it if needed
                 # via cached_property
                 'resolver',
                 # Exclude definitions because it contain runtime defined type and those
-                # are not directly pickable.
-                # Check bravado_core.model.to_pickable_representation for details.
+                # are not directly pickleable.
+                # Check bravado_core.model.to_pickleable_representation for details.
                 'definitions',
             )
         }
 
         # A possible approach would be to re-execute model discovery on the newly Spec
         # instance (in __setstate__) but it would be very slow.
-        # To avoid model discovery we store a pickable representation of the Model types
+        # To avoid model discovery we store a pickleable representation of the Model types
         # such that we can re-create them.
         state['definitions'] = {
-            model_name: to_pickable_representation(model_name, model_type)
+            model_name: to_pickleable_representation(model_name, model_type)
             for model_name, model_type in iteritems(self.definitions)
         }
         # Store the bravado-core version used to create the Spec state
@@ -292,8 +292,8 @@ class Spec(object):
 
         # Re-create Model types, avoiding model discovery
         state['definitions'] = {
-            model_name: from_pickable_representation(pickable_representation)
-            for model_name, pickable_representation in iteritems(state['definitions'])
+            model_name: from_pickleable_representation(pickleable_representation)
+            for model_name, pickleable_representation in iteritems(state['definitions'])
         }
         self.__dict__.clear()
         self.__dict__.update(state)

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -140,15 +140,18 @@ class Spec(object):
         self.user_defined_formats = {}
         self.format_checker = FormatChecker()
 
-        self.resolver = RefResolver(
-            base_uri=origin_url or '',
-            referrer=self.spec_dict,
-            handlers=self.get_ref_handlers(),
-        )
-
         # spec dict used to build resources, in case internally_dereference_refs config is enabled
         # it will be overridden by the dereferenced specs (by build method). More context in PR#263
         self._internal_spec_dict = spec_dict
+
+    @cached_property
+    def resolver(self):
+        # type: () -> RefResolver
+        return RefResolver(
+            base_uri=self.origin_url or '',
+            referrer=self.spec_dict,
+            handlers=self.get_ref_handlers(),
+        )
 
     def is_equal(self, other):
         # type: (typing.Any) -> bool

--- a/tests/model/pickling_test.py
+++ b/tests/model/pickling_test.py
@@ -32,6 +32,9 @@ def test_ensure_that_get_model_type__from_pickleable_representation_returns_the_
                 isinstance(cat_type.__dict__[attr_name], ModelDocstring) and
                 isinstance(reconstructed_model_type.__dict__[attr_name], ModelDocstring)
             )
+        elif attr_name == '_abc_impl':
+            # _abc_impl is of type builtins._abc_data which is not really comparable. So we'll ignore it
+            return True
         else:
             return cat_type.__dict__[attr_name] == reconstructed_model_type.__dict__[attr_name]
 

--- a/tests/model/pickling_test.py
+++ b/tests/model/pickling_test.py
@@ -2,25 +2,25 @@
 from six import iterkeys
 from six.moves.cPickle import dumps
 
-from bravado_core.model import from_pickable_representation
+from bravado_core.model import from_pickleable_representation
 from bravado_core.model import ModelDocstring
-from bravado_core.model import to_pickable_representation
+from bravado_core.model import to_pickleable_representation
 
 
-def test_ensure_pickable_representation_is_pickable(cat_type):
-    pickable_representation = to_pickable_representation('Cat', cat_type)
-    # Ensures that the pickle.dump of the pickable representation is pickable
+def test_ensure_pickleable_representation_is_pickleable(cat_type):
+    pickleable_representation = to_pickleable_representation('Cat', cat_type)
+    # Ensures that the pickle.dump of the pickleable representation is pickleable
     # If the dumps call does not raise an exception then we were able to pickle
     # the model type
-    dumps(pickable_representation)
+    dumps(pickleable_representation)
 
 
-def test_ensure_that_get_model_type_from_pickable_representation_returns_the_original_model(cat_type):
-    # Ensures that the pickle.dump of the pickable representation is pickable
+def test_ensure_that_get_model_type_from_pickleable_representation_returns_the_original_model(cat_type):
+    # Ensures that the pickle.dump of the pickleable representation is pickleable
     # If the dumps call does not raise an exception then we were able to pickle
     # the model type
-    reconstructed_model_type = from_pickable_representation(
-        model_pickable_representation=to_pickable_representation('Cat', cat_type),
+    reconstructed_model_type = from_pickleable_representation(
+        model_pickleable_representation=to_pickleable_representation('Cat', cat_type),
     )
     assert reconstructed_model_type.__name__ == 'Cat'
 

--- a/tests/model/pickling_test.py
+++ b/tests/model/pickling_test.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+from six import iterkeys
+from six.moves.cPickle import dumps
+
+from bravado_core.model import from_pickable_representation
+from bravado_core.model import ModelDocstring
+from bravado_core.model import to_pickable_representation
+
+
+def test_ensure_pickable_representation_is_pickable(cat_type):
+    pickable_representation = to_pickable_representation('Cat', cat_type)
+    # Ensures that the pickle.dump of the pickable representation is pickable
+    # If the dumps call does not raise an exception then we were able to pickle
+    # the model type
+    dumps(pickable_representation)
+
+
+def test_ensure_that_get_model_type_from_pickable_representation_returns_the_original_model(cat_type):
+    # Ensures that the pickle.dump of the pickable representation is pickable
+    # If the dumps call does not raise an exception then we were able to pickle
+    # the model type
+    reconstructed_model_type = from_pickable_representation(
+        model_pickable_representation=to_pickable_representation('Cat', cat_type),
+    )
+    assert reconstructed_model_type.__name__ == 'Cat'
+
+    def is_the_same(attr_name):
+        if attr_name == '_swagger_spec':
+            return cat_type._swagger_spec.is_equal(reconstructed_model_type._swagger_spec)
+        elif attr_name == '__doc__':
+            return (
+                isinstance(cat_type.__dict__[attr_name], ModelDocstring) and
+                isinstance(reconstructed_model_type.__dict__[attr_name], ModelDocstring)
+            )
+        else:
+            return cat_type.__dict__[attr_name] == reconstructed_model_type.__dict__[attr_name]
+
+    assert [
+        attribute_name
+        for attribute_name in iterkeys(cat_type.__dict__)
+        if not is_the_same(attribute_name)
+    ] == []

--- a/tests/model/pickling_test.py
+++ b/tests/model/pickling_test.py
@@ -2,25 +2,25 @@
 from six import iterkeys
 from six.moves.cPickle import dumps
 
-from bravado_core.model import from_pickleable_representation
+from bravado_core.model import _from_pickleable_representation
+from bravado_core.model import _to_pickleable_representation
 from bravado_core.model import ModelDocstring
-from bravado_core.model import to_pickleable_representation
 
 
 def test_ensure_pickleable_representation_is_pickleable(cat_type):
-    pickleable_representation = to_pickleable_representation('Cat', cat_type)
+    pickleable_representation = _to_pickleable_representation('Cat', cat_type)
     # Ensures that the pickle.dump of the pickleable representation is pickleable
     # If the dumps call does not raise an exception then we were able to pickle
     # the model type
     dumps(pickleable_representation)
 
 
-def test_ensure_that_get_model_type_from_pickleable_representation_returns_the_original_model(cat_type):
+def test_ensure_that_get_model_type__from_pickleable_representation_returns_the_original_model(cat_type):
     # Ensures that the pickle.dump of the pickleable representation is pickleable
     # If the dumps call does not raise an exception then we were able to pickle
     # the model type
-    reconstructed_model_type = from_pickleable_representation(
-        model_pickleable_representation=to_pickleable_representation('Cat', cat_type),
+    reconstructed_model_type = _from_pickleable_representation(
+        model_pickleable_representation=_to_pickleable_representation('Cat', cat_type),
     )
     assert reconstructed_model_type.__name__ == 'Cat'
 

--- a/tests/spec/pickling_test.py
+++ b/tests/spec/pickling_test.py
@@ -10,7 +10,7 @@ from tests.conftest import get_url
 
 @pytest.mark.parametrize('validate_swagger_spec', [True, False])
 @pytest.mark.parametrize('internally_dereference_refs', [True, False])
-def test_ensure_spec_is_pickable(petstore_dict, petstore_abspath, internally_dereference_refs, validate_swagger_spec):
+def test_ensure_spec_is_pickleable(petstore_dict, petstore_abspath, internally_dereference_refs, validate_swagger_spec):
     spec = Spec.from_dict(
         spec_dict=petstore_dict,
         origin_url=get_url(petstore_abspath),

--- a/tests/spec/pickling_test.py
+++ b/tests/spec/pickling_test.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+import pytest
+from six.moves.cPickle import dumps
+from six.moves.cPickle import loads
+
+from bravado_core.spec import Spec
+from tests.conftest import get_url
+
+
+@pytest.mark.parametrize('validate_swagger_spec', [True, False])
+@pytest.mark.parametrize('internally_dereference_refs', [True, False])
+def test_ensure_spec_is_pickable(petstore_dict, petstore_abspath, internally_dereference_refs, validate_swagger_spec):
+    spec = Spec.from_dict(
+        spec_dict=petstore_dict,
+        origin_url=get_url(petstore_abspath),
+        config={
+            'validate_swagger_spec': validate_swagger_spec,
+            'internally_dereference_refs': internally_dereference_refs,
+        },
+    )
+    assert spec.is_equal(loads(dumps(spec)))

--- a/tests/spec/pickling_test.py
+++ b/tests/spec/pickling_test.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import mock
 import pytest
 from six.moves.cPickle import dumps
 from six.moves.cPickle import loads
@@ -19,3 +20,12 @@ def test_ensure_spec_is_pickable(petstore_dict, petstore_abspath, internally_der
         },
     )
     assert spec.is_equal(loads(dumps(spec)))
+
+
+def test_ensure_warning_presence_in_case_of_version_mismatch(petstore_spec):
+    with mock.patch('bravado_core.spec._version', '0.0.0'):
+        petstore_pickle = dumps(petstore_spec)
+
+    with pytest.warns(UserWarning, match='different bravado-core version.*created by version 0.0.0, current version'):
+        restored_petstore_spec = loads(petstore_pickle)
+    assert petstore_spec.is_equal(restored_petstore_spec)


### PR DESCRIPTION
The goal of this PR is to fix #370 

In order to make `bravado_core.spec.Spec` pickable I had to define `__getstate__` and `__setstate__` methods into `Spec` and `Resource` class.

The reason of this is that pickling an object usually gets all the object attributes and tries to pickle them:
 * `Resource` does define `__dir__` method which confuses the pickling process
 * `Spec` needs to deal with the fact that runtime created types (models) are not picklable. In order to make them pickable I'm pickling a representation of the arguments needed to rebuild the type.
Unfortunately this approach has the defect that restoring (unpickling) the object might depend on the version of bravdo_core in use (more importantly on the signature of `create_model_type`.
I think that this is eventually acceptable considering that the signature did not changed over time and that in case that would happen we could still ensure that `bavado_core.__version__` is encoded into the picklable object.
