### PR TITLE
Use standard library mock when possible

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@
 # This issue sounds similar to https://github.com/pypa/pip/issues/3903, but
 # that was fixed in pip 20.3 and we're still seeing this issue on 22.0.2.
 jsonschema<4
-mock
+mock; python_version<'3.3'
 mypy
 mypy-extensions
 pre-commit

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,10 @@ from itertools import chain
 import pytest
 import simplejson as json
 import yaml
-from mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 from six import iteritems
 from six import iterkeys
 from six.moves.urllib import parse as urlparse

--- a/tests/formatter/to_python_test.py
+++ b/tests/formatter/to_python_test.py
@@ -3,7 +3,10 @@ from datetime import date
 from datetime import datetime
 
 import six
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 from bravado_core.formatter import SwaggerFormat
 from bravado_core.formatter import to_python

--- a/tests/formatter/to_wire_test.py
+++ b/tests/formatter/to_wire_test.py
@@ -4,7 +4,10 @@ from datetime import datetime
 
 import pytest
 import six
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 from pytz import timezone
 
 from bravado_core.exception import SwaggerMappingError

--- a/tests/model/bless_models_test.py
+++ b/tests/model/bless_models_test.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import pytest
 
 from bravado_core.model import _bless_models

--- a/tests/model/create_model_type_test.py
+++ b/tests/model/create_model_type_test.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import pytest
 
 from bravado_core.model import create_model_type

--- a/tests/model/get_model_name_test.py
+++ b/tests/model/get_model_name_test.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import pytest
 
 from bravado_core.model import _get_model_name

--- a/tests/model/model_discovery_test.py
+++ b/tests/model/model_discovery_test.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import pytest
 
 from bravado_core.model import _run_post_processing

--- a/tests/model/model_test.py
+++ b/tests/model/model_test.py
@@ -3,7 +3,10 @@ import datetime
 from copy import deepcopy
 
 import pytest
-from mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 from six import add_metaclass
 
 from bravado_core.content_type import APP_JSON

--- a/tests/model/post_process_spec_test.py
+++ b/tests/model/post_process_spec_test.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 import functools
 
-from mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 
 from bravado_core.model import _post_process_spec
 from bravado_core.spec import Spec

--- a/tests/model/tag_models_test.py
+++ b/tests/model/tag_models_test.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 import copy
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import pytest
 
 from bravado_core import model

--- a/tests/operation/security_object_test.py
+++ b/tests/operation/security_object_test.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 import pytest
-from mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 from six import iteritems
 
 from bravado_core.exception import SwaggerSchemaError

--- a/tests/param/add_file_test.py
+++ b/tests/param/add_file_test.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 import pytest
-from mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 
 from bravado_core.exception import SwaggerMappingError
 from bravado_core.operation import Operation

--- a/tests/param/cast_request_param_test.py
+++ b/tests/param/cast_request_param_test.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 from bravado_core.param import cast_request_param
 

--- a/tests/param/get_param_type_spec_test.py
+++ b/tests/param/get_param_type_spec_test.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 import pytest
-from mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 
 from bravado_core.exception import SwaggerMappingError
 from bravado_core.operation import Operation

--- a/tests/param/marshal_param_test.py
+++ b/tests/param/marshal_param_test.py
@@ -5,8 +5,10 @@ from json import loads
 
 import pytest
 from jsonschema import ValidationError
-from mock import Mock
-from mock import patch
+try:
+    from unittest.mock import Mock, patch
+except ImportError:
+    from mock import Mock, patch
 
 from bravado_core.content_type import APP_JSON
 from bravado_core.operation import Operation

--- a/tests/param/unmarshal_param_test.py
+++ b/tests/param/unmarshal_param_test.py
@@ -2,8 +2,10 @@
 import datetime
 
 import pytest
-from mock import Mock
-from mock import patch
+try:
+    from unittest.mock import Mock, patch
+except ImportError:
+    from mock import Mock, patch
 
 from bravado_core.operation import Operation
 from bravado_core.param import Param

--- a/tests/request/unmarshal_request_test.py
+++ b/tests/request/unmarshal_request_test.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 import pytest
-from mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 
 from bravado_core.exception import SwaggerMappingError
 from bravado_core.operation import Operation

--- a/tests/response/unmarshal_response_test.py
+++ b/tests/response/unmarshal_response_test.py
@@ -2,8 +2,10 @@
 import msgpack
 import pytest
 from jsonschema import ValidationError
-from mock import Mock
-from mock import patch
+try:
+    from unittest.mock import Mock, patch
+except ImportError:
+    from mock import Mock, patch
 
 from bravado_core.content_type import APP_JSON
 from bravado_core.content_type import APP_MSGPACK

--- a/tests/response/validate_response_body_test.py
+++ b/tests/response/validate_response_body_test.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 import msgpack
 import pytest
-from mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 
 from bravado_core.content_type import APP_MSGPACK
 from bravado_core.exception import SwaggerMappingError

--- a/tests/response/validate_response_headers_test.py
+++ b/tests/response/validate_response_headers_test.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 import pytest
 from jsonschema.exceptions import ValidationError
-from mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 
 from bravado_core.operation import Operation
 from bravado_core.response import OutgoingResponse

--- a/tests/response/validate_response_test.py
+++ b/tests/response/validate_response_test.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
-from mock import Mock
-from mock import patch
+try:
+    from unittest.mock import Mock, patch
+except ImportError:
+    from mock import Mock, patch
 
 from bravado_core.operation import Operation
 from bravado_core.response import OutgoingResponse

--- a/tests/spec/Spec/build_test.py
+++ b/tests/spec/Spec/build_test.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 import pytest
-from mock import Mock
-from mock import patch
+try:
+    from unittest.mock import Mock, patch
+except ImportError:
+    from mock import Mock, patch
 from six import iterkeys
 from six.moves.urllib.request import pathname2url
 from swagger_spec_validator.common import SwaggerValidationError

--- a/tests/spec/Spec/flattened_spec_test.py
+++ b/tests/spec/Spec/flattened_spec_test.py
@@ -3,7 +3,10 @@ import copy
 import functools
 import os
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import pytest
 from six.moves.urllib.parse import urlparse
 from swagger_spec_validator import validator20

--- a/tests/spec/build_http_handlers_test.py
+++ b/tests/spec/build_http_handlers_test.py
@@ -2,7 +2,10 @@
 import json
 from io import StringIO
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import pytest
 import yaml
 

--- a/tests/spec/pickling_test.py
+++ b/tests/spec/pickling_test.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import pytest
 from six.moves.cPickle import dumps
 from six.moves.cPickle import loads

--- a/tests/swagger20_validator/enum_validator_test.py
+++ b/tests/swagger20_validator/enum_validator_test.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 import pytest
 from jsonschema import ValidationError
-from mock import Mock
-from mock import patch
+try:
+    from unittest.mock import Mock, patch
+except ImportError:
+    from mock import Mock, patch
 
 from bravado_core.spec import Spec
 from bravado_core.swagger20_validator import enum_validator

--- a/tests/swagger20_validator/format_validator_test.py
+++ b/tests/swagger20_validator/format_validator_test.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 import pytest
 from jsonschema import ValidationError
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 from bravado_core.exception import SwaggerValidationError
 from bravado_core.formatter import SwaggerFormat

--- a/tests/swagger20_validator/ref_validator_test.py
+++ b/tests/swagger20_validator/ref_validator_test.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 import pytest
 from jsonschema.validators import RefResolver
-from mock import MagicMock
-from mock import Mock
+try:
+    from unittest.mock import MagicMock, Mock
+except ImportError:
+    from mock import MagicMock, Mock
 
 from bravado_core.swagger20_validator import ref_validator
 

--- a/tests/swagger20_validator/required_validator_test.py
+++ b/tests/swagger20_validator/required_validator_test.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 import pytest
 from jsonschema.exceptions import ValidationError
-from mock import Mock
-from mock import patch
+try:
+    from unittest.mock import Mock, patch
+except ImportError:
+    from mock import Mock, patch
 
 from bravado_core.swagger20_validator import required_validator
 

--- a/tests/swagger20_validator/type_validator_test.py
+++ b/tests/swagger20_validator/type_validator_test.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 from bravado_core.swagger20_validator import type_validator
 

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 from inspect import getcallargs
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import pytest
 
 from bravado_core.util import AliasKeyDict


### PR DESCRIPTION
Mock has been in the standard library since 3.3.  Use it when available, falling back to the mock from PyPI if necessary.