### PR TITLE
Restrict pytest to <4.7 to fix build, add py36 and mypy to tox envlist

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,6 @@ mock
 mypy-extensions; python_version>='3.5'
 mypy; python_version>='3.5'
 pre-commit
-pytest
 pytest-benchmark[histogram]
 pytest-cov
+pytest<4.7  # need support for Python 2.7, see https://docs.pytest.org/en/latest/py27-py34-deprecation.html

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ filterwarnings =
     ignore:.*will be deprecated in the next major release. Please use the more general entry-point offered in.*:DeprecationWarning
 
 [tox]
-envlist = py27, py37, pre-commit
+envlist = py27, py36, py37, mypy, pre-commit
 
 [testenv]
 deps =
@@ -40,7 +40,7 @@ exclude = .svn,CVS,.bzr,.hg,.git,__pycache__,.tox,docs,virtualenv_run
 max_line_length = 130
 
 [testenv:pre-commit]
-basepython = /usr/bin/python2.7
+basepython = python2.7
 deps =
     pre-commit>0.12.0
 setenv =


### PR DESCRIPTION
This fixes the build in the same way I fixed it for bravado. It also makes sure we run mypy as well as tests on Python 3.6 locally, and fixes installation / usage of pre-commit on systems where `python2.7` is not in `/usr/bin`.