### PR TITLE
Add option to set validate_swagger_spec default via environment variable

### DIFF
--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -65,7 +65,7 @@ CONFIG_DEFAULTS = {
     'validate_requests': True,
 
     # Use swagger_spec_validator to validate the swagger spec
-    'validate_swagger_spec': True,
+    'validate_swagger_spec': os.environ.get("BRAVADO_CORE_SKIP_SPEC_VALIDATION") != "1",
 
     # Use Python classes (models) instead of dicts for #/definitions/{models}
     # On the client side, this applies to incoming responses.


### PR DESCRIPTION
This adds an option to set the `validate_swagger_spec` default via an environment variable.

The motivation is that we've found that a large amount of time is spent validating swagger specs in certain circumstances (e.g. tests) where it can dramatically increase test timings. Unfortunately, a lot of this validation happens at import time where it's difficult to patch the default via Python code, so we'd like to have the option to do it via environment variable.