### PR TITLE
Update Spec to return new resolver instances for validators fixing an IndexError in RefResolver due to it not being thread-safe

### DIFF
--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -161,6 +161,15 @@ class Spec(object):
             handlers=self.get_ref_handlers(),
         )
 
+    @property
+    def validation_resolver(self):
+        # type: () -> RefResolver
+        return RefResolver(
+            base_uri=self.origin_url or '',
+            referrer=self.spec_dict,
+            handlers=self.get_ref_handlers(),
+        )
+
     def is_equal(self, other):
         # type: (typing.Any) -> bool
         """

--- a/bravado_core/validate.py
+++ b/bravado_core/validate.py
@@ -97,7 +97,7 @@ def validate_primitive(
     get_validator_type(swagger_spec=swagger_spec)(
         primitive_spec,
         format_checker=swagger_spec.format_checker,
-        resolver=swagger_spec.resolver,
+        resolver=swagger_spec.validation_resolver,
     ).validate(value)
 
 
@@ -116,7 +116,7 @@ def validate_array(
     get_validator_type(swagger_spec=swagger_spec)(
         array_spec,
         format_checker=swagger_spec.format_checker,
-        resolver=swagger_spec.resolver,
+        resolver=swagger_spec.validation_resolver,
     ).validate(value)
 
 
@@ -135,7 +135,7 @@ def validate_object(
     get_validator_type(swagger_spec=swagger_spec)(
         object_spec,
         format_checker=swagger_spec.format_checker,
-        resolver=swagger_spec.resolver,
+        resolver=swagger_spec.validation_resolver,
     ).validate(value)
 
 


### PR DESCRIPTION
This resolves an issue which occasionally results in an `IndexError` due to a race condition.
See MLOCPAR-6374 in JIRA for context.