### PR TITLE
Upstream jsonschema refresolution issue patch

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,7 @@ Related Projects
 * `bravado <https://github.com/Yelp/bravado>`__
 * `pyramid-swagger <https://github.com/striglia/pyramid_swagger>`__
 * `swagger-spec-validator <https://github.com/Yelp/swagger_spec_validator>`__
+* `bottle-swagger-2 <https://github.com/cope-systems/bottle-swagger>`__
 
 Development
 ===========

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup
 import bravado_core
 
 install_requires = [
-    "jsonref",
+    "jsonref<=3.2.0",
     "jsonschema[format]>=2.5.1",
     "python-dateutil",
     "pyyaml",


### PR DESCRIPTION
Schema validation with bravado-core causes "RefResolutionError" when used with newer versions of jsonschema (4.0.0+); this seems to be a problem with jsonschema itself (https://github.com/Julian/jsonschema/issues/847). This commit pins jsonschema to the last known compatible version for bravado-core until the
upstream issue is addressed.