### PR TITLE
Fix mypy and docs

### DIFF
--- a/bravado_core/marshal.py
+++ b/bravado_core/marshal.py
@@ -193,7 +193,7 @@ def _no_op_marshaling(value):
 
 
 def _unknown_type_marshaling(object_type, value):
-    # type: (typing.Union[typing.Type[dict], typing.Type[Model]], typing.Any) -> NoReturn
+    # type: (typing.Text, typing.Any) -> NoReturn
     raise SwaggerMappingError(
         'Unknown type {0} for value {1}'.format(
             object_type, value,
@@ -415,11 +415,11 @@ def _marshaling_method_primitive_type(swagger_spec, object_schema):
     """
     format_name = schema.get_format(swagger_spec, object_schema)
     swagger_format = swagger_spec.get_format(format_name) if format_name is not None else None
-    if swagger_format is not None:
+    primitive_type = get_type_from_schema(swagger_spec, object_schema)
+    if swagger_format is not None and primitive_type is not None:
         return partial(
             _marshal_primitive_type,
-            get_type_from_schema(swagger_spec, object_schema),
+            primitive_type,
             swagger_format,
         )
-    else:
-        return _no_op_marshaling
+    return _no_op_marshaling

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -193,7 +193,7 @@ def _no_op_unmarshaling(value):
 
 
 def _unknown_type_unmarshaling(object_type, value):
-    # type: (typing.Union[typing.Type[dict], typing.Type[Model]], typing.Any) -> NoReturn
+    # type: (typing.Text, typing.Any) -> NoReturn
     raise SwaggerMappingError(
         "Don't know how to unmarshal value {0} with a type of {1}".format(
             value, object_type,

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-import sphinx_rtd_theme
-
 from bravado_core import version
 
 # -- General configuration -----------------------------------------------
@@ -35,14 +33,11 @@ pygments_style = 'sphinx'
 
 html_theme = 'sphinx_rtd_theme'
 
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-
-
 html_static_path = ['_static']
 
 htmlhelp_basename = 'bravado_core-pydoc'
 
 
 intersphinx_mapping = {
-    'http://docs.python.org/': None,
+    'python': ('https://docs.python.org/3', None),
 }

--- a/tests/param/unmarshal_param_test.py
+++ b/tests/param/unmarshal_param_test.py
@@ -6,7 +6,6 @@ import pytest
 from mock import Mock
 from mock import patch
 
-from bravado_core.content_type import APP_JSON
 from bravado_core.content_type import APP_MSGPACK
 from bravado_core.exception import SwaggerMappingError
 from bravado_core.operation import Operation

--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,7 @@ commands =
     mypy bravado_core tests
 
 [testenv:docs]
+basepython = /usr/bin/python3.10
 deps =
     sphinx
     sphinx-rtd-theme


### PR DESCRIPTION
## Problem

The docs build and mypy checks were broken due to incompatibilities with newer versions of Sphinx and stale type annotations.

## Solution

Two separate issues are addressed:

**Docs build (Sphinx 8+ compatibility)**
- Updated configs
- Pin the `docs` tox env to Python 3.10

**Mypy fixes**
- Correct the type annotation on `_unknown_type_marshaling` / `_unknown_type_unmarshaling` from `Union[Type[dict], Type[Model]]` to `Text`, matching actual usage
- Guard `_marshaling_method_primitive_type` against a `None` return from `get_type_from_schema` before passing it to `partial`
 - Removed an unused `APP_JSON` import in `tests/param/unmarshal_param_test.py` surfaced by the mypy run.

## Verification

`make docs` and `make test` pass