### PR TITLE
extend regex of processed URLs to include additional json schemas

### DIFF
--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -880,7 +880,7 @@ def _run_post_processing(spec):
     processed_uris = {
         uri
         for uri in spec.resolver.store
-        if uri == spec.origin_url or re.match(r'http://json-schema.org/draft-\d+/schema', uri)
+        if uri == spec.origin_url or re.match(r'http(s)?://json-schema\.org/draft(/\d{4})?-\d+/(schema|meta/.*)', uri)
     }
     additional_uri = _get_unprocessed_uri(spec, processed_uris)
     while additional_uri is not None:


### PR DESCRIPTION
jsonschema>=4.0.0 is using different URLs than 3.x and bravado is not processing them correctly when testing offline. A list of examples can be found below. 

This pull request adds those schemas to the regex to restore compatibility. 

  https://json-schema.org/draft/2019-09/meta/meta-data
  http://json-schema.org/draft-04/schema
  http://json-schema.org/draft-06/schema
  https://json-schema.org/draft/2020-12/schema
  https://json-schema.org/draft/2020-12/meta/format-annotation
  https://json-schema.org/draft/2020-12/meta/applicator
  https://json-schema.org/draft/2019-09/meta/applicator
  https://json-schema.org/draft/2020-12/meta/unevaluated
  http://json-schema.org/draft-03/schema
  https://json-schema.org/draft/2020-12/meta/content
  http://json-schema.org/draft-07/schema
  https://json-schema.org/draft/2020-12/meta/meta-data
  https://json-schema.org/draft/2019-09/meta/format
  https://json-schema.org/draft/2019-09/meta/core
  https://json-schema.org/draft/2020-12/meta/core
  https://json-schema.org/draft/2019-09/meta/validation
  https://json-schema.org/draft/2020-12/meta/validation
  https://json-schema.org/draft/2019-09/meta/content
  https://json-schema.org/draft/2019-09/meta/hyper-schema
  https://json-schema.org/draft/2019-09/schema