### PR TITLE
Typing annotations: resource and operation

### DIFF
--- a/bravado_core/param.py
+++ b/bravado_core/param.py
@@ -4,6 +4,7 @@ from functools import partial
 
 import simplejson as json
 import six
+import typing
 from six.moves.urllib.parse import quote
 
 from bravado_core import schema
@@ -12,6 +13,13 @@ from bravado_core.exception import SwaggerMappingError
 from bravado_core.marshal import marshal_schema_object
 from bravado_core.unmarshal import unmarshal_schema_object
 from bravado_core.validate import validate_schema_object
+
+
+if getattr(typing, 'TYPE_CHECKING', False):
+    from bravado_core.operation import Operation
+    from bravado_core.spec import Spec
+    from bravado_core._compat_typing import JSONDict
+
 
 log = logging.getLogger(__name__)
 
@@ -42,6 +50,7 @@ class Param(object):
     """
 
     def __init__(self, swagger_spec, op, param_spec):
+        # type: (Spec, Operation, JSONDict) -> None
         self.op = op
         self.swagger_spec = swagger_spec
         self.param_spec = swagger_spec.deref(param_spec)

--- a/mypy.ini
+++ b/mypy.ini
@@ -19,11 +19,6 @@ disallow_untyped_calls = False
 check_untyped_defs = False
 disallow_untyped_defs = False
 
-[mypy-bravado_core.operation.*]
-disallow_untyped_calls = False
-check_untyped_defs = False
-disallow_untyped_defs = False
-
 [mypy-bravado_core.param.*]
 disallow_untyped_calls = False
 check_untyped_defs = False
@@ -33,9 +28,6 @@ disallow_untyped_defs = False
 disallow_untyped_calls = False
 check_untyped_defs = False
 disallow_untyped_defs = False
-
-[mypy-bravado_core.resource.*]
-disallow_untyped_calls = False
 
 [mypy-bravado_core.response.*]
 disallow_untyped_calls = False

--- a/mypy.ini
+++ b/mypy.ini
@@ -36,8 +36,6 @@ disallow_untyped_defs = False
 
 [mypy-bravado_core.resource.*]
 disallow_untyped_calls = False
-check_untyped_defs = False
-disallow_untyped_defs = False
 
 [mypy-bravado_core.response.*]
 disallow_untyped_calls = False


### PR DESCRIPTION
The goal of this PR is to fully type the bravado_core.operation and bravado_core.resource modules.

In order to achieve proper typing I had to update the implementation of the `__repr__` methods as they were returning unicode strings while `object.__repr__` expect strings (this applies only to python 2).

I thought that adding the condition over the python version would be the best way of dealing with the issue instead of dropping an effective (but unsightly) `type: ignore`