### PR TITLE
Change jsonschema extra to format-nongpl

### DIFF
--- a/bravado_core/formatter.py
+++ b/bravado_core/formatter.py
@@ -141,8 +141,8 @@ def return_true_wrapper(validate_func):
 BASE64_BYTE_FORMAT = SwaggerFormat(
     format='byte',
     # Note: In Python 3, this requires a bytes-like object as input
-    to_wire=lambda b: six.ensure_str(base64.b64encode(b), encoding=str('ascii')),
-    to_python=lambda s: base64.b64decode(six.ensure_binary(s, encoding=str('ascii'))),
+    to_wire=lambda b: six.ensure_str(base64.b64encode(b), encoding=str('ascii')),  # type: ignore
+    to_python=lambda s: base64.b64decode(six.ensure_binary(s, encoding=str('ascii'))),  # type: ignore
     validate=NO_OP,  # jsonschema validates string
     description='Converts [wire]string:byte <=> python bytes',
 )
@@ -150,30 +150,30 @@ BASE64_BYTE_FORMAT = SwaggerFormat(
 DEFAULT_FORMATS = {
     'byte': SwaggerFormat(
         format='byte',
-        to_wire=lambda b: b if isinstance(b, str) else str(b),
-        to_python=lambda s: s if isinstance(s, str) else str(s),
+        to_wire=lambda b: b if isinstance(b, str) else str(b),  # type: ignore
+        to_python=lambda s: s if isinstance(s, str) else str(s),  # type: ignore
         validate=NO_OP,  # jsonschema validates string
         description='Converts [wire]string:byte <=> python byte',
     ),
     'date': SwaggerFormat(
         format='date',
-        to_wire=lambda d: d.isoformat(),
-        to_python=lambda d: dateutil.parser.parse(d).date(),
+        to_wire=lambda d: d.isoformat(),  # type: ignore
+        to_python=lambda d: dateutil.parser.parse(d).date(),  # type: ignore
         validate=NO_OP,  # jsonschema validates date
         description='Converts [wire]string:date <=> python datetime.date',
     ),
     # Python has no double. float is C's double in CPython
     'double': SwaggerFormat(
         format='double',
-        to_wire=lambda d: d if isinstance(d, float) else float(d),
-        to_python=lambda d: d if isinstance(d, float) else float(d),
+        to_wire=lambda d: d if isinstance(d, float) else float(d),  # type: ignore
+        to_python=lambda d: d if isinstance(d, float) else float(d),  # type: ignore
         validate=NO_OP,  # jsonschema validates number
         description='Converts [wire]number:double <=> python float',
     ),
     'date-time': SwaggerFormat(
         format='date-time',
-        to_wire=lambda dt: (dt if dt.tzinfo else pytz.utc.localize(dt)).isoformat(),
-        to_python=lambda dt: dateutil.parser.parse(dt),
+        to_wire=lambda dt: (dt if dt.tzinfo else pytz.utc.localize(dt)).isoformat(),  # type: ignore
+        to_python=lambda dt: dateutil.parser.parse(dt),  # type: ignore
         validate=NO_OP,  # jsonschema validates date-time
         description=(
             'Converts string:date-time <=> python datetime.datetime'
@@ -181,22 +181,22 @@ DEFAULT_FORMATS = {
     ),
     'float': SwaggerFormat(
         format='float',
-        to_wire=lambda f: f if isinstance(f, float) else float(f),
-        to_python=lambda f: f if isinstance(f, float) else float(f),
+        to_wire=lambda f: f if isinstance(f, float) else float(f),  # type: ignore
+        to_python=lambda f: f if isinstance(f, float) else float(f),  # type: ignore
         validate=NO_OP,  # jsonschema validates number
         description='Converts [wire]number:float <=> python float',
     ),
     'int32': SwaggerFormat(
         format='int32',
-        to_wire=lambda i: i if isinstance(i, int) else int(i),
-        to_python=lambda i: i if isinstance(i, int) else int(i),
+        to_wire=lambda i: i if isinstance(i, int) else int(i),  # type: ignore
+        to_python=lambda i: i if isinstance(i, int) else int(i),  # type: ignore
         validate=NO_OP,  # jsonschema validates integer
         description='Converts [wire]integer:int32 <=> python int',
     ),
     'int64': SwaggerFormat(
         format='int64',
-        to_wire=lambda i: i if isinstance(i, long) else long(i),
-        to_python=lambda i: i if isinstance(i, long) else long(i),
+        to_wire=lambda i: i if isinstance(i, long) else long(i),  # type: ignore
+        to_python=lambda i: i if isinstance(i, long) else long(i),  # type: ignore
         validate=NO_OP,  # jsonschema validates integer
         description='Converts [wire]integer:int64 <=> python long',
     ),

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,8 @@
 # TODO: avoids an issue with hanging forever in tests (CORESERV-12009).
+# Inclusion of rfc3339-validator here is a workaround for an issue where
+# pip is not installing this package (defined by `jsonschema[format-nongpl]`).
+# This issue sounds similar to https://github.com/pypa/pip/issues/3903, but
+# that was fixed in pip 20.3 and we're still seeing this issue on 22.0.2.
 jsonschema<4
 mock
 mypy
@@ -7,6 +11,7 @@ pre-commit
 pytest
 pytest-benchmark[histogram]
 pytest-cov
+rfc3339-validator
 types-mock
 types-python-dateutil
 types-pytz

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     ],
     install_requires=[
         "jsonref",
-        "jsonschema[format]>=2.5.1",
+        "jsonschema[format-nogpl]>=2.5.1",
         "python-dateutil",
         "pyyaml",
         'requests',

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     ],
     install_requires=[
         "jsonref",
-        "jsonschema[format-nogpl]>=2.5.1",
+        "jsonschema[format-nongpl]>=2.5.1",
         "python-dateutil",
         "pyyaml",
         'requests',

--- a/tests/swagger20_validator/format_validator_test.py
+++ b/tests/swagger20_validator/format_validator_test.py
@@ -108,8 +108,8 @@ def validate_dummy(dummy_string):
 
 DummyFormat = SwaggerFormat(
     format="dummy",
-    to_wire=lambda x: x,
-    to_python=lambda x: x,
+    to_wire=lambda x: x,  # type: ignore
+    to_python=lambda x: x,  # type: ignore
     validate=validate_dummy,
     description="dummy format",
 )

--- a/tests/validate/conftest.py
+++ b/tests/validate/conftest.py
@@ -10,8 +10,8 @@ def validate_email_address(email_address):
 
 email_address_format = SwaggerFormat(
     format='email_address',
-    to_wire=lambda x: x,
-    to_python=lambda x: x,
+    to_wire=lambda x: x,  # type: ignore
+    to_python=lambda x: x,  # type: ignore
     validate=validate_email_address,
     description='blah',
 )


### PR DESCRIPTION
`jsonschema[format]` is GPL, which is in conflict with our BSD license. Switching over to the conveniently available `jsonschema[format-nongpl]` extra fixes this.

Additionally, add rfc3339-validator to requirements-dev.txt to workaround a mystery issue where pip is not installing this dependency (defined in `jsonschema[format-nongpl`) by default, causing the date time validator to pass all inputs, even invalid ones.

And finally, ignore a bunch of lines for mypy type checks. These were already failing on master.