### PR TITLE
Pin to jsonschema < 4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ import bravado_core
 
 install_requires = [
     "jsonref",
-    "jsonschema[format]>=2.5.1",
+    "jsonschema[format]>=2.5.1,<4.0.0",
     "python-dateutil",
     "pyyaml",
     "simplejson",


### PR DESCRIPTION
jsonschema 4.0 deprecates `RefResolver.in_scope` and breaks `RefResolver.resolve` for `Spec.from_dict`.