### PR TITLE
Tentative to remove overhead of models

### DIFF
--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -335,17 +335,6 @@ class Model(dict):
     _model_spec = None  # type: typing.ClassVar[JSONDict]
     _json_reference = None  # type: typing.ClassVar[str]
 
-    def __init__(self, *args, **kwargs):
-        dict.__init__(self, *args, **kwargs)
-        if self._model_spec.get('additionalProperties') is False:
-            additional_properties = self._additional_props
-            if additional_properties:
-                raise AttributeError(
-                    "Model {0} does not have attributes for: {1}".format(
-                        type(self), list(additional_properties),
-                    ),
-                )
-
     @lazy_class_attribute
     def _properties(cls):
         return collapsed_properties(cls._model_spec, cls._swagger_spec)

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -293,15 +293,18 @@ def _unmarshal_object(
             return unmarshal_func(model_value)
 
     unmarshaled_value = model_type()
+    unmarshaled_attributes = set()
     for property_name, property_value in iteritems(model_value):
         unmarshaling_function = properties_to_unmarshaling_function.get(
             property_name, additional_properties_unmarshaling_function,
         )
         unmarshaled_value[property_name] = unmarshaling_function(property_value)
+        unmarshaled_attributes.add(property_name)
 
     if swagger_spec.config['include_missing_properties']:
         for property_name, unmarshaling_function in iteritems(properties_to_unmarshaling_function):
-            if property_name not in unmarshaled_value:
+            # if property_name not in unmarshaled_value:
+            if property_name not in unmarshaled_attributes:
                 unmarshaled_value[property_name] = properties_to_default_value.get(property_name)
 
     return unmarshaled_value

--- a/tests/model/model_constructor_test.py
+++ b/tests/model/model_constructor_test.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-import pytest
-
 from bravado_core.schema import collapsed_properties
 
 
@@ -52,16 +50,6 @@ def test_additionalProperties_true(definitions_spec, user_type, user_kwargs):
     assert user.foo == 'bar'
     assert 'foo' in dir(user)
     assert set(user) == set(definitions_spec['User']['properties'].keys()).union({'foo'})
-
-
-def test_additionalProperties_false(user_type, user_kwargs):
-    # verify exra kwargs are caught during model construction when
-    # additionalProperties is False
-    user_type._model_spec['additionalProperties'] = False
-    user_kwargs['foo'] = 'bar'  # additional prop
-    with pytest.raises(AttributeError) as excinfo:
-        user_type(**user_kwargs)
-    assert "does not have attributes for: ['foo']" in str(excinfo.value)
 
 
 def test_allOf(cat_swagger_spec, cat_type, cat_kwargs):

--- a/tests/model/model_test.py
+++ b/tests/model/model_test.py
@@ -150,8 +150,13 @@ def test_model_deepcopy(user_type, user_kwargs):
     user_copy = deepcopy(user)
 
     assert isinstance(user_copy, user_type)
+    assert id(user) != id(user_copy)
     assert user == user_copy
     assert user._as_dict() == user_copy._as_dict()
+
+    user.firstName = 'An other name'
+    assert user.firstName == 'An other name'
+    assert user_copy.firstName != 'An other name'
 
 
 @pytest.mark.parametrize(

--- a/tests/profiling/use_model_profiler_test.py
+++ b/tests/profiling/use_model_profiler_test.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from bravado_core.spec import Spec
+from bravado_core.unmarshal import unmarshal_schema_object
+
+
+@pytest.fixture(
+    params=[True, False],
+    ids=['use-models', 'use-dicts'],
+)
+def perf_petstore_spec(request, petstore_spec):
+    return Spec.from_dict(
+        spec_dict=petstore_spec.spec_dict,
+        origin_url=petstore_spec.origin_url,
+        config=dict(petstore_spec.config, use_models=request.param),
+    )
+
+
+@pytest.fixture
+def findByStatusReponseSchema(perf_petstore_spec):
+    parts = ['paths', '/pet/findByStatus', 'get', 'responses', '200', 'schema']
+    result = perf_petstore_spec._internal_spec_dict
+    for part in parts:
+        result = perf_petstore_spec.deref(result[part])
+    return result
+
+
+def test_small_objects(
+    benchmark, perf_petstore_spec, findByStatusReponseSchema, small_pets,
+):
+    benchmark(
+        unmarshal_schema_object,
+        perf_petstore_spec,
+        findByStatusReponseSchema,
+        small_pets,
+    )
+
+
+def test_large_objects(
+    benchmark, perf_petstore_spec, findByStatusReponseSchema, large_pets,
+):
+    benchmark(
+        unmarshal_schema_object,
+        perf_petstore_spec,
+        findByStatusReponseSchema,
+        large_pets,
+    )


### PR DESCRIPTION
The goal of this PR is to reduce the performance gap present while unmarshaling schemas if `use_models` is enabled or disabled.

In order to achieve the performance parity between models disabled (so raw `dict`) and models enabled (so `bravado_core.model.Model`) I've ensured that `Model` class extends `dict`.

In order to prevent unexpected regressions I've made sure that no tests would have been modified after the changing `Model`  base class.
This is true except for the last commit (6374839) where there is a _backward_ incompatible change (from commit message)
> Remove check for additional properties while creating model
> This is needed to reduce even more the difference in Model vs dict creation.
> NOTE: Once a model is created there are no checks in case additional properties would have been added.

Some hightligths:
 * pre-PR there was ~50% performance penalty on using models
 * after-PR there is <1% performance penalty on using models

Raw data are available on https://gist.github.com/macisamuele/dcd58fafd470c80902643760e4eb87ea
