### PR TITLE
Fixes for mypy, autopep8

### DIFF
--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -339,9 +339,9 @@ class Model(object):
         '_Model__dict',  # Note the name mangling!
     )
 
-    _swagger_spec = None  # type: Spec
-    _model_spec = None  # type: JSONDict
-    _json_reference = None  # type: str
+    _swagger_spec = None  # type: Spec  # type: ignore[assignment]
+    _model_spec = None  # type: JSONDict  # type: ignore[assignment]
+    _json_reference = None  # type: str  # type: ignore[assignment]
 
     def __init__(self, **kwargs):
         """Initialize from property values in keyword arguments.

--- a/bravado_core/param.py
+++ b/bravado_core/param.py
@@ -172,7 +172,6 @@ def marshal_param(param, value, request):
         )
 
 
-
 def unmarshal_param(param, request):
     """Unmarshal the given parameter from the passed in request like object.
 


### PR DESCRIPTION
## Problem

The build is failing for these reasons:

```
bravado_core/model.py:342: error: Incompatible types in assignment (expression has type "None", variable has type "Spec")  [assignment]
bravado_core/model.py:343: error: Incompatible types in assignment (expression has type "None", variable has type "dict[str, Any]")  [assignment]
bravado_core/model.py:344: error: Incompatible types in assignment (expression has type "None", variable has type "str")  [assignment]
```


```
autopep8.................................................................Failed
- hook id: autopep8
- files were modified by this hook

<string>:1: SyntaxWarning: 'ellipsis' object is not callable; perhaps you missed a comma?
<string>:1: SyntaxWarning: 'ellipsis' object is not callable; perhaps you missed a comma?
```

## Solution

* Add type ignores to base model
* Manually remove extra newline