### PR TITLE
Update setup.cfg to comply setuptools ban of dashes

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-description-file = README.rst
+long_description = file: README.rst
 
 [wheel]
 universal = True


### PR DESCRIPTION
Setuptools deprecated support for dashes in field names in 2021 and recently removed support altogether. See [this recent PR](https://github.com/pypa/setuptools/pull/4870) which disallows dashes in field names.

This PR makes use of the new syntax ([see docs](https://setuptools.pypa.io/en/latest/userguide/declarative_config.html#example-setup-config:~:text=long_description%20%3D%20file%3A%20README.rst)).