### PR TITLE
Drop python 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ setup(
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
@@ -53,5 +52,5 @@ setup(
     package_data={
         'bravado_core': ['py.typed'],
     },
-    python_requires='>=3.7',
+    python_requires='>=3.8',
 )


### PR DESCRIPTION
## Feature

Drop Python 3.7 support, which reached end-of-life in June 2023.

## Solution

Remove the `Python :: 3.7` PyPI classifier and bump `python_requires` from `>=3.7` to `>=3.8` in `setup.py`.