### PR TITLE
add fallback http client for spec resolution as jsonschema requires it

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ install_requires = [
     "jsonschema[format]>=2.5.1",
     "python-dateutil",
     "pyyaml",
+    'requests',
     "simplejson",
     "six",
     "swagger-spec-validator>=2.0.1",


### PR DESCRIPTION
This is kind of a doozy. Basically at some point jsonschema changed some behavior where it will now use the remote resolver logic to get remote jsonschema draft meta-specs. The old logic wouldn't actually work without an http client, which was not required to be set on a `Spec` object. This adds a default client object.

The client object itself is a little strange, because the docstring for the `Spec` type specifies that it should be a `bravado.http_client.HttpClient`. However, depending on that would lead to a circular dependency and untangling that is a lot of work. Instead, I made the most basic type which satisfies the minimal requirements for making this functional, which means creating the `BasicHTTPClient` and `BasicHTTPFuture` types.