### PR TITLE
Use http_client from the internal spec in the `_SpecFlattener.model_discovery`.

### DIFF
--- a/bravado_core/spec_flattening.py
+++ b/bravado_core/spec_flattening.py
@@ -318,9 +318,7 @@ class _SpecFlattener(object):
                         for uri, value in iteritems(self.known_mappings['definitions'])
                     },
                 },
-                origin_url=self.swagger_spec.origin_url,
                 http_client=self.swagger_spec.http_client,
-                config=self.swagger_spec.config,
             ),
         )
 

--- a/bravado_core/spec_flattening.py
+++ b/bravado_core/spec_flattening.py
@@ -318,6 +318,9 @@ class _SpecFlattener(object):
                         for uri, value in iteritems(self.known_mappings['definitions'])
                     },
                 },
+                origin_url=self.swagger_spec.origin_url,
+                http_client=self.swagger_spec.http_client,
+                config=self.swagger_spec.config,
             ),
         )
 


### PR DESCRIPTION
This will allow you to use bravado-core with the jsonschema > 4.0.

E.g. in the following case:
```python
from bravado_core.spec import Spec
from bravado.requests_client import RequestsClient

http_client = RequestsClient()
spec = Spec.from_dict(spec_dict, origin_url=origin_url, config=config, http_client=http_client)

# This call can throw an error without the fix
flattened_spec = spec.deref_flattened_spec
```